### PR TITLE
ci: require release tags from main history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.12"
           enable-cache: true
           version: "0.9.18"
-      - name: Verify tag, version, and main ancestry
+      - name: Verify tag, version, and main first-parent history
         id: version
         shell: bash
         run: |
@@ -37,8 +37,12 @@ jobs:
             echo "Tag $tag does not match project version $version" >&2
             exit 1
           fi
-          git fetch --no-tags origin main
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          git fetch --no-tags origin refs/heads/main
+          release_commit="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+          if ! git rev-list --first-parent FETCH_HEAD | grep -Fx "$release_commit" >/dev/null; then
+            echo "Tag $tag must point to a commit on main's first-parent history" >&2
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Test release source
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,5 +34,25 @@ the PyPI Trusted Publisher (or pending publisher) with these exact claims:
 
 Require a maintainer approval on the `pypi` environment. Do not add a long-lived PyPI token to
 GitHub secrets. The release workflow accepts version tags such as `v0.1.0` only when the tag
-matches `pyproject.toml` and its commit belongs to `main`; it then tests, builds, publishes with
-OIDC, and creates the GitHub Release with checksums, an SBOM, and the standalone Codex Skill.
+matches `pyproject.toml` and its commit appears on `main`'s first-parent history; it then tests,
+builds, publishes with OIDC, and creates the GitHub Release with checksums, an SBOM, and the
+standalone Codex Skill.
+
+For each release:
+
+1. Update the version in `pyproject.toml` and `src/repolocus/__init__.py`, refresh `uv.lock`, and
+   update `CHANGELOG.md` in a pull request.
+2. Wait for the required CI check and merge the pull request into `main`.
+3. Tag the resulting `main` commit, not the pull-request head:
+
+   ```bash
+   git switch main
+   git pull --ff-only origin main
+   git tag -a vX.Y.Z -m "RepoLocus vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+4. Approve the waiting `pypi` environment deployment. The remaining PyPI and GitHub Release
+   steps are automatic.
+
+Never move or reuse a published release tag.


### PR DESCRIPTION
## Summary

- require release tags to point to commits on `main`'s first-parent history
- reject tags created from merged pull-request head commits while allowing older released `main` commits
- document the version bump, merge, tag, approval, and tag-immutability release sequence

## Verification

- `actionlint` v1.7.12
- `uv lock --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (`215 passed`)
- verified the guard rejects the v0.1.0 pull-request head and accepts both its merge commit and an older `main` first-parent commit

## Repository setting

`main` branch protection is already enabled separately: pull requests are required, administrators are included, all nine CI checks are required from GitHub Actions, branches must be up to date, force pushes and deletion are disabled, and conversations must be resolved.
