### PR TITLE
chore(release): prepare v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes are recorded here. The format follows Keep a Changelog, and versions use
 Semantic Versioning while the project is in alpha.
 
+## [0.1.2] - 2026-08-04
+
+### Changed
+
+- Precompiled reusable regular expressions in the Markdown and configuration parsers, avoiding
+  repeated regular-expression cache lookups for every source line.
+
 ## [0.1.1] - 2026-08-03
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repolocus"
-version = "0.1.1"
+version = "0.1.2"
 description = "A read-only, local-first codebase map with source-backed answers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repolocus/__init__.py
+++ b/src/repolocus/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "repolocus"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- bump the package and runtime version to 0.1.2
- record the Markdown/config parser regex precompilation improvement
- refresh the locked local package version

## Validation

- `uv lock --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (215 passed)
- `uv run repolocus doctor --security --json`
- built wheel and sdist; `twine check` passed