### PR TITLE
fix: harden release and skill boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,10 @@ jobs:
       - run: uv sync --all-extras --locked
       - run: uv run repolocus doctor --security --json
       - name: Scan Python for medium/high-severity security issues
-        run: uvx bandit==1.9.4 -q -r src -ll
+        run: >-
+          uvx bandit==1.9.4 -q -ll -r
+          src
+          skills/repolocus-analyze-repo/scripts
       - name: Export runtime SBOM, including API dependencies
         run: >-
           uv export --frozen --no-dev --extra api --preview-features sbom-export

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          version: "0.9.18"
+      - name: Verify tag, version, and main ancestry
+        id: version
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="$(uv version --short)"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Unsupported release tag: $tag" >&2
+            exit 1
+          fi
+          if [[ "$tag" != "v$version" ]]; then
+            echo "Tag $tag does not match project version $version" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Test release source
+        env:
+          PROJECT_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          uv sync --all-extras --locked
+          runtime_version="$(uv run python -c 'import repolocus; print(repolocus.__version__)')"
+          test "$runtime_version" = "$PROJECT_VERSION"
+          uv run ruff format --check .
+          uv run ruff check .
+          uv run pytest
+          uv run repolocus doctor --security --json
+      - name: Build and check Python distributions
+        run: |
+          mkdir -p release-assets
+          uv build --out-dir release-assets
+          uvx twine==6.2.0 check release-assets/*.whl release-assets/*.tar.gz
+      - name: Package Codex Skill
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: >-
+          git archive --format=zip
+          --prefix=repolocus-analyze-repo/
+          --output="release-assets/repolocus-analyze-repo-${VERSION}.zip"
+          HEAD:skills/repolocus-analyze-repo
+      - name: Export CycloneDX SBOM
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: >-
+          uv export --frozen --no-dev --extra api --preview-features sbom-export
+          --format cyclonedx1.5
+          --output-file "release-assets/repolocus-${VERSION}.cyclonedx.json"
+      - name: Generate SHA-256 checksums
+        run: |
+          cd release-assets
+          LC_ALL=C sha256sum * > SHA256SUMS
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets/*
+          if-no-files-found: error
+          retention-days: 14
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/repolocus
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+      - name: Select Python distributions
+        run: |
+          mkdir -p dist
+          cp release-assets/*.whl release-assets/*.tar.gz dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  publish-github-release:
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+      - name: Create GitHub Release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "$GITHUB_REF_NAME" release-assets/*
+          --verify-tag
+          --generate-notes
+          --title "RepoLocus $GITHUB_REF_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Semantic Versioning while the project is in alpha.
 - Ollama, OpenAI-compatible, and Anthropic providers with redacted previews and explicit consent.
 - Root-confined FastAPI service, multi-stage Docker image, cross-platform CI, SBOM, vulnerability
   and license checks.
+- Local-only Codex Skill with guarded `doctor`, `scan`, `ask`, `map`, and `diagram` adapters.
+- Tag-gated release automation for PyPI Trusted Publishing and verifiable GitHub Release assets.
 - Reproducible retrieval evaluation and 1k/10k/100k synthetic scan benchmark harness.
 
 ### Security
@@ -23,8 +25,12 @@ Semantic Versioning while the project is in alpha.
 - Repository configuration cannot choose models, network endpoints, telemetry, or credentials.
 - Cloud preview and upload use one immutable evidence bundle.
 - Non-loopback Ollama endpoints require consent; API cloud use requires an operator flag.
-- Cache files use private permissions, untrusted display controls are escaped, and model output
-  with unsafe controls or unsupported links is withheld.
+- Remote provider endpoints require HTTPS, prompts are redacted immediately before transport,
+  and plain HTTP remains available only for loopback services.
+- The Codex Skill isolates runtime discovery and execution from the untrusted target repository.
+- POSIX cache files use private permissions; Windows ACL status is reported as unverified until
+  native inspection is available. Untrusted display controls are escaped, and model output with
+  unsafe controls or unsupported links is withheld.
 
 ### Known limitations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,18 @@ line ranges. Security fixes should include a regression test without publishing 
 
 Use conventional commit-style subjects where practical (`feat:`, `fix:`, `docs:`, `test:`).
 Maintainers squash only when it preserves contributor attribution and DCO sign-offs.
+
+## Releasing
+
+Before the first release, configure a protected GitHub environment named `pypi` and register
+the PyPI Trusted Publisher (or pending publisher) with these exact claims:
+
+- owner: `Henry-Yolky`;
+- repository: `RepoLocus`;
+- workflow: `release.yml`;
+- environment: `pypi`.
+
+Require a maintainer approval on the `pypi` environment. Do not add a long-lived PyPI token to
+GitHub secrets. The release workflow accepts version tags such as `v0.1.0` only when the tag
+matches `pyproject.toml` and its commit belongs to `main`; it then tests, builds, publishes with
+OIDC, and creates the GitHub Release with checksums, an SBOM, and the standalone Codex Skill.

--- a/MODEL_SUPPORT.md
+++ b/MODEL_SUPPORT.md
@@ -3,7 +3,7 @@
 | Provider string | Network | Credential | Status |
 |---|---|---|---|
 | `local` or `extractive` | None | None | Supported; deterministic evidence output |
-| `ollama/MODEL` | Loopback by default; configurable | None | Supported; non-loopback requires explicit consent |
+| `ollama/MODEL` | Loopback by default; configurable | None | Supported; non-loopback requires HTTPS and explicit consent |
 | `openai/MODEL` | Cloud or compatible gateway | `OPENAI_API_KEY` | Supported; explicit consent |
 | `anthropic/MODEL` | Cloud | `ANTHROPIC_API_KEY` | Supported; explicit consent |
 
@@ -20,6 +20,10 @@ Environment configuration:
 - `REPOLOCUS_REQUEST_TIMEOUT`
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
+
+Plain HTTP endpoints are accepted only on loopback addresses such as `localhost`, `127.0.0.1`,
+or `::1`. Every non-loopback Ollama, OpenAI-compatible, or Anthropic endpoint must use HTTPS.
+Prompts sent through HTTP providers are redacted immediately before transport.
 
 Model output is not treated as evidence. A citation must point into one of the retrieved source
 ranges or the narrative is withheld in favor of the deterministic evidence response.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -16,13 +16,15 @@ directory. `repolocus privacy status` displays them and `repolocus privacy revok
 ## Network access
 
 `local` mode has no network access. Ollama defaults to `http://127.0.0.1:11434`; only a loopback
-Ollama URL is treated as local. A non-loopback Ollama endpoint and every cloud provider are
-disabled until the user either passes `--allow-cloud` for one call or records a
-repository/provider grant. Before every approved remote CLI call, RepoLocus displays the exact
-redacted source content and ranges, fragment count, estimated tokens, and redaction count that
-will be sent, including calls covered by a remembered grant. The self-hosted API has no
-interactive confirmation UI; cloud access is operator-disabled by default and should remain so
-unless a trusted front end provides an equivalent review step.
+Ollama URL is treated as local. Plain HTTP is accepted only for loopback endpoints; every
+non-loopback Ollama, OpenAI-compatible, or Anthropic endpoint must use HTTPS. A non-loopback
+Ollama endpoint and every cloud provider are disabled until the user either passes
+`--allow-cloud` for one call or records a repository/provider grant. Before every approved
+remote CLI call, RepoLocus displays the exact redacted source content and ranges, fragment count,
+estimated tokens, and redaction count that will be sent, including calls covered by a remembered
+grant. System and user prompts are redacted again immediately before transport. The self-hosted
+API has no interactive confirmation UI; cloud access is operator-disabled by default and should
+remain so unless a trusted front end provides an equivalent review step.
 
 Only retrieved fragments needed for the question are sent. API credentials are read from
 environment variables and are never written to repository or consent configuration.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,22 @@ answer on top of the same evidence.
 
 RepoLocus requires Python 3.10 or newer.
 
+For a tagged version that is available on PyPI:
+
 ```bash
 pipx install repolocus
+```
+
+If that version has not been published to PyPI yet, install from a source checkout instead:
+
+```bash
+git clone https://github.com/Henry-Yolky/RepoLocus.git
+pipx install ./RepoLocus
+```
+
+Then run RepoLocus inside the repository you want to inspect:
+
+```bash
 cd your-repository
 repolocus scan
 repolocus map
@@ -90,20 +104,37 @@ ends it. Follow-up context is never written to the repository or consent state.
 ## Agent Skill
 
 The repository ships a local-only Codex Skill at
-[`skills/repolocus-analyze-repo`](skills/repolocus-analyze-repo). Its adapter exposes `doctor`,
+[`skills/repolocus-analyze-repo`](https://github.com/Henry-Yolky/RepoLocus/tree/main/skills/repolocus-analyze-repo).
+Its adapter exposes `doctor`,
 `scan`, `ask`, `map`, and `diagram` while forcing extractive local answers and sending generated
 documents to stdout instead of writing them into the target repository.
 
-From a source checkout, install RepoLocus and copy the Skill into Codex's skill directory:
+GitHub Releases provide the Skill separately as `repolocus-analyze-repo-VERSION.zip`. Extract that
+archive as `$CODEX_HOME/skills/repolocus-analyze-repo`, where `CODEX_HOME` defaults to
+`~/.codex`. From a source checkout, install RepoLocus and copy the Skill with:
 
 ```bash
 pipx install .
-mkdir -p ~/.codex/skills
-cp -R skills/repolocus-analyze-repo ~/.codex/skills/
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+mkdir -p "$CODEX_HOME/skills"
+cp -R skills/repolocus-analyze-repo "$CODEX_HOME/skills/"
 ```
 
-Then invoke it as `$repolocus-analyze-repo`. The Skill intentionally exposes no cloud-consent
-flags; an agent cannot silently send repository content to a remote provider through this path.
+PowerShell equivalent:
+
+```powershell
+pipx install .
+if (-not $env:CODEX_HOME) { $env:CODEX_HOME = Join-Path $HOME ".codex" }
+New-Item -ItemType Directory -Force (Join-Path $env:CODEX_HOME "skills") | Out-Null
+Copy-Item -Recurse -Force "skills/repolocus-analyze-repo" (Join-Path $env:CODEX_HOME "skills")
+```
+
+Restart Codex after copying the directory, or reload its Skill registry when the host provides
+that action. Then invoke the Skill as `$repolocus-analyze-repo`. It intentionally exposes no
+cloud-consent flags; an agent cannot silently send repository content to a remote provider
+through this path.
+
+## Self-hosted API
 
 Install the API extra with `pipx install 'repolocus[api]'`, then constrain the server to
 one repository tree:
@@ -136,15 +167,21 @@ The source mount is read-only and API cloud access remains disabled in this exam
   names, and likely credential-bearing files are excluded.
 - Canonical path checks prevent reads outside the requested repository root.
 - Indexes live in the operating-system user cache and consent records in the user state
-  directory, outside the scanned repository. Both are permission-hardened; telemetry is absent.
+  directory, outside the scanned repository. POSIX permissions are hardened. On Windows,
+  `doctor --security` reports ACL verification as unavailable until native ACL inspection is
+  implemented, instead of claiming an unverified success. Telemetry is absent.
 - Loopback Ollama is local by default. A non-loopback Ollama endpoint is treated like a cloud
   provider and requires per-call or remembered per-repository consent. Selected, redacted source
   fragments are shown by the CLI before every approved remote send.
+- Plain HTTP provider endpoints are limited to loopback addresses. Every non-loopback endpoint
+  requires HTTPS, and provider prompts are redacted again immediately before transport.
 - `map` and `diagram` are the only normal commands that write in the repository, and only to
   the output path requested by the user.
 
-See [PRIVACY.md](PRIVACY.md), [SECURITY.md](SECURITY.md), and
-[docs/architecture.md](docs/architecture.md) for the detailed model.
+See [PRIVACY.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/PRIVACY.md),
+[SECURITY.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/SECURITY.md), and
+[docs/architecture.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/docs/architecture.md)
+for the detailed model.
 
 ## Supported languages
 
@@ -165,7 +202,8 @@ roadmap.
 
 Provider strings use `family/model`, for example `ollama/qwen3-coder`,
 `openai/gpt-4.1-mini`, or `anthropic/claude-sonnet-4-5`. OpenAI-compatible gateways can be set
-with `REPOLOCUS_OPENAI_BASE_URL`. See [MODEL_SUPPORT.md](MODEL_SUPPORT.md).
+with `REPOLOCUS_OPENAI_BASE_URL`. See
+[MODEL_SUPPORT.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/MODEL_SUPPORT.md).
 
 ## Why this is not another coding agent
 
@@ -184,8 +222,12 @@ uv run python scripts/evaluate_retrieval.py evaluation/questions.json .
 uv build
 ```
 
-Architecture decisions live in [`docs/adr/`](docs/adr/). Contributions are welcome; start with
-[CONTRIBUTING.md](CONTRIBUTING.md), [CHANGELOG.md](CHANGELOG.md), and the issue templates.
+Architecture decisions live in
+[`docs/adr/`](https://github.com/Henry-Yolky/RepoLocus/tree/main/docs/adr). Contributions are
+welcome; start with
+[CONTRIBUTING.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/CONTRIBUTING.md),
+[CHANGELOG.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/CHANGELOG.md), and the
+[issue templates](https://github.com/Henry-Yolky/RepoLocus/issues/new/choose).
 
 ## Roadmap and limits
 
@@ -193,14 +235,18 @@ The repository includes a reproducible synthetic scan harness under `benchmarks/
 source-citation regression set under `evaluation/`; neither substitutes for the planned
 multi-repository, 100-question release evaluation. The next milestones are Tree-sitter adapters,
 stronger graph resolution, a public-repository-only Web Demo, and an opt-in GitHub Action. The project will not
-claim a complete dynamic call graph from static source. See [ROADMAP.md](ROADMAP.md) for scope.
+claim a complete dynamic call graph from static source. See
+[ROADMAP.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/ROADMAP.md) for scope.
 
 On the recorded Jetson Orin NX synthetic fixture, 10,000 small Python files scanned in 7.54 s
 cold, 2.70 s warm, and 2.69 s after one file changed. These are scanner/index timings, not model
 latency, and are not a claim about arbitrary repositories. The exact fixture procedure and
-machine metadata are in [benchmarks/](benchmarks/README.md).
+machine metadata are in
+[benchmarks/](https://github.com/Henry-Yolky/RepoLocus/blob/main/benchmarks/README.md).
 
-RepoLocus is licensed under Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+RepoLocus is licensed under Apache-2.0. See
+[LICENSE](https://github.com/Henry-Yolky/RepoLocus/blob/main/LICENSE) and
+[NOTICE](https://github.com/Henry-Yolky/RepoLocus/blob/main/NOTICE).
 
 The installable distribution and command are both named `repolocus`; the product name is
 RepoLocus.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,8 +11,22 @@ Mermaid 图，并为代码问题检索可核验的源码证据。
 
 ## 快速开始
 
+RepoLocus 需要 Python 3.10 或更高版本。对于已经发布到 PyPI 的 tag 版本：
+
 ```bash
 pipx install repolocus
+```
+
+如果所需版本尚未发布到 PyPI，请从源码检出安装：
+
+```bash
+git clone https://github.com/Henry-Yolky/RepoLocus.git
+pipx install ./RepoLocus
+```
+
+然后进入需要分析的仓库：
+
+```bash
 cd 你的仓库
 repolocus scan
 repolocus map
@@ -27,7 +41,8 @@ repolocus ask "请求如何进入核心循环？" --model ollama/qwen3-coder
 ```
 
 只有回环地址上的 Ollama 被视为本地服务；如果把 Ollama 地址配置到其他主机，RepoLocus
-会将它按远程供应商处理并要求授权。
+会将它按远程供应商处理并要求授权。明文 HTTP 仅允许用于回环地址，所有非回环供应商
+端点都必须使用 HTTPS；提示词会在发送前再次脱敏。
 
 云模型调用前，RepoLocus 会展示将发送的源码片段、文件列表和估算 Token 数。可用
 `--allow-cloud` 仅授权本次调用，或同时使用 `--remember-consent` 为当前仓库记住该供应商。
@@ -46,18 +61,44 @@ repolocus ask "请求如何进入核心循环？" --model ollama/qwen3-coder
 
 ## Agent Skill
 
-仓库内置 [`skills/repolocus-analyze-repo`](skills/repolocus-analyze-repo)，可供 Codex 等具备
-Shell 能力的 Agent 调用。它提供 `doctor`、`scan`、`ask`、`map` 和 `diagram`，强制使用
-本地提取式回答，并让项目地图和架构图输出到 stdout，避免自动写入目标仓库。
+仓库内置
+[`skills/repolocus-analyze-repo`](https://github.com/Henry-Yolky/RepoLocus/tree/main/skills/repolocus-analyze-repo)，
+可供 Codex 等具备 Shell 能力的 Agent 调用。它提供 `doctor`、`scan`、`ask`、`map` 和
+`diagram`，强制使用本地提取式回答，并让项目地图和架构图输出到 stdout，避免自动写入
+目标仓库。
+
+GitHub Release 会单独提供 `repolocus-analyze-repo-VERSION.zip`。请将其解压为
+`$CODEX_HOME/skills/repolocus-analyze-repo`；未设置 `CODEX_HOME` 时默认使用
+`~/.codex`。也可以从源码检出安装：
 
 ```bash
 pipx install .
-mkdir -p ~/.codex/skills
-cp -R skills/repolocus-analyze-repo ~/.codex/skills/
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+mkdir -p "$CODEX_HOME/skills"
+cp -R skills/repolocus-analyze-repo "$CODEX_HOME/skills/"
 ```
 
-安装后以 `$repolocus-analyze-repo` 调用。该 Skill 不暴露云端授权参数，Agent 不能通过
-这条路径静默把仓库内容发送给远程模型。
+PowerShell 等价命令：
+
+```powershell
+pipx install .
+if (-not $env:CODEX_HOME) { $env:CODEX_HOME = Join-Path $HOME ".codex" }
+New-Item -ItemType Directory -Force (Join-Path $env:CODEX_HOME "skills") | Out-Null
+Copy-Item -Recurse -Force "skills/repolocus-analyze-repo" (Join-Path $env:CODEX_HOME "skills")
+```
+
+复制后请重启 Codex；如果宿主提供 Skill 注册表重载操作，也可以执行重载。之后以
+`$repolocus-analyze-repo` 调用。该 Skill 不暴露云端授权参数，Agent 不能通过这条路径
+静默把仓库内容发送给远程模型。
+
+## 自托管 API
+
+安装 API 可选依赖，并把服务限制在一个允许的仓库目录树中：
+
+```bash
+pipx install 'repolocus[api]'
+repolocus serve --root /path/to/allowed/repositories
+```
 
 API 默认只监听回环地址、只允许访问 `--root` 指定目录之下的仓库，并禁用云模型。
 对外监听必须显式使用 `--allow-remote`，且应放在具备认证和授权的网关之后；服务端若要
@@ -70,5 +111,11 @@ README、注释和测试数据都按不可信输入处理。当前 Python 使用
 JavaScript、Go、Rust、Java、C/C++ 使用保守的启发式解析器；动态调用、反射、依赖注入
 和生成代码可能无法被静态分析还原。
 
-完整命令、架构、测试与开发说明以英文 [README.md](README.md) 为准。隐私与安全细节见
-[PRIVACY.md](PRIVACY.md) 和 [SECURITY.md](SECURITY.md)，路线图见 [ROADMAP.md](ROADMAP.md)。
+索引和授权记录均保存在仓库之外。POSIX 平台会收紧文件权限；Windows 上尚未实现原生
+ACL 检查，因此 `doctor --security` 会明确将 ACL 状态报告为“未验证”，不会声称检查成功。
+
+完整命令、架构、测试与开发说明以英文
+[README.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/README.md) 为准。隐私与安全
+细节见 [PRIVACY.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/PRIVACY.md) 和
+[SECURITY.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/SECURITY.md)，路线图见
+[ROADMAP.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/ROADMAP.md)。

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -12,10 +12,12 @@ read-only.
 |---|---|
 | Symlink or path traversal reads outside the repository | Canonical-root validation and no symlink following |
 | Build, hook, or README-triggered command execution | Scanner and providers expose no command execution interface |
+| Target-repository runtime or module shadowing through the Codex Skill | Target paths are canonicalized; target-local interpreters and executables are rejected; child Python runs isolated from a trusted directory |
 | Accidental key indexing | Sensitive-name rules, content secret detection, binary/size limits |
 | Prompt injection in source | Source is delimited as untrusted data and providers have no tools |
 | Unapproved cloud upload | Per-call flag or remembered repository/provider grant |
 | Excessive cloud disclosure | Retrieval limit, context budget, preview, and redaction |
+| Cleartext remote-provider traffic | HTTP is limited to loopback; non-loopback endpoints require HTTPS |
 | Fabricated source citations | Structured citation markers validated against retrieved ranges |
 | Mermaid links or directives | Deterministic restricted grammar; model output is never diagram source |
 | Index committed to Git | Cache defaults outside the repository; `.repolocus/` is ignored |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ dependencies = [
   "typer>=0.12,<1",
 ]
 
+[project.urls]
+Homepage = "https://github.com/Henry-Yolky/RepoLocus"
+Repository = "https://github.com/Henry-Yolky/RepoLocus"
+Issues = "https://github.com/Henry-Yolky/RepoLocus/issues"
+Changelog = "https://github.com/Henry-Yolky/RepoLocus/blob/main/CHANGELOG.md"
+
 [project.optional-dependencies]
 api = ["fastapi>=0.115,<1", "uvicorn>=0.30,<1"]
 dev = [

--- a/skills/repolocus-analyze-repo/SKILL.md
+++ b/skills/repolocus-analyze-repo/SKILL.md
@@ -12,10 +12,11 @@ returned on stdout instead of written into the target repository.
 ## Prerequisites
 
 - Require a local repository path that the user placed in scope.
-- Run the adapter with Python 3.10 or newer:
+- Use Python 3.10 or newer whose resolved executable is outside the target repository. Never use
+  the target repository's `.venv`; the adapter rejects it. Run the adapter in isolated mode:
 
   ```bash
-  python <skill-dir>/scripts/run_repolocus.py --help
+  python -I <skill-dir>/scripts/run_repolocus.py --help
   ```
 
 - If the adapter cannot find RepoLocus, install the `repolocus` distribution or run the Skill
@@ -26,13 +27,13 @@ returned on stdout instead of written into the target repository.
 1. Run the security and runtime preflight:
 
    ```bash
-   python <skill-dir>/scripts/run_repolocus.py doctor <repository>
+   python -I <skill-dir>/scripts/run_repolocus.py doctor <repository>
    ```
 
 2. Build or refresh the external local index:
 
    ```bash
-   python <skill-dir>/scripts/run_repolocus.py scan <repository>
+   python -I <skill-dir>/scripts/run_repolocus.py scan <repository>
    ```
 
 3. Choose the smallest evidence operation that answers the request:
@@ -40,19 +41,19 @@ returned on stdout instead of written into the target repository.
    - Locate or explain code:
 
      ```bash
-     python <skill-dir>/scripts/run_repolocus.py ask "<question>" <repository>
+     python -I <skill-dir>/scripts/run_repolocus.py ask "<question>" <repository>
      ```
 
    - Summarize structure and reading order:
 
      ```bash
-     python <skill-dir>/scripts/run_repolocus.py map <repository>
+     python -I <skill-dir>/scripts/run_repolocus.py map <repository>
      ```
 
    - Explain static architecture relationships:
 
      ```bash
-     python <skill-dir>/scripts/run_repolocus.py diagram <repository>
+     python -I <skill-dir>/scripts/run_repolocus.py diagram <repository>
      ```
 
 4. Inspect the returned paths, line ranges, confidence, and excerpts. Open the cited files when
@@ -66,6 +67,8 @@ returned on stdout instead of written into the target repository.
 - Keep this Skill local-only. The adapter forces `model=local`, disables telemetry, and exposes no
   cloud-consent flags.
 - Do not execute repository commands, builds, tests, hooks, or code as part of RepoLocus analysis.
+- Keep the adapter interpreter outside the target repository. Let the adapter resolve the target
+  to an absolute path, sanitize runtime discovery, and launch RepoLocus from its trusted directory.
 - Prefer the adapter's stdout behavior for maps and diagrams; do not create `PROJECT_MAP.md` or
   `ARCHITECTURE.md` unless the user separately requests those writes.
 - Remember that `scan` writes only an index under the operating-system user cache, outside the

--- a/skills/repolocus-analyze-repo/scripts/run_repolocus.py
+++ b/skills/repolocus-analyze-repo/scripts/run_repolocus.py
@@ -4,47 +4,287 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
+_TRUSTED_WORKING_DIRECTORY = Path(__file__).resolve().parent
+_PYTHON_IMPORT_ENVIRONMENT = (
+    "PYTHONCASEOK",
+    "PYTHONEXECUTABLE",
+    "PYTHONHOME",
+    "PYTHONINSPECT",
+    "PYTHONPATH",
+    "PYTHONPLATLIBDIR",
+    "PYTHONSTARTUP",
+    "PYTHONUSERBASE",
+    "__PYVENV_LAUNCHER__",
+)
+_UV_ENVIRONMENT = (
+    "UV_CONFIG_FILE",
+    "UV_PROJECT",
+    "UV_PROJECT_ENVIRONMENT",
+    "UV_PYTHON",
+    "UV_WORKING_DIRECTORY",
+    "VIRTUAL_ENV",
+)
+_COVERAGE_ENVIRONMENT = ("COVERAGE_FILE", "COVERAGE_PROCESS_START")
+
 
 class AdapterError(RuntimeError):
     """Raised when the RepoLocus runtime cannot be located."""
 
 
-def _command_prefix(explicit_binary: str | None) -> list[str]:
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _source_checkout() -> Path | None:
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "pyproject.toml").is_file() and (candidate / "src" / "repolocus").is_dir():
+            return candidate
+    return None
+
+
+def _overlaps(path: Path, other: Path) -> bool:
+    return _is_within(path, other) or _is_within(other, path)
+
+
+def _account_home() -> Path | None:
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            profile = ctypes.create_unicode_buffer(32_768)
+            result = ctypes.windll.shell32.SHGetFolderPathW(None, 0x0028, None, 0, profile)
+            return Path(profile.value).resolve() if result == 0 and profile.value else None
+        except (AttributeError, OSError):
+            return None
+    try:
+        import pwd
+
+        return Path(pwd.getpwuid(os.getuid()).pw_dir).resolve()
+    except (ImportError, KeyError, OSError):
+        return None
+
+
+def _trusted_roots(repository: Path, interpreter: Path) -> tuple[Path, ...]:
+    candidates = [interpreter.parent, _source_checkout()]
+    account_home = _account_home()
+    if account_home is not None:
+        candidates.append(account_home / ".local" / "bin")
+
+    roots: list[Path] = []
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if not resolved.is_dir() or _overlaps(resolved, repository) or resolved in roots:
+            continue
+        roots.append(resolved)
+    return tuple(roots)
+
+
+def _trusted_interpreter(repository: Path) -> Path:
+    interpreter = Path(os.path.abspath(Path(sys.executable).expanduser()))
+    try:
+        resolved = interpreter.resolve()
+    except OSError as exc:
+        raise AdapterError(f"Cannot resolve the Python interpreter: {exc}") from exc
+    if _is_within(interpreter, repository) or _is_within(resolved, repository):
+        raise AdapterError(
+            "The adapter is running with a Python interpreter inside the target repository; "
+            "rerun it with a trusted Python interpreter outside the target repository"
+        )
+    return interpreter
+
+
+def _path_is_trusted(
+    path: Path,
+    *,
+    untrusted_roots: tuple[Path, ...],
+    trusted_roots: tuple[Path, ...],
+) -> bool:
+    if any(_is_within(path, root) for root in trusted_roots):
+        return True
+    return not any(_is_within(path, root) for root in untrusted_roots)
+
+
+def _resolved_executable(
+    command: str,
+    *,
+    path_value: str,
+    untrusted_roots: tuple[Path, ...],
+    trusted_roots: tuple[Path, ...],
+) -> Path | None:
+    requested_path = Path(command).expanduser()
+    expanded = str(requested_path)
+    if os.path.dirname(expanded):
+        candidate = shutil.which(expanded)
+        if candidate is None:
+            return None
+        try:
+            resolved = Path(candidate).resolve()
+        except (OSError, RuntimeError):
+            return None
+        from_trusted_root = any(_is_within(resolved, root) for root in trusted_roots)
+        if not requested_path.is_absolute() and not from_trusted_root:
+            return None
+        if _path_is_trusted(resolved, untrusted_roots=untrusted_roots, trusted_roots=trusted_roots):
+            return resolved
+        return None
+
+    seen: set[Path] = set()
+    for raw_entry in path_value.split(os.pathsep):
+        entry = raw_entry or os.curdir
+        candidate = shutil.which(command, path=entry)
+        if candidate is None:
+            continue
+        try:
+            resolved = Path(candidate).resolve()
+        except (OSError, RuntimeError):
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if _path_is_trusted(resolved, untrusted_roots=untrusted_roots, trusted_roots=trusted_roots):
+            return resolved
+    return None
+
+
+def _safe_path(
+    path_value: str,
+    *,
+    invocation_cwd: Path,
+    untrusted_roots: tuple[Path, ...],
+    trusted_roots: tuple[Path, ...],
+) -> str:
+    entries: list[str] = []
+    for raw_entry in path_value.split(os.pathsep):
+        raw_path = Path(raw_entry or os.curdir).expanduser()
+        try:
+            entry = raw_path.resolve()
+        except (OSError, RuntimeError):
+            continue
+        from_trusted_root = any(_is_within(entry, root) for root in trusted_roots)
+        if not from_trusted_root and (not raw_path.is_absolute() or entry == invocation_cwd):
+            continue
+        if _path_is_trusted(entry, untrusted_roots=untrusted_roots, trusted_roots=trusted_roots):
+            entries.append(str(entry))
+    return os.pathsep.join(entries)
+
+
+def _execution_environment(
+    *,
+    invocation_cwd: Path,
+    untrusted_roots: tuple[Path, ...],
+    trusted_roots: tuple[Path, ...],
+) -> dict[str, str]:
+    environment = dict(os.environ)
+    for name in (*_PYTHON_IMPORT_ENVIRONMENT, *_UV_ENVIRONMENT, *_COVERAGE_ENVIRONMENT):
+        environment.pop(name, None)
+    for name in tuple(environment):
+        if name.startswith("COV_CORE_"):
+            environment.pop(name)
+    environment["PATH"] = _safe_path(
+        environment.get("PATH", os.defpath),
+        invocation_cwd=invocation_cwd,
+        untrusted_roots=untrusted_roots,
+        trusted_roots=trusted_roots,
+    )
+    environment["PYTHONSAFEPATH"] = "1"
+    environment["REPOLOCUS_MODEL"] = "local"
+    environment["REPOLOCUS_TELEMETRY"] = "false"
+    return environment
+
+
+def _isolated_module_origin(environment: dict[str, str], interpreter: Path) -> Path | None:
+    probe = (
+        "import importlib.util; "
+        "spec = importlib.util.find_spec('repolocus'); "
+        "print(spec.origin if spec and spec.origin else '')"
+    )
+    try:
+        completed = subprocess.run(
+            [str(interpreter), "-I", "-c", probe],
+            cwd=_TRUSTED_WORKING_DIRECTORY,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return None
+    try:
+        return Path(completed.stdout.strip()).resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def _command_prefix(
+    explicit_binary: str | None,
+    *,
+    environment: dict[str, str],
+    interpreter: Path,
+    untrusted_roots: tuple[Path, ...],
+    trusted_roots: tuple[Path, ...],
+) -> list[str]:
     requested = explicit_binary or os.environ.get("REPOLOCUS_BIN")
     if requested:
-        resolved = shutil.which(requested)
-        if resolved:
-            return [resolved]
-        raise AdapterError(f"RepoLocus executable not found: {requested}")
+        resolved = _resolved_executable(
+            requested,
+            path_value=environment["PATH"],
+            untrusted_roots=untrusted_roots,
+            trusted_roots=trusted_roots,
+        )
+        if resolved is not None:
+            return [str(resolved)]
+        raise AdapterError(
+            f"RepoLocus executable not found outside the target repository: {requested}"
+        )
 
-    installed = shutil.which("repolocus")
-    if installed:
-        return [installed]
+    installed = _resolved_executable(
+        "repolocus",
+        path_value=environment["PATH"],
+        untrusted_roots=untrusted_roots,
+        trusted_roots=trusted_roots,
+    )
+    if installed is not None:
+        return [str(installed)]
 
-    if importlib.util.find_spec("repolocus") is not None:
-        return [sys.executable, "-m", "repolocus"]
+    module_origin = _isolated_module_origin(environment, interpreter)
+    if module_origin is not None and _path_is_trusted(
+        module_origin, untrusted_roots=untrusted_roots, trusted_roots=trusted_roots
+    ):
+        return [str(interpreter), "-I", "-m", "repolocus"]
 
-    uv = shutil.which("uv")
-    if uv:
-        for candidate in Path(__file__).resolve().parents:
-            if (candidate / "pyproject.toml").is_file() and (
-                candidate / "src" / "repolocus"
-            ).is_dir():
-                return [
-                    uv,
-                    "run",
-                    "--project",
-                    str(candidate),
-                    "--locked",
-                    "repolocus",
-                ]
+    source_checkout = _source_checkout()
+    uv = _resolved_executable(
+        "uv",
+        path_value=environment["PATH"],
+        untrusted_roots=untrusted_roots,
+        trusted_roots=trusted_roots,
+    )
+    if source_checkout is not None and source_checkout in trusted_roots and uv is not None:
+        return [
+            str(uv),
+            "run",
+            "--project",
+            str(source_checkout),
+            "--locked",
+            "repolocus",
+        ]
 
     raise AdapterError(
         "RepoLocus is unavailable; install it with 'pipx install repolocus' or run this "
@@ -80,19 +320,19 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _operation_arguments(arguments: argparse.Namespace) -> list[str]:
-    repository = str(Path(arguments.repository).expanduser())
+def _operation_arguments(arguments: argparse.Namespace, repository: Path) -> list[str]:
+    repository_argument = str(repository)
     if arguments.operation == "doctor":
-        return ["doctor", repository, "--security", "--json"]
+        return ["doctor", repository_argument, "--security", "--json"]
     if arguments.operation == "scan":
-        return ["scan", repository, "--json"]
+        return ["scan", repository_argument, "--json"]
     if arguments.operation in {"map", "diagram"}:
-        return [arguments.operation, repository, "--stdout"]
+        return [arguments.operation, repository_argument, "--stdout"]
     if arguments.operation == "ask":
         return [
             "ask",
             arguments.question,
-            repository,
+            repository_argument,
             "--model",
             "local",
             "--limit",
@@ -106,15 +346,33 @@ def main() -> int:
     parser = _parser()
     arguments = parser.parse_args()
     try:
-        command = _command_prefix(arguments.binary) + _operation_arguments(arguments)
+        repository = Path(arguments.repository).expanduser().resolve()
+        invocation_cwd = Path.cwd().resolve()
+        interpreter = _trusted_interpreter(repository)
+        untrusted_roots = (repository, invocation_cwd)
+        trusted_roots = _trusted_roots(repository, interpreter)
+        environment = _execution_environment(
+            invocation_cwd=invocation_cwd,
+            untrusted_roots=untrusted_roots,
+            trusted_roots=trusted_roots,
+        )
+        command = _command_prefix(
+            arguments.binary,
+            environment=environment,
+            interpreter=interpreter,
+            untrusted_roots=untrusted_roots,
+            trusted_roots=trusted_roots,
+        ) + _operation_arguments(arguments, repository)
     except AdapterError as exc:
         parser.error(str(exc))
 
-    environment = dict(os.environ)
-    environment["REPOLOCUS_MODEL"] = "local"
-    environment["REPOLOCUS_TELEMETRY"] = "false"
     try:
-        completed = subprocess.run(command, env=environment, check=False)
+        completed = subprocess.run(
+            command,
+            cwd=_TRUSTED_WORKING_DIRECTORY,
+            env=environment,
+            check=False,
+        )
     except FileNotFoundError as exc:
         print(f"RepoLocus execution failed: {exc}", file=sys.stderr)
         return 127

--- a/src/repolocus/cli.py
+++ b/src/repolocus/cli.py
@@ -107,6 +107,21 @@ def _service(root: Path) -> RepoLocusService:
     return RepoLocusService(_settings(root))
 
 
+def _index_cache_permission_status(path: Path, platform_name: str) -> tuple[bool, str, bool]:
+    """Return ``ok``, detail, and whether cache permissions can be verified.
+
+    POSIX mode bits provide a direct, dependency-free check.  Python's standard
+    library does not expose an equivalent Windows ACL inspection API, so that
+    platform must remain an explicit, non-required unknown instead of being
+    reported as secure without evidence.
+    """
+
+    if platform_name == "nt":
+        return False, "unknown: Windows ACLs were not inspected", False
+    mode = path.stat().st_mode & 0o777
+    return mode & 0o077 == 0, oct(mode), True
+
+
 def _fail(exc: Exception, code: int = 1) -> None:
     error_console.print(
         "Error: " + escape_untrusted_display(str(exc)),
@@ -590,18 +605,18 @@ def doctor(
     index_cache = cache_root()
     index_cache_private = False
     index_cache_mode = "unavailable"
+    index_cache_permissions_required = True
     try:
         index_cache.mkdir(parents=True, exist_ok=True, mode=0o700)
         if os.name != "nt":
             index_cache.chmod(0o700)
         with tempfile.NamedTemporaryFile(dir=index_cache):
             pass
-        if os.name == "nt":
-            index_cache_private = True
-            index_cache_mode = "platform ACLs"
-        else:
-            index_cache_mode = oct(index_cache.stat().st_mode & 0o777)
-            index_cache_private = index_cache.stat().st_mode & 0o077 == 0
+        (
+            index_cache_private,
+            index_cache_mode,
+            index_cache_permissions_required,
+        ) = _index_cache_permission_status(index_cache, os.name)
         record("index_cache_write", True, str(index_cache))
     except OSError as exc:
         record("index_cache_write", False, str(exc))
@@ -621,6 +636,7 @@ def doctor(
             "index_cache_permissions",
             index_cache_private,
             index_cache_mode,
+            required=index_cache_permissions_required,
         )
         record("repository_execution", True, "scanner has no command-execution interface")
 

--- a/src/repolocus/config.py
+++ b/src/repolocus/config.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
+from repolocus.security.network import is_loopback_url
+
 DEFAULT_MODEL = "local"
 MAX_CONFIG_BYTES = 1_000_000
 
@@ -213,6 +215,8 @@ def _validate_base_url(name: str, value: object) -> None:
         raise ConfigError(f"{name} must not contain credentials")
     if parsed.query or parsed.fragment:
         raise ConfigError(f"{name} must not contain a query or fragment")
+    if parsed.scheme == "http" and not is_loopback_url(value):
+        raise ConfigError(f"{name} must use HTTPS unless it targets a loopback address")
 
 
 def _ensure_repo_config_path(root: Path, config_path: Path) -> None:

--- a/src/repolocus/index/store.py
+++ b/src/repolocus/index/store.py
@@ -313,7 +313,7 @@ class RepositoryIndex:
 
     @staticmethod
     def _harden_path(path: Path, mode: int) -> None:
-        """Restrict plaintext index access on POSIX; Windows uses ACLs instead."""
+        """Restrict plaintext index access where POSIX mode bits are available."""
 
         if os.name == "nt":
             return

--- a/src/repolocus/providers/http.py
+++ b/src/repolocus/providers/http.py
@@ -111,8 +111,8 @@ class OllamaProvider(_HTTPProvider):
             payload={
                 "model": self.model,
                 "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
+                    {"role": "system", "content": redact_text(system_prompt)},
+                    {"role": "user", "content": redact_text(user_prompt)},
                 ],
                 "stream": False,
             },
@@ -263,7 +263,12 @@ def _normalise_base_url(value: str) -> str:
         raise ProviderConfigurationError("provider base URL must not contain credentials")
     if parsed.query or parsed.fragment:
         raise ProviderConfigurationError("provider base URL must not contain a query or fragment")
-    return value.rstrip("/")
+    normalised = value.rstrip("/")
+    if parsed.scheme == "http" and not is_loopback_url(normalised):
+        raise ProviderConfigurationError(
+            "provider base URL must use HTTPS unless it targets a loopback address"
+        )
+    return normalised
 
 
 def _append_endpoint(base_url: str, endpoint: str, *, accepted_suffix: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from repolocus.cli import app
+from repolocus.cli import _index_cache_permission_status, app
 from repolocus.config import Settings
 from repolocus.core import RepoLocusService
 from repolocus.security import PrivacyStore
@@ -135,6 +135,48 @@ def test_doctor_does_not_probe_non_loopback_ollama(
     ollama = next(check for check in data["checks"] if check["name"] == "ollama")
     assert ollama["required"] is False
     assert "not loopback" in ollama["detail"]
+
+
+def test_windows_cache_acl_status_is_unknown(tmp_path: Path) -> None:
+    ok, detail, required = _index_cache_permission_status(tmp_path, "nt")
+
+    assert ok is False
+    assert detail == "unknown: Windows ACLs were not inspected"
+    assert required is False
+
+
+def test_doctor_reports_unverified_cache_permissions_as_warning(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "repolocus.cli._index_cache_permission_status",
+        lambda _path, _platform_name: (
+            False,
+            "unknown: Windows ACLs were not inspected",
+            False,
+        ),
+    )
+
+    result = runner.invoke(app, ["doctor", str(sample_repo), "--security", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    permissions = next(
+        check for check in data["checks"] if check["name"] == "index_cache_permissions"
+    )
+    assert permissions == {
+        "name": "index_cache_permissions",
+        "ok": False,
+        "detail": "unknown: Windows ACLs were not inspected",
+        "required": False,
+    }
+
+    table_result = runner.invoke(app, ["doctor", str(sample_repo), "--security"])
+    assert table_result.exit_code == 0, table_result.output
+    assert "WARN" in table_result.output
+    assert "Windows ACLs were not inspected" in table_result.output
 
 
 def test_generated_output_refuses_escape_and_unrecognized_overwrite(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -168,6 +168,48 @@ def test_base_url_cannot_embed_credentials() -> None:
         Settings(openai_base_url="https://example.invalid/\nredirect")
 
 
+@pytest.mark.parametrize(
+    "environment_name",
+    [
+        "REPOLOCUS_OLLAMA_BASE_URL",
+        "REPOLOCUS_OPENAI_BASE_URL",
+        "REPOLOCUS_ANTHROPIC_BASE_URL",
+    ],
+)
+def test_non_loopback_plain_http_base_urls_are_rejected_during_load(
+    tmp_path: Path,
+    environment_name: str,
+) -> None:
+    with pytest.raises(
+        ConfigError,
+        match="must use HTTPS unless it targets a loopback address",
+    ):
+        Settings.load(
+            environ={environment_name: "http://provider.example.invalid"},
+            user_config_path=tmp_path / "missing.toml",
+        )
+
+
+def test_loopback_http_and_https_base_urls_are_allowed() -> None:
+    loopback = Settings(
+        ollama_base_url="http://localhost:11434",
+        openai_base_url="http://127.0.0.1:8080/v1",
+        anthropic_base_url="http://[::1]:8081",
+    )
+    secure_remote = Settings(
+        ollama_base_url="https://ollama.example.invalid",
+        openai_base_url="https://openai.example.invalid/v1",
+        anthropic_base_url="https://anthropic.example.invalid",
+    )
+
+    assert loopback.ollama_base_url.startswith("http://")
+    assert loopback.openai_base_url.startswith("http://")
+    assert loopback.anthropic_base_url.startswith("http://")
+    assert secure_remote.ollama_base_url.startswith("https://")
+    assert secure_remote.openai_base_url.startswith("https://")
+    assert secure_remote.anthropic_base_url.startswith("https://")
+
+
 def test_oversized_repository_config_is_rejected(tmp_path: Path) -> None:
     config = tmp_path / ".repolocus.toml"
     config.write_text("#" + "x" * 1_000_000, encoding="utf-8")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -158,6 +158,60 @@ def test_remote_ollama_endpoint_is_not_classified_as_local() -> None:
     assert provider.is_local is False
 
 
+@pytest.mark.parametrize("family", ["ollama", "openai", "anthropic"])
+def test_remote_plain_http_provider_urls_are_rejected(family: str) -> None:
+    with pytest.raises(
+        ProviderConfigurationError,
+        match="must use HTTPS unless it targets a loopback address",
+    ):
+        _provider_for_url(family, "http://provider.example.invalid")
+
+
+@pytest.mark.parametrize("family", ["ollama", "openai", "anthropic"])
+@pytest.mark.parametrize(
+    "base_url",
+    ["http://127.0.0.1:11434", "https://provider.example.invalid"],
+    ids=["loopback-http", "https"],
+)
+def test_loopback_http_and_https_provider_urls_are_allowed(
+    family: str,
+    base_url: str,
+) -> None:
+    provider = _provider_for_url(family, base_url)
+
+    assert provider.base_url == base_url
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    ["http://localhost:11434", "https://ollama.example.invalid"],
+    ids=["loopback", "remote"],
+)
+def test_ollama_redacts_prompts_before_sending(base_url: str) -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"message": {"content": "Safe answer."}})
+
+    provider = OllamaProvider(
+        "model",
+        base_url=base_url,
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert (
+        provider.generate('password = "system-secret"', 'api_key = "user-secret"') == "Safe answer."
+    )
+    payload = json.loads(captured[0].content)
+    assert payload["messages"] == [
+        {"role": "system", "content": 'password = "[REDACTED]"'},
+        {"role": "user", "content": 'api_key = "[REDACTED]"'},
+    ]
+    assert "system-secret" not in captured[0].content.decode()
+    assert "user-secret" not in captured[0].content.decode()
+
+
 def test_http_failure_is_clear_and_never_retried() -> None:
     requests = 0
 
@@ -182,3 +236,27 @@ def test_malformed_provider_response_has_clear_error() -> None:
 
     with pytest.raises(ProviderResponseError, match="missing message"):
         provider.generate("System", "Question")
+
+
+def _provider_for_url(
+    family: str,
+    base_url: str,
+) -> OllamaProvider | OpenAICompatibleProvider | AnthropicProvider:
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, json={}))
+    if family == "ollama":
+        return OllamaProvider("model", base_url=base_url, transport=transport)
+    if family == "openai":
+        return OpenAICompatibleProvider(
+            "model",
+            base_url=base_url,
+            environ={"OPENAI_API_KEY": "test-key"},
+            transport=transport,
+        )
+    if family == "anthropic":
+        return AnthropicProvider(
+            "model",
+            base_url=base_url,
+            environ={"ANTHROPIC_API_KEY": "test-key"},
+            transport=transport,
+        )
+    raise AssertionError(f"unexpected provider family: {family}")

--- a/tests/test_skill_adapter.py
+++ b/tests/test_skill_adapter.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -17,16 +20,46 @@ ADAPTER = (
 )
 
 
+def _load_adapter() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("repolocus_skill_adapter", ADAPTER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _run_adapter(
-    *arguments: str, environment: dict[str, str] | None = None
+    *arguments: str,
+    environment: dict[str, str] | None = None,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    clean_environment = dict(os.environ if environment is None else environment)
+    clean_environment.pop("COVERAGE_FILE", None)
+    clean_environment.pop("COVERAGE_PROCESS_START", None)
+    for name in tuple(clean_environment):
+        if name.startswith("COV_CORE_"):
+            clean_environment.pop(name)
     return subprocess.run(
-        [sys.executable, str(ADAPTER), *arguments],
+        [sys.executable, "-I", str(ADAPTER), *arguments],
         check=False,
         capture_output=True,
         text=True,
-        env=environment,
+        env=clean_environment,
+        cwd=cwd,
     )
+
+
+def _write_path_hijack(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    if os.name == "nt":
+        executable = directory / "repolocus.cmd"
+        executable.write_text("@echo off\r\necho PATH_HIJACKED\r\n", encoding="utf-8")
+        return executable
+
+    executable = directory / "repolocus"
+    executable.write_text("#!/bin/sh\necho PATH_HIJACKED\n", encoding="utf-8")
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    return executable
 
 
 def test_skill_adapter_forces_local_json_answers(
@@ -67,3 +100,128 @@ def test_skill_adapter_returns_documents_without_writing_repository(
     assert result.returncode == 0, result.stderr
     assert marker in result.stdout
     assert not (sample_repo / output_name).exists()
+
+
+def test_skill_adapter_ignores_target_path_and_module_hijacks(
+    sample_repo: Path, isolated_user_dirs: Path
+) -> None:
+    package = sample_repo / "repolocus"
+    package.mkdir()
+    (package / "__main__.py").write_text("print('MODULE_HIJACKED')\n", encoding="utf-8")
+    executable_directory = sample_repo / "bin"
+    _write_path_hijack(executable_directory)
+
+    environment = dict(os.environ)
+    environment["PATH"] = os.pathsep.join(
+        (str(executable_directory), environment.get("PATH", os.defpath))
+    )
+    environment["PYTHONPATH"] = str(sample_repo)
+    environment["VIRTUAL_ENV"] = str(sample_repo / ".venv")
+
+    result = _run_adapter(
+        "scan",
+        ".",
+        environment=environment,
+        cwd=sample_repo,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "PATH_HIJACKED" not in result.stdout
+    assert "MODULE_HIJACKED" not in result.stdout
+    assert json.loads(result.stdout)["root"] == str(sample_repo.resolve())
+
+
+def test_skill_adapter_rejects_explicit_binary_inside_target(
+    sample_repo: Path, isolated_user_dirs: Path
+) -> None:
+    executable = _write_path_hijack(sample_repo / "bin")
+
+    result = _run_adapter(
+        "--binary",
+        str(executable),
+        "scan",
+        ".",
+        environment=dict(os.environ),
+        cwd=sample_repo,
+    )
+
+    assert result.returncode == 2
+    assert "outside the target repository" in result.stderr
+    assert "PATH_HIJACKED" not in result.stdout
+
+
+def test_skill_adapter_ignores_path_hijack_under_parent_cwd(
+    sample_repo: Path, isolated_user_dirs: Path
+) -> None:
+    invocation_cwd = sample_repo.parent
+    executable_directory = invocation_cwd / ".local" / "bin"
+    _write_path_hijack(executable_directory)
+    environment = dict(os.environ)
+    environment["HOME"] = str(invocation_cwd)
+    environment["USERPROFILE"] = str(invocation_cwd)
+    environment["PATH"] = os.pathsep.join(
+        (str(executable_directory), environment.get("PATH", os.defpath))
+    )
+
+    result = _run_adapter(
+        "scan",
+        str(sample_repo),
+        environment=environment,
+        cwd=invocation_cwd,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "PATH_HIJACKED" not in result.stdout
+    assert json.loads(result.stdout)["root"] == str(sample_repo.resolve())
+
+
+def test_skill_adapter_rejects_python_interpreter_inside_target(
+    sample_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter()
+    target_interpreter = sample_repo / ".venv" / "bin" / "python"
+    monkeypatch.setattr(adapter.sys, "executable", str(target_interpreter))
+
+    with pytest.raises(adapter.AdapterError, match="Python interpreter inside the target"):
+        adapter._trusted_interpreter(sample_repo.resolve())
+
+
+def test_skill_adapter_keeps_absolute_user_bin_while_sanitizing_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter()
+    invocation_cwd = tmp_path / "home"
+    user_bin = invocation_cwd / ".local" / "bin"
+    target = invocation_cwd / "projects" / "target"
+    target_bin = target / "bin"
+    for directory in (user_bin, target_bin):
+        directory.mkdir(parents=True)
+    monkeypatch.chdir(invocation_cwd)
+    monkeypatch.setattr(adapter, "_account_home", lambda: invocation_cwd.resolve())
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join((str(user_bin), ".", "relative-bin", str(target_bin), os.defpath)),
+    )
+    for name in (*adapter._PYTHON_IMPORT_ENVIRONMENT, *adapter._UV_ENVIRONMENT):
+        monkeypatch.setenv(name, str(target))
+    monkeypatch.setenv("COVERAGE_PROCESS_START", str(target / "coverage.ini"))
+    monkeypatch.setenv("COV_CORE_SOURCE", "repolocus")
+
+    interpreter = adapter._trusted_interpreter(target.resolve())
+    trusted_roots = adapter._trusted_roots(target.resolve(), interpreter)
+
+    environment = adapter._execution_environment(
+        invocation_cwd=invocation_cwd.resolve(),
+        untrusted_roots=(target.resolve(), invocation_cwd.resolve()),
+        trusted_roots=trusted_roots,
+    )
+
+    path_entries = set(environment["PATH"].split(os.pathsep))
+    assert str(user_bin.resolve()) in path_entries
+    assert str(invocation_cwd.resolve()) not in path_entries
+    assert str((invocation_cwd / "relative-bin").resolve()) not in path_entries
+    assert str(target_bin.resolve()) not in path_entries
+    assert all(name not in environment for name in adapter._PYTHON_IMPORT_ENVIRONMENT)
+    assert all(name not in environment for name in adapter._UV_ENVIRONMENT)
+    assert "COVERAGE_PROCESS_START" not in environment
+    assert "COV_CORE_SOURCE" not in environment


### PR DESCRIPTION
## Summary

- isolate the bundled Codex Skill runtime from untrusted target repositories, PATH entries, Python modules, interpreters, and environment overrides
- redact Ollama prompts before transport and require HTTPS for every non-loopback provider endpoint
- report unverified Windows cache ACLs as an optional warning instead of a false success
- add tag-gated release automation for wheel, sdist, standalone Skill ZIP, CycloneDX SBOM, SHA-256 checksums, PyPI Trusted Publishing, and GitHub Releases
- update package metadata, changelog, security/privacy documentation, and English/Chinese installation guidance

## Validation

- Python 3.10: 215 tests passed; 86.16% branch coverage
- Python 3.12: 215 tests passed
- Ruff formatting and lint checks passed
- Bandit medium/high scan passed for runtime and Skill Python sources
- actionlint 1.7.12 passed for both workflows
- Skill quick validation and read-only forward test passed
- wheel/sdist build, Twine check, clean wheel install, doctor, Skill smoke test, SBOM export, and package-layout checks passed

## Before tagging

Configure a protected GitHub environment named `pypi` and register the PyPI Pending Trusted Publisher with owner `Henry-Yolky`, repository `RepoLocus`, workflow `release.yml`, and environment `pypi`. No long-lived PyPI token is required.
