### PR TITLE
chore: prepare v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes are recorded here. The format follows Keep a Changelog, and versions use
 Semantic Versioning while the project is in alpha.
 
+## [0.1.1] - 2026-08-03
+
+### Changed
+
+- Release tags must point to commits on `main`'s first-parent history, preventing tags on merged
+  pull-request heads from producing incomplete generated release notes.
+- Documented the repeatable version-bump, merge, tag, approval, and immutable-tag release flow.
+
 ## [0.1.0] - 2026-08-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repolocus"
-version = "0.1.0"
+version = "0.1.1"
 description = "A read-only, local-first codebase map with source-backed answers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repolocus/__init__.py
+++ b/src/repolocus/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 
+from repolocus import __version__
 from repolocus.api import create_app
 
 
@@ -37,7 +38,7 @@ def test_self_hosted_api_health_and_local_workflow(
     )
 
     assert health.status_code == 200
-    assert health.json()["version"] == "0.1.0"
+    assert health.json()["version"] == __version__
     assert scan.status_code == 200, scan.text
     assert scan.json()["scan"]["indexed_files"] >= 4
     assert project_map.status_code == 200, project_map.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from repolocus import __version__
 from repolocus.cli import _index_cache_permission_status, app
 from repolocus.config import Settings
 from repolocus.core import RepoLocusService
@@ -20,7 +21,7 @@ def test_cli_help_and_version() -> None:
     assert help_result.exit_code == 0
     assert "source-backed answers" in help_result.stdout
     assert version_result.exit_code == 0
-    assert "RepoLocus 0.1.0" in version_result.stdout
+    assert f"RepoLocus {__version__}" in version_result.stdout
 
 
 def test_cli_scan_map_ask_and_diagram(sample_repo: Path, isolated_user_dirs: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "repolocus"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- bump the package, runtime, and lockfile versions to `0.1.1`
- add the `0.1.1` changelog entry for the hardened release-tag flow
- make CLI and API version tests follow the canonical runtime version instead of hard-coding `0.1.0`

## Verification

- `actionlint` v1.7.12
- `uv lock --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest --cov=repolocus --cov-report=term-missing` (`215 passed`, `86.16%`)
- `uv run repolocus doctor --security --json`
- built and validated `repolocus-0.1.1` wheel and sdist with Twine
- installed the wheel with the API extra in a clean Python 3.12 environment
