### PR TITLE
fix: address follow-up security review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Semantic Versioning while the project is in alpha.
 - Stream provider responses under byte, media-type, HTTP phase-timeout, elapsed-deadline, and
   JSON-structure limits; read repository configuration once through a pinned, no-follow
   descriptor chain.
+- Force low-level scanner and repository-config reads into binary mode on Windows so raw-byte
+  size, hashes, secret checks, and Ctrl-Z handling remain consistent across platforms.
 
 ## [0.1.3] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes are recorded here. The format follows Keep a Changelog, and versions use
 Semantic Versioning while the project is in alpha.
 
+## [Unreleased]
+
+## [0.1.4] - 2026-08-04
+
+### Changed
+
+- `refresh=auto` now performs an identity-bound delta scan; the evidence path uses a metadata-only
+  manifest so unchanged files avoid source reads and parser-fact materialization, while changed
+  files are securely read, hashed, and parsed.
+- The public `RepoLocusService.scan()` result is metadata-only for unchanged files; callers that
+  need source text and parser facts should use `map()`, `diagram()`, or retrieval evidence.
+- The bundled Skill now requires a RepoLocus `>=0.1.4,<0.2.0` runtime so older security and
+  analysis policies cannot pass adapter preflight.
+- CJK retrieval uses position-spread bounded n-gram coverage, and answerable retrieval metrics are
+  aggregated separately from no-answer classification metrics and query-type breakdowns.
+- Generated-output detection is extension-independent, nested generated documents use correct
+  relative source links, and generated CLI files require a Markdown suffix.
+- Added repository-wide limits for entries/files, bytes, depth, chunks, symbols, and scan time.
+
+### Security
+
+- Invalidated older analysis facts and path-only index/consent identities; repository replacement,
+  stale parser caches, and incomplete upgrades now fail closed.
+- Unified scanner and transport secret rules, count prompt redactions in previews, and scan the
+  final serialized request before transport.
+- Stream provider responses under byte, media-type, HTTP phase-timeout, elapsed-deadline, and
+  JSON-structure limits; read repository configuration once through a pinned, no-follow
+  descriptor chain.
+
 ## [0.1.3] - 2026-08-04
 
 ### Added

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,9 +22,13 @@ Ollama endpoint and every cloud provider are disabled until the user either pass
 `--allow-cloud` for one call or records a repository/provider grant. Before every approved
 remote CLI call, RepoLocus displays the exact redacted source content and ranges, fragment count,
 estimated tokens, and redaction count that will be sent, including calls covered by a remembered
-grant. System and user prompts are redacted again immediately before transport. The self-hosted
-API has no interactive confirmation UI; cloud access is operator-disabled by default and should
-remain so unless a trusted front end provides an equivalent review step.
+grant. System and user prompts are redacted again immediately before transport, and the final
+serialized JSON body is scanned fail-closed before a network client is created. Provider responses
+are read with byte, content-type, JSON-depth, per-HTTP-phase timeout, and elapsed-deadline checks
+between streamed chunks. A blocking HTTP phase is bounded by the configured HTTPX phase timeout;
+the elapsed deadline is cooperative rather than an operating-system-level interrupt. The
+self-hosted API has no interactive confirmation UI; cloud access is operator-disabled by default
+and should remain so unless a trusted front end provides an equivalent review step.
 
 Only retrieved fragments needed for the question are sent. API credentials are read from
 environment variables and are never written to repository or consent configuration.
@@ -44,7 +48,7 @@ are not a guarantee that arbitrary source contains no confidential information. 
 RepoLocus does not import configuration, indexes, environment-variable settings, or remembered
 cloud consent from pre-rename DevPilot alpha builds. Requiring fresh configuration and consent
 prevents old network destinations or grants from silently carrying over. The legacy
-`.devpilot/` directory remains excluded from scans, and existing generated documents can still
-be safely replaced, but `repolocus clean --all` and `repolocus privacy revoke` operate only on
+`.devpilot/` directory remains excluded from scans, and recognized generated Markdown outputs can
+still be safely replaced, but `repolocus clean --all` and `repolocus privacy revoke` operate only on
 RepoLocus state. Inspect and explicitly remove obsolete operating-system config, cache, and state
 directories named `devpilot` if they are no longer needed.

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ repolocus ask "Where is configuration validated?" \
   --model openai/gpt-4.1-mini --allow-cloud
 ```
 
-Remembered-consent format v2 binds a grant to the canonical repository, provider, scheme, host,
-effective port, and complete request path. Changing a compatible-provider endpoint therefore
-requires fresh consent. Legacy v1 family-only grants are intentionally ignored after upgrade and
-must be granted again.
+Remembered-consent format v3 binds a grant to the current repository identity, canonical path,
+provider, scheme, host, effective port, and complete request path. Replacing the directory or its
+Git marker, or changing a compatible-provider endpoint, therefore requires fresh consent. Legacy
+path-only v1/v2 grants are intentionally ignored after upgrade.
 
 ## What it produces
 
@@ -112,9 +112,11 @@ supports the claim. A model answer that passes these checks is still labeled `ne
 | `repolocus serve` | Start the optional self-hosted FastAPI service |
 
 Every command accepts `--help`. Use `--json` on automation-friendly commands where available.
-`map`, `diagram`, and `ask` default to `--refresh auto`: they query the last compatible committed
-snapshot and scan only when one is unavailable. Use `--refresh always` to scan before the
-operation, or `--refresh never` to forbid scanning and fail if no compatible snapshot exists.
+`map`, `diagram`, and `ask` default to `--refresh auto`: they perform a bounded incremental refresh
+before querying, so edits or a repository replaced at the same path cannot inherit old evidence.
+Use `--refresh never` only when explicitly pinning the last compatible committed snapshot.
+The Python `RepoLocusService.scan()` result keeps unchanged files metadata-only (including cached
+fact counts); use `map()`, `diagram()`, or `evidence()` when materialized facts are required.
 
 Add `--follow-up` to `ask` for a non-persistent in-memory question session; entering a blank line
 ends it. The first answer pins an index generation, and every follow-up uses that exact generation
@@ -257,13 +259,14 @@ of evaluating autonomous behavior.
 uv sync --all-extras
 uv run ruff check .
 uv run pytest --cov=repolocus --cov-report=term-missing
-uv run python scripts/evaluate_retrieval.py evaluation/questions.json .
+uv run python scripts/evaluate_retrieval.py evaluation/questions.dataset .
 uv build
 ```
 
 The retrieval report includes per-case recall@k, reciprocal rank, nDCG@k, expected-path coverage,
 and citation recall, plus aggregate macro recall, MRR, mean nDCG, any/all-path rates,
-no-answer precision and accuracy, and per-language breakdowns. The CLI can enforce minimum
+no-answer precision/recall/F1/accuracy, and per-language/per-query-type breakdowns. Answerable retrieval and
+no-answer classification are aggregated separately. The CLI can enforce minimum
 any-path hit rate, macro recall, and MRR. These metrics describe the checked-in regression cases,
 not the planned release-scale evaluation.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@ pipx install ./RepoLocus
 cd 你的仓库
 repolocus scan
 repolocus map
-repolocus ask "配置在哪里校验？"
+repolocus ask "设置值由哪个模块检查？"
 repolocus diagram
 ```
 
@@ -46,12 +46,12 @@ repolocus ask "请求如何进入核心循环？" --model ollama/qwen3-coder
 
 云模型调用前，RepoLocus 会展示模型、规范化目的端点、精确序列化 payload 字节数、源码
 片段、文件列表和估算 Token 数。可用 `--allow-cloud` 仅授权本次调用，或同时使用
-`--remember-consent` 为当前仓库记住该供应商端点。v2 授权会绑定规范仓库路径、供应商、
-scheme、host、有效端口和完整请求路径；compatible endpoint 变化后必须重新授权。升级前的
-v1 供应商级授权会按 fail-closed 原则失效，需要重新 grant。
-`map`、`diagram` 和 `ask` 默认使用 `--refresh auto`：优先读取最近一次兼容的已提交 snapshot，
-仅在不存在兼容 snapshot 时扫描。`--refresh always` 会先扫描，`--refresh never` 禁止扫描并在
-没有兼容 snapshot 时失败。
+`--remember-consent` 为当前仓库记住该供应商端点。v3 授权会绑定当前仓库身份、规范路径、
+供应商、scheme、host、有效端口和完整请求路径；仓库目录或 Git marker 被替换、compatible
+endpoint 变化后都必须重新授权。旧的 v1/v2 路径级授权会按 fail-closed 原则失效。
+`map`、`diagram` 和 `ask` 默认使用 `--refresh auto`：查询前执行有界资源预算的增量刷新，避免同一
+路径下的新内容继承旧证据。只有显式要求固定最近一次兼容 snapshot 时才使用
+`--refresh never`。
 
 `repolocus ask ... --follow-up` 可在当前进程内继续追问；首次回答会固定 index generation，
 后续问题关闭 refresh 并要求同一 generation，若其他扫描推进 generation 则 fail closed。输入
@@ -61,6 +61,7 @@ v1 供应商级授权会按 fail-closed 原则失效，需要重新 grant。
 
 - 安全扫描：遵循 `.gitignore`，排除二进制、大文件、密钥文件、构建产物和符号链接；
 - 增量索引：仓库外 SQLite/FTS5 缓存，按文件哈希更新；
+- 配置安全：用户、仓库与环境设置合并后执行类型和边界校验，仓库配置只能收紧资源限制；
 - 项目地图：固定章节、源码链接和 `Confirmed` / `Inferred` / `Needs review` 标签；
 - 证据问答：符号、FTS5/BM25、term 索引与依赖邻居混合检索；term 索引拆分
   camelCase、snake_case 和路径，并为连续 CJK 文本建立 bigram/trigram；用户可通过
@@ -72,7 +73,7 @@ v1 供应商级授权会按 fail-closed 原则失效，需要重新 grant。
 - 隐私控制：默认关闭遥测，云端逐次授权或按仓库和端点记忆授权，可预览与撤回；
 - 自托管 API：安装 `api` 可选依赖后运行 `repolocus serve`。
 - 评测：输出 recall@k、MRR、nDCG@k、any/all-path、citation recall、no-answer
-  precision/accuracy 及按语言汇总；当前仍只是小型 regression set。
+  precision/recall/F1/accuracy，以及按语言和查询类型汇总；当前仍只是小型 regression set。
 
 ## Agent Skill
 
@@ -144,7 +145,13 @@ ACL 检查，因此 `doctor --security` 会明确将 ACL 状态报告为“未�
 扫描器默认排除识别出的 RepoLocus 生成文档；索引仍为迁移或显式导入的记录保留
 `generated` provenance。不完整或暂时不可读的扫描会把旧 facts 保留为 `stale`。默认查询只使用 `source` 且非 `stale` 的已提交 snapshot，确认删除后
 才移除对应行。每次提交通过单调 generation 做 compare-and-swap，拒绝旧扫描覆盖新结果。
-这属于安全重读、内容哈希和 parser-fact 复用，不是 manifest-delta watcher。
+`ask` 的兼容分析版本刷新使用 metadata-only manifest，跳过未变化文件的正文和 parser facts；
+Python API 的 `RepoLocusService.scan()` 对未变化文件同样只返回 metadata 和已缓存的 fact
+计数。需要物化 facts 时应调用 `map()`、`diagram()` 或 `evidence()`。变化文件会安全读取、
+哈希并重新解析。
+扫描同时限制文件/entry 数、总字节、目录深度、chunks、symbols，并在有界操作前后检查总耗时；
+阻塞的文件系统调用或第三方 parser 可能在下一次检查前超时。检测到预算耗尽时，未完成范围会
+标为 `stale`，而不是确认删除旧 facts。
 
 完整命令、架构、测试与开发说明以英文
 [README.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/README.md) 为准。隐私与安全

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,10 @@ flowchart LR
 
 ## Data invariants
 
-All stored and returned paths are POSIX-style and relative to one canonical repository root.
+Indexed source addresses are POSIX-style and relative to one canonical repository root. Generated
+file links are relative to the output document; stdout/API document links are explicitly
+repository-root-relative. Operational metadata may separately expose the canonical absolute root
+and external index path.
 Source lines are one-based and inclusive. Every symbol and chunk has a concrete line range.
 Index updates occur in a transaction. Retrieval never expands beyond indexed chunks. Provider
 context is redacted and bounded by a character budget. Every material provider claim must be
@@ -54,11 +57,10 @@ body; execution consumes those values rather than retrieving the evidence again.
 ## Snapshot and index lifecycle
 
 The canonical repository path is hashed to choose an opaque database name under the user cache
-directory. The database records its canonical root, schema/parser versions, and monotonic commit
-generation. `map`, `diagram`, and `ask` use `refresh=auto` by default: a compatible committed
-snapshot is queried without scanning, while a missing or incompatible snapshot triggers a scan.
-`refresh=always` scans first; `refresh=never` forbids scanning and fails closed without a compatible
-snapshot. Callers can also pin an expected generation. CLI follow-up sessions pin the first
+directory. The database records its canonical root, directory identity, schema/parser versions,
+and monotonic commit generation. `map`, `diagram`, and `ask` use `refresh=auto` by default and run a
+bounded incremental refresh before querying. `refresh=never` is the explicit snapshot-only mode
+and fails closed without a compatible snapshot. Callers can also pin an expected generation. CLI follow-up sessions pin the first
 answer's generation and use `refresh=never`, so a concurrent generation change ends the session.
 
 Recognized RepoLocus-generated documents are excluded by the scanner. The schema also retains
@@ -73,11 +75,15 @@ scan cannot overwrite a newer commit. Unpinned scans may retry from the new gene
 caller that pinned a generation fails closed. `repolocus clean` deletes only that database and its
 SQLite sidecars.
 
-For a compatible analysis version, the scanner safely re-reads and hashes candidate files but
-reuses stored parser facts when the bytes are identical. This avoids trusting timestamps alone,
-while skipping AST/heuristic parsing and SQLite replacement for unchanged files. Parser or chunk
-policy changes alter the analysis version and force full fact regeneration. This is content-hash
-fact reuse after bounded discovery, not a manifest-delta watcher.
+For a compatible analysis version and repository identity, evidence refresh loads a metadata-only
+manifest instead of every source body and parser fact. Exact size/mtime/ctime matches reuse the
+stored facts; changed files are opened without following links, hashed, and reparsed. Parser,
+secret-detector, or chunk-policy changes alter the analysis version and force regeneration.
+Repository scans enforce hard count/size limits for entries/files, total candidate bytes, directory
+depth, chunks, and symbols. A monotonic elapsed-time deadline is checked before and after bounded
+I/O and parser operations; a blocking filesystem call or third-party parser may overrun before the
+next check. Any detected exhaustion marks the unvisited range incomplete so old facts become
+excluded `stale` rows rather than confirmed deletions.
 
 ## Extension points
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -40,15 +40,15 @@ retrieved evidence and that the paired quote occurs in that cited source range. 
 that the quote logically supports the model's claim; accepted model text therefore keeps
 `needs_review` confidence.
 
-The default `refresh=auto` query path reads the last compatible committed snapshot without
-rescanning. This makes one operation internally reproducible but does not promise that the
-snapshot reflects an uncommitted filesystem change made afterward. Use `refresh=always` when a
-new scan is required; `refresh=never` fails closed if no compatible snapshot exists. Follow-up
-sessions additionally pin the original generation and stop if another scan changes it.
+The default `refresh=auto` query path performs a bounded incremental refresh before reading
+evidence. `refresh=never` is the explicit committed-snapshot mode and fails closed if no compatible
+snapshot exists. Follow-up sessions pin the original generation and stop if another scan changes
+it. Metadata reuse is permitted only for the same repository identity and analysis version;
+changed files are reopened, hashed, and reparsed.
 
-Remembered-consent state v2 binds a canonical repository and provider to the destination scheme,
-host, effective port, and complete request path. It deliberately does not carry forward legacy v1
-family-only grants because no safe endpoint can be inferred during migration. A changed endpoint
+Remembered-consent state v3 binds the current root-directory and Git-marker identity, canonical
+path, and provider to the destination scheme, host, effective port, and complete request path. It
+does not carry forward legacy v1/v2 path-only grants. A replaced repository or changed endpoint
 therefore requires a new explicit grant. Model names are displayed in previews but are not part of
 the grant identity.
 

--- a/evaluation/questions.dataset
+++ b/evaluation/questions.dataset
@@ -1,60 +1,87 @@
 [
   {
     "question": "Where is Settings configuration validated?",
-    "expected_paths": ["src/repolocus/config.py"]
+    "language": "en",
+    "query_type": "identifier",
+    "expected_paths": ["src/repolocus/config.py"],
+    "expected_citations": ["src/repolocus/config.py:139"]
   },
   {
     "question": "How is cloud provider consent enforced?",
+    "language": "en",
+    "query_type": "english",
     "expected_paths": ["src/repolocus/core/service.py", "src/repolocus/security/privacy.py"]
   },
   {
     "question": "Where are symlinks rejected during repository scanning?",
+    "language": "en",
+    "query_type": "english",
     "expected_paths": ["src/repolocus/scanner/repository.py"]
   },
   {
     "question": "Where is the SQLite FTS5 schema created?",
+    "language": "en",
+    "query_type": "identifier",
     "expected_paths": ["src/repolocus/index/store.py"]
   },
   {
     "question": "How is generated Mermaid syntax validated?",
+    "language": "en",
+    "query_type": "identifier",
     "expected_paths": ["src/repolocus/generators/mermaid.py"]
   },
   {
     "question": "Where does the OpenAI-compatible provider send requests?",
+    "language": "en",
+    "query_type": "identifier",
     "expected_paths": ["src/repolocus/providers/http.py"]
   },
   {
     "question": "How does the API confine requests to its configured root?",
+    "language": "en",
+    "query_type": "identifier",
     "expected_paths": ["src/repolocus/api/app.py"]
   },
   {
     "question": "Where are secrets redacted before model use?",
+    "language": "en",
+    "query_type": "english",
     "expected_paths": ["src/repolocus/security/redaction.py", "src/repolocus/core/service.py"]
   },
   {
     "question": "Where are generated output paths kept inside the repository?",
+    "language": "en",
+    "query_type": "english",
     "expected_paths": ["src/repolocus/security/paths.py", "src/repolocus/cli.py"]
   },
   {
     "question": "Where is the parser plugin registry implemented?",
+    "language": "en",
+    "query_type": "english",
     "expected_paths": ["src/repolocus/parsers/base.py"]
   },
   {
     "question": "How are retrieval candidates ranked and deduplicated?",
+    "language": "en",
+    "query_type": "english",
     "expected_paths": ["src/repolocus/retrieval/engine.py"]
   },
   {
     "question": "Where does clean refuse unsafe cache contents?",
+    "language": "en",
+    "query_type": "identifier",
     "expected_paths": ["src/repolocus/cli.py"]
   },
   {
     "question": "配置在哪里校验",
     "language": "zh",
-    "expected_paths": ["tests/test_terms.py"]
+    "query_type": "cjk",
+    "expected_paths": ["README.zh-CN.md"]
   },
   {
-    "question": "？？？",
-    "language": "no-answer",
+    "question": "How does the Erlang OTP supervisor restart crashed workers?",
+    "language": "en",
+    "query_type": "english",
     "expected_paths": []
   }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repolocus"
-version = "0.1.3"
+version = "0.1.4"
 description = "A read-only, local-first codebase map with source-backed answers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -90,10 +90,13 @@ def evaluate_cases(
         raise ValueError("evaluation limit must be positive")
     outcomes: list[dict[str, object]] = []
     language_metrics: dict[str, list[tuple[float, float, float]]] = defaultdict(list)
-    predicted_no_answer = 0
-    correct_predicted_no_answer = 0
-    no_answer_cases = 0
-    correct_no_answer_cases = 0
+    language_case_counts: dict[str, int] = defaultdict(int)
+    query_type_metrics: dict[str, list[tuple[float, float, float]]] = defaultdict(list)
+    query_type_case_counts: dict[str, int] = defaultdict(int)
+    no_answer_true_positive = 0
+    no_answer_false_positive = 0
+    no_answer_false_negative = 0
+    no_answer_true_negative = 0
     citation_scores: list[float] = []
     for case in cases:
         question = str(case["question"])
@@ -103,43 +106,51 @@ def evaluate_cases(
         expected = {str(path) for path in raw_expected}
         evidence = retrieval.search(question, limit=limit)
         returned = _unique_paths(evidence)
+        answerable = bool(expected)
+        predicted_no_answer = not returned
         relevant_ranks = [rank for rank, path in enumerate(returned, 1) if path in expected]
-        recall = (
-            len(expected.intersection(returned)) / len(expected)
-            if expected
-            else float(not returned)
+        recall = len(expected.intersection(returned)) / len(expected) if answerable else None
+        reciprocal_rank = (
+            (1.0 / relevant_ranks[0] if relevant_ranks else 0.0) if answerable else None
         )
-        reciprocal_rank = 1.0 / relevant_ranks[0] if relevant_ranks else 0.0
-        if not expected and not returned:
-            reciprocal_rank = 1.0
-        ndcg = _ndcg(returned, expected, limit)
+        ndcg = _ndcg(returned, expected, limit) if answerable else None
         expected_citations = case.get("expected_citations", [])
         if not isinstance(expected_citations, list):
             raise ValueError("expected_citations must be a JSON list")
         citation_recall = _citation_recall(evidence, [str(item) for item in expected_citations])
         if citation_recall is not None:
             citation_scores.append(citation_recall)
-        if not returned:
-            predicted_no_answer += 1
-            if not expected:
-                correct_predicted_no_answer += 1
-        if not expected:
-            no_answer_cases += 1
-            if not returned:
-                correct_no_answer_cases += 1
+        if not answerable and predicted_no_answer:
+            no_answer_true_positive += 1
+        elif answerable and predicted_no_answer:
+            no_answer_false_positive += 1
+        elif not answerable:
+            no_answer_false_negative += 1
+        else:
+            no_answer_true_negative += 1
         language = str(case.get("language", "unspecified"))
-        language_metrics[language].append((recall, reciprocal_rank, ndcg))
+        language_case_counts[language] += 1
+        query_type = str(case.get("query_type", "unspecified"))
+        query_type_case_counts[query_type] += 1
+        if answerable:
+            if recall is None or reciprocal_rank is None or ndcg is None:  # pragma: no cover
+                raise RuntimeError("answerable metric invariant violated")
+            language_metrics[language].append((recall, reciprocal_rank, ndcg))
+            query_type_metrics[query_type].append((recall, reciprocal_rank, ndcg))
         outcomes.append(
             {
                 "question": question,
                 "language": language,
-                "any_expected_path": (
-                    bool(expected.intersection(returned)) if expected else not returned
+                "query_type": query_type,
+                "answerable": answerable,
+                "predicted_no_answer": predicted_no_answer,
+                "any_expected_path": bool(expected.intersection(returned)) if answerable else None,
+                "all_expected_paths": expected.issubset(returned) if answerable else None,
+                "recall_at_k": round(recall, 6) if recall is not None else None,
+                "reciprocal_rank": (
+                    round(reciprocal_rank, 6) if reciprocal_rank is not None else None
                 ),
-                "all_expected_paths": expected.issubset(returned) if expected else not returned,
-                "recall_at_k": round(recall, 6),
-                "reciprocal_rank": round(reciprocal_rank, 6),
-                "ndcg_at_k": round(ndcg, 6),
+                "ndcg_at_k": round(ndcg, 6) if ndcg is not None else None,
                 "citation_recall": (
                     round(citation_recall, 6) if citation_recall is not None else None
                 ),
@@ -149,46 +160,93 @@ def evaluate_cases(
             }
         )
 
-    answerable = [outcome for outcome in outcomes if outcome["expected_paths"]]
+    answerable = [outcome for outcome in outcomes if outcome["answerable"]]
+    no_answer_cases = len(outcomes) - len(answerable)
+    no_answer_precision_denominator = no_answer_true_positive + no_answer_false_positive
+    no_answer_recall_denominator = no_answer_true_positive + no_answer_false_negative
+    no_answer_precision = (
+        no_answer_true_positive / no_answer_precision_denominator
+        if no_answer_precision_denominator
+        else 0.0
+        if no_answer_cases
+        else None
+    )
+    no_answer_recall = (
+        no_answer_true_positive / no_answer_recall_denominator
+        if no_answer_recall_denominator
+        else None
+    )
+    no_answer_f1 = (
+        2 * no_answer_precision * no_answer_recall / (no_answer_precision + no_answer_recall)
+        if no_answer_precision is not None
+        and no_answer_recall is not None
+        and no_answer_precision + no_answer_recall > 0
+        else 0.0
+        if no_answer_precision is not None and no_answer_recall is not None
+        else None
+    )
+
+    def answerable_average(field: str) -> float | None:
+        if not answerable:
+            return None
+        return round(sum(float(outcome[field]) for outcome in answerable) / len(answerable), 6)
+
+    def bucket_summary(
+        counts: Mapping[str, int],
+        values: Mapping[str, list[tuple[float, float, float]]],
+    ) -> dict[str, dict[str, int | float | None]]:
+        summary: dict[str, dict[str, int | float | None]] = {}
+        for label in sorted(counts):
+            answerable_values = values[label]
+            answerable_count = len(answerable_values)
+            summary[label] = {
+                "cases": counts[label],
+                "answerable_cases": answerable_count,
+                "no_answer_cases": counts[label] - answerable_count,
+                "macro_recall_at_k": (
+                    round(sum(item[0] for item in answerable_values) / answerable_count, 6)
+                    if answerable_values
+                    else None
+                ),
+                "mrr": (
+                    round(sum(item[1] for item in answerable_values) / answerable_count, 6)
+                    if answerable_values
+                    else None
+                ),
+                "mean_ndcg_at_k": (
+                    round(sum(item[2] for item in answerable_values) / answerable_count, 6)
+                    if answerable_values
+                    else None
+                ),
+            }
+        return summary
+
     metrics: dict[str, object] = {
-        "macro_recall_at_k": round(
-            sum(float(outcome["recall_at_k"]) for outcome in outcomes) / len(outcomes), 6
-        ),
-        "mrr": round(
-            sum(float(outcome["reciprocal_rank"]) for outcome in outcomes) / len(outcomes), 6
-        ),
-        "mean_ndcg_at_k": round(
-            sum(float(outcome["ndcg_at_k"]) for outcome in outcomes) / len(outcomes), 6
-        ),
-        "any_expected_path_rate": round(
-            sum(bool(outcome["any_expected_path"]) for outcome in outcomes) / len(outcomes), 6
-        ),
-        "all_expected_paths_rate": round(
-            sum(bool(outcome["all_expected_paths"]) for outcome in outcomes) / len(outcomes), 6
-        ),
-        "answerable_all_paths_rate": round(
-            sum(bool(outcome["all_expected_paths"]) for outcome in answerable) / len(answerable), 6
-        )
-        if answerable
-        else None,
+        "cases": len(outcomes),
+        "answerable_cases": len(answerable),
+        "no_answer_cases": no_answer_cases,
+        "macro_recall_at_k": answerable_average("recall_at_k"),
+        "mrr": answerable_average("reciprocal_rank"),
+        "mean_ndcg_at_k": answerable_average("ndcg_at_k"),
+        "any_expected_path_rate": answerable_average("any_expected_path"),
+        "all_expected_paths_rate": answerable_average("all_expected_paths"),
+        # Compatibility alias retained for reports produced by v0.1.3.
+        "answerable_all_paths_rate": answerable_average("all_expected_paths"),
         "citation_recall": round(sum(citation_scores) / len(citation_scores), 6)
         if citation_scores
         else None,
-        "no_answer_precision": round(correct_predicted_no_answer / predicted_no_answer, 6)
-        if predicted_no_answer
+        "no_answer_precision": (
+            round(no_answer_precision, 6) if no_answer_precision is not None else None
+        ),
+        "no_answer_recall": round(no_answer_recall, 6) if no_answer_recall is not None else None,
+        "no_answer_f1": round(no_answer_f1, 6) if no_answer_f1 is not None else None,
+        "no_answer_accuracy": round(
+            (no_answer_true_positive + no_answer_true_negative) / len(outcomes), 6
+        )
+        if outcomes
         else None,
-        "no_answer_accuracy": round(correct_no_answer_cases / no_answer_cases, 6)
-        if no_answer_cases
-        else None,
-        "by_language": {
-            language: {
-                "cases": len(values),
-                "macro_recall_at_k": round(sum(item[0] for item in values) / len(values), 6),
-                "mrr": round(sum(item[1] for item in values) / len(values), 6),
-                "mean_ndcg_at_k": round(sum(item[2] for item in values) / len(values), 6),
-            }
-            for language, values in sorted(language_metrics.items())
-        },
+        "by_language": bucket_summary(language_case_counts, language_metrics),
+        "by_query_type": bucket_summary(query_type_case_counts, query_type_metrics),
     }
     return outcomes, metrics
 
@@ -211,6 +269,8 @@ def main() -> int:
     with RepositoryIndex.open(repository) as index:
         retrieval = RetrievalEngine(index)
         outcomes, metrics = evaluate_cases(retrieval, questions, limit=arguments.limit)
+    if not metrics["answerable_cases"]:
+        raise ValueError("evaluation file must contain at least one answerable case")
     hit_rate = float(metrics["any_expected_path_rate"])
     report = {
         "repository": str(repository),

--- a/skills/repolocus-analyze-repo/SKILL.md
+++ b/skills/repolocus-analyze-repo/SKILL.md
@@ -20,7 +20,7 @@ returned on stdout instead of written into the target repository.
   ```
 
 - The Skill does not bundle RepoLocus itself. Require a compatible runtime
-  (`>=0.1.2,<0.2.0`). The adapter resolves the module in isolated Python, validates its origin and
+  (`>=0.1.4,<0.2.0`). The adapter resolves the module in isolated Python, validates its origin and
   distribution version, and then runs that same module; it does not blindly execute a
   `repolocus` command found on `PATH`.
 - If running from a RepoLocus source checkout, prepare its environment ahead of time with

--- a/skills/repolocus-analyze-repo/scripts/run_repolocus.py
+++ b/skills/repolocus-analyze-repo/scripts/run_repolocus.py
@@ -69,9 +69,9 @@ _PATH_ENVIRONMENT = frozenset(
         "XDG_STATE_HOME",
     }
 )
-_MINIMUM_RUNTIME_VERSION = (0, 1, 2)
+_MINIMUM_RUNTIME_VERSION = (0, 1, 4)
 _MAXIMUM_RUNTIME_VERSION = (0, 2, 0)
-_RUNTIME_REQUIREMENT = ">=0.1.2,<0.2.0"
+_RUNTIME_REQUIREMENT = ">=0.1.4,<0.2.0"
 _VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 _RUNTIME_PROBE = (
     "import importlib.metadata as metadata, importlib.util as util, json; "

--- a/src/repolocus/__init__.py
+++ b/src/repolocus/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/src/repolocus/cli.py
+++ b/src/repolocus/cli.py
@@ -28,6 +28,7 @@ from repolocus.config import Settings
 from repolocus.core import PrivacyRequiredError, RepoLocusService
 from repolocus.index import cache_root, index_path_for
 from repolocus.models import Evidence
+from repolocus.scanner import is_generated_document
 from repolocus.security import (
     CloudSendPreview,
     PrivacyStore,
@@ -48,11 +49,7 @@ app.add_typer(privacy_app, name="privacy")
 console = Console()
 error_console = Console(stderr=True)
 
-_GENERATED_OUTPUT_MARKER = re.compile(
-    r"^[ \t]*<!--[ \t]*Generator:[ \t]*(?:RepoLocus|DevPilot)"
-    r"(?:[ \t]+[^;<>\r\n]+)?;[ \t]*deterministic[ \t]+"
-    r"(?:source[ \t]+map|static[ \t]+graph)\.[ \t]*-->[ \t]*$"
-)
+_MARKDOWN_OUTPUT_SUFFIXES = frozenset({".md", ".markdown", ".mdown", ".mdx"})
 
 RepoArgument = Annotated[
     Path,
@@ -138,7 +135,14 @@ def _fail(exc: Exception, code: int = 1) -> None:
     raise typer.Exit(code)
 
 
+def _require_markdown_output(requested: Path) -> None:
+    if requested.suffix.casefold() not in _MARKDOWN_OUTPUT_SUFFIXES:
+        supported = ", ".join(sorted(_MARKDOWN_OUTPUT_SUFFIXES))
+        raise ValueError(f"generated output must use a Markdown suffix ({supported})")
+
+
 def _generated_file(root: Path, requested: Path, content: str, force: bool) -> Path:
+    _require_markdown_output(requested)
     requested_destination = requested if requested.is_absolute() else root / requested
     if requested_destination.is_symlink():
         raise ValueError(f"refusing to replace symlink output: {requested_destination}")
@@ -146,10 +150,9 @@ def _generated_file(root: Path, requested: Path, content: str, force: bool) -> P
     if destination.exists():
         if destination.is_symlink() or not destination.is_file():
             raise ValueError(f"refusing to replace non-regular output: {destination}")
-        prior = destination.read_text(encoding="utf-8", errors="replace")[:4096]
-        generated = any(
-            _GENERATED_OUTPUT_MARKER.fullmatch(line) for line in prior.splitlines()[:16]
-        )
+        with destination.open("r", encoding="utf-8", errors="replace") as handle:
+            prior = handle.read(4096)
+        generated = is_generated_document(prior)
         if not (force or generated):
             raise ValueError(
                 f"output already exists and is not recognized as generated: {destination}; "
@@ -286,7 +289,12 @@ def map_command(
     """Generate a stable, source-linked PROJECT_MAP.md."""
 
     try:
-        document, operation = _service(path).map(path, refresh=refresh)  # type: ignore[arg-type]
+        _require_markdown_output(output)
+        document, operation = _service(path).map(  # type: ignore[arg-type]
+            path,
+            refresh=refresh,
+            destination=None if stdout else output,
+        )
         if stdout:
             sys.stdout.write(document)
             return
@@ -321,9 +329,11 @@ def diagram(
     """Generate a deterministic, validated Mermaid architecture graph."""
 
     try:
+        _require_markdown_output(output)
         document, operation = _service(path).diagram(  # type: ignore[arg-type]
             path,
             refresh=refresh,
+            destination=None if stdout else output,
         )
         if stdout:
             sys.stdout.write(document)

--- a/src/repolocus/config.py
+++ b/src/repolocus/config.py
@@ -522,7 +522,7 @@ def _read_repository_config_bytes(root: Path, path: Path) -> bytes | None:
                 descriptors.append(directory_fd)
             name = relative.parts[-1]
             flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
-            flags |= nofollow | getattr(os, "O_NONBLOCK", 0)
+            flags |= nofollow | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0)
             descriptor = os.open(name, flags, dir_fd=directory_fd)
             file_opened = True
             descriptors.append(descriptor)
@@ -589,7 +589,11 @@ def _read_repository_config_bytes(root: Path, path: Path) -> bytes | None:
             resolved = candidate.resolve(strict=True)
             resolved.relative_to(root)
             flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
-            flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+            flags |= (
+                getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_NONBLOCK", 0)
+                | getattr(os, "O_BINARY", 0)
+            )
             descriptor = os.open(candidate, flags)
             file_opened = True
             try:

--- a/src/repolocus/config.py
+++ b/src/repolocus/config.py
@@ -461,6 +461,16 @@ def _same_config_state(first: os.stat_result, second: os.stat_result) -> bool:
     )
 
 
+def _same_config_identity_and_content(first: os.stat_result, second: os.stat_result) -> bool:
+    """Compare metadata collected from a path and an open handle."""
+
+    return (
+        (first.st_dev, first.st_ino) == (second.st_dev, second.st_ino)
+        and first.st_size == second.st_size
+        and first.st_mtime_ns == second.st_mtime_ns
+    )
+
+
 def _is_reparse_point(metadata: os.stat_result) -> bool:
     marker = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
     return bool(getattr(metadata, "st_file_attributes", 0) & marker)
@@ -548,6 +558,7 @@ def _read_repository_config_bytes(root: Path, path: Path) -> bytes | None:
                     os.close(descriptor)
     else:
         candidate = root.joinpath(*relative.parts)
+        file_opened = False
         try:
             expected = candidate.lstat()
         except FileNotFoundError:
@@ -580,13 +591,14 @@ def _read_repository_config_bytes(root: Path, path: Path) -> bytes | None:
             flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
             flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
             descriptor = os.open(candidate, flags)
+            file_opened = True
             try:
                 opened = os.fstat(descriptor)
                 opened_path = descriptor_path(descriptor)
                 if (
                     not stat.S_ISREG(opened.st_mode)
                     or _is_reparse_point(opened)
-                    or not _same_config_state(expected, opened)
+                    or (expected.st_dev, expected.st_ino) != (opened.st_dev, opened.st_ino)
                     or opened_path is None
                     or not opened_path.is_relative_to(root)
                 ):
@@ -600,18 +612,21 @@ def _read_repository_config_bytes(root: Path, path: Path) -> bytes | None:
             finally:
                 os.close(descriptor)
             current = candidate.lstat()
+            if stat.S_ISLNK(current.st_mode) or _is_reparse_point(current):
+                raise ConfigError(f"repository config changed while being read: {path}")
             current_resolved = candidate.resolve(strict=True)
             current_resolved.relative_to(root)
             if (
-                stat.S_ISLNK(current.st_mode)
-                or _is_reparse_point(current)
-                or not _same_config_state(opened, finished)
-                or not _same_config_state(finished, current)
+                not _same_config_state(opened, finished)
+                or not _same_config_identity_and_content(finished, current)
+                or not _same_config_state(expected, current)
             ):
                 raise ConfigError(f"repository config changed while being read: {path}")
         except ConfigError:
             raise
         except (OSError, ValueError) as exc:
+            if file_opened:
+                raise ConfigError(f"repository config changed while being read: {path}") from exc
             raise ConfigError(
                 f"repository config escapes repository root or uses an unsafe link: {path}"
             ) from exc

--- a/src/repolocus/config.py
+++ b/src/repolocus/config.py
@@ -12,13 +12,16 @@ import json
 import math
 import os
 import re
+import stat
 from collections.abc import Mapping
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
 from repolocus.security.display import has_unsafe_display_controls
+from repolocus.security.identity import descriptor_path
 from repolocus.security.network import is_loopback_url
 
 DEFAULT_MODEL = "local"
@@ -39,6 +42,12 @@ _DEFAULTS: dict[str, object] = {
     "max_output_tokens": 2048,
     "max_file_bytes": 1_000_000,
     "context_char_budget": 24_000,
+    "max_repository_files": 100_000,
+    "max_repository_bytes": 512_000_000,
+    "max_directory_depth": 64,
+    "max_repository_chunks": 500_000,
+    "max_repository_symbols": 500_000,
+    "max_scan_seconds": 120,
     "query_synonyms": "{}",
 }
 
@@ -57,6 +66,12 @@ _ENV_KEYS = {
     "REPOLOCUS_MAX_OUTPUT_TOKENS": "max_output_tokens",
     "REPOLOCUS_MAX_FILE_BYTES": "max_file_bytes",
     "REPOLOCUS_CONTEXT_CHAR_BUDGET": "context_char_budget",
+    "REPOLOCUS_MAX_REPOSITORY_FILES": "max_repository_files",
+    "REPOLOCUS_MAX_REPOSITORY_BYTES": "max_repository_bytes",
+    "REPOLOCUS_MAX_DIRECTORY_DEPTH": "max_directory_depth",
+    "REPOLOCUS_MAX_REPOSITORY_CHUNKS": "max_repository_chunks",
+    "REPOLOCUS_MAX_REPOSITORY_SYMBOLS": "max_repository_symbols",
+    "REPOLOCUS_MAX_SCAN_SECONDS": "max_scan_seconds",
     "REPOLOCUS_QUERY_SYNONYMS": "query_synonyms",
 }
 
@@ -68,7 +83,18 @@ _SECRET_KEY_RE = re.compile(
 # Repository files are untrusted input. A committed config may only tighten
 # local resource limits; it cannot select a model, network destination,
 # telemetry policy, request timeout, or spending limit.
-_REPOSITORY_LIMIT_KEYS = frozenset({"max_file_bytes", "context_char_budget"})
+_REPOSITORY_LIMIT_KEYS = frozenset(
+    {
+        "max_file_bytes",
+        "context_char_budget",
+        "max_repository_files",
+        "max_repository_bytes",
+        "max_directory_depth",
+        "max_repository_chunks",
+        "max_repository_symbols",
+        "max_scan_seconds",
+    }
+)
 
 
 def _default_user_config_path() -> Path:
@@ -101,6 +127,12 @@ class Settings:
     max_output_tokens: int = 2048
     max_file_bytes: int = 1_000_000
     context_char_budget: int = 24_000
+    max_repository_files: int = 100_000
+    max_repository_bytes: int = 512_000_000
+    max_directory_depth: int = 64
+    max_repository_chunks: int = 500_000
+    max_repository_symbols: int = 500_000
+    max_scan_seconds: int = 120
     query_synonyms: str = "{}"
 
     def __post_init__(self) -> None:
@@ -119,7 +151,17 @@ class Settings:
             or self.request_timeout <= 0
         ):
             raise ConfigError("request_timeout must be greater than zero")
-        for field_name in ("max_output_tokens", "max_file_bytes", "context_char_budget"):
+        for field_name in (
+            "max_output_tokens",
+            "max_file_bytes",
+            "context_char_budget",
+            "max_repository_files",
+            "max_repository_bytes",
+            "max_directory_depth",
+            "max_repository_chunks",
+            "max_repository_symbols",
+            "max_scan_seconds",
+        ):
             value = getattr(self, field_name)
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise ConfigError(f"{field_name} must be a positive integer")
@@ -171,14 +213,22 @@ class Settings:
         else:
             repo_paths = []
 
+        if repo_config_path is not None and root is None:
+            raise ConfigError("root is required when repo_config_path is supplied")
+
+        repo_root = Path(root).expanduser().resolve(strict=True) if root is not None else None
         for path in repo_paths:
-            if not path.is_file():
+            if repo_root is None:
+                if not path.is_file():
+                    continue
+                raw = _read_config_bytes(path, source="repository")
+            else:
+                raw = _read_repository_config_bytes(repo_root, path)
+                if raw is None:
+                    continue
+            if path.name == "pyproject.toml" and not _pyproject_declares_repolocus(raw, path):
                 continue
-            if root is not None:
-                _ensure_repo_config_path(Path(root), path)
-            if path.name == "pyproject.toml" and not _pyproject_declares_repolocus(path):
-                continue
-            table = _read_config(path, source="repository")
+            table = _parse_config(raw, path, source="repository")
             # A pyproject is relevant only when it contains [tool.repolocus].
             if path.name == "pyproject.toml" and not _has_repolocus_table(table):
                 continue
@@ -230,11 +280,13 @@ def _validate_base_url(name: str, value: object) -> None:
         raise ConfigError(f"{name} must use HTTPS unless it targets a loopback address")
 
 
-def _ensure_repo_config_path(root: Path, config_path: Path) -> None:
+def _ensure_repo_config_path(root: Path, config_path: Path) -> Path:
+    """Return a lexical path below ``root`` without following repository links."""
+
     root_real = root.expanduser().resolve(strict=True)
-    config_real = config_path.expanduser().resolve(strict=True)
+    config_absolute = config_path.expanduser().absolute()
     try:
-        config_real.relative_to(root_real)
+        return config_absolute.relative_to(root_real)
     except ValueError as exc:
         raise ConfigError(f"repository config escapes repository root: {config_path}") from exc
 
@@ -244,10 +296,10 @@ def _has_repolocus_table(data: Mapping[str, Any]) -> bool:
     return isinstance(tool, Mapping) and isinstance(tool.get("repolocus"), Mapping)
 
 
-def _pyproject_declares_repolocus(path: Path) -> bool:
+def _pyproject_declares_repolocus(raw: bytes, path: Path) -> bool:
     try:
-        text = _read_config_bytes(path, source="repository").decode("utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
         raise ConfigError(f"cannot inspect repository config {path}: {exc}") from exc
     return bool(re.search(r"(?m)^\s*\[tool\.repolocus\]\s*(?:#.*)?$", text))
 
@@ -306,7 +358,17 @@ def _coerce_value(key: str, value: object, source: str) -> object:
         except (TypeError, ValueError) as exc:
             raise ConfigError(f"{source}: request_timeout must be a number") from exc
         return parsed
-    if key in {"max_output_tokens", "max_file_bytes", "context_char_budget"}:
+    if key in {
+        "max_output_tokens",
+        "max_file_bytes",
+        "context_char_budget",
+        "max_repository_files",
+        "max_repository_bytes",
+        "max_directory_depth",
+        "max_repository_chunks",
+        "max_repository_symbols",
+        "max_scan_seconds",
+    }:
         if isinstance(value, bool) or not isinstance(value, (int, str)):
             raise ConfigError(f"{source}: {key} must be an integer")
         try:
@@ -367,6 +429,12 @@ def _parse_query_synonyms(
 
 def _read_config(path: Path, *, source: str) -> Mapping[str, Any]:
     raw = _read_config_bytes(path, source=source)
+    return _parse_config(raw, path, source=source)
+
+
+def _parse_config(raw: bytes, path: Path, *, source: str) -> Mapping[str, Any]:
+    """Parse exactly one already-pinned configuration byte snapshot."""
+
     try:
         try:
             import tomllib  # type: ignore[import-not-found]
@@ -382,6 +450,175 @@ def _read_config(path: Path, *, source: str) -> Mapping[str, Any]:
     if not isinstance(parsed, Mapping):
         raise ConfigError(f"invalid TOML table in {source} config {path}")
     return parsed
+
+
+def _same_config_state(first: os.stat_result, second: os.stat_result) -> bool:
+    return (
+        (first.st_dev, first.st_ino) == (second.st_dev, second.st_ino)
+        and first.st_size == second.st_size
+        and first.st_mtime_ns == second.st_mtime_ns
+        and first.st_ctime_ns == second.st_ctime_ns
+    )
+
+
+def _is_reparse_point(metadata: os.stat_result) -> bool:
+    marker = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(getattr(metadata, "st_file_attributes", 0) & marker)
+
+
+def _read_config_descriptor(descriptor: int) -> bytes:
+    blocks: list[bytes] = []
+    remaining = MAX_CONFIG_BYTES + 1
+    while remaining:
+        block = os.read(descriptor, min(65_536, remaining))
+        if not block:
+            break
+        blocks.append(block)
+        remaining -= len(block)
+    return b"".join(blocks)
+
+
+def _read_repository_config_bytes(root: Path, path: Path) -> bytes | None:
+    """Open one repository config beneath a pinned root and read it exactly once.
+
+    POSIX walks each component relative to directory descriptors, rejecting links.
+    The fallback keeps a file handle open while it revalidates identity, boundary,
+    and content state before accepting the snapshot.
+    """
+
+    relative = _ensure_repo_config_path(root, path)
+    if not relative.parts:
+        raise ConfigError(f"repository config is not a regular file: {path}")
+    if any(part in {"", ".", ".."} for part in relative.parts):
+        raise ConfigError(f"repository config escapes repository root: {path}")
+
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    supports_openat = (
+        bool(nofollow) and os.open in os.supports_dir_fd and os.stat in os.supports_dir_fd
+    )
+    if supports_openat:
+        descriptors: list[int] = []
+        directory_fd: int | None = None
+        file_opened = False
+        try:
+            root_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            root_flags |= getattr(os, "O_DIRECTORY", 0) | nofollow
+            directory_fd = os.open(root, root_flags)
+            descriptors.append(directory_fd)
+            for component in relative.parts[:-1]:
+                flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+                flags |= getattr(os, "O_DIRECTORY", 0) | nofollow
+                directory_fd = os.open(component, flags, dir_fd=directory_fd)
+                descriptors.append(directory_fd)
+            name = relative.parts[-1]
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            flags |= nofollow | getattr(os, "O_NONBLOCK", 0)
+            descriptor = os.open(name, flags, dir_fd=directory_fd)
+            file_opened = True
+            descriptors.append(descriptor)
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or _is_reparse_point(opened):
+                raise ConfigError(f"repository config is not a safe regular file: {path}")
+            if opened.st_size > MAX_CONFIG_BYTES:
+                raise ConfigError(
+                    f"repository config exceeds the {MAX_CONFIG_BYTES}-byte limit: {path}"
+                )
+            raw = _read_config_descriptor(descriptor)
+            finished = os.fstat(descriptor)
+            current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            if (
+                _is_reparse_point(current)
+                or not _same_config_state(opened, finished)
+                or not _same_config_state(finished, current)
+            ):
+                raise ConfigError(f"repository config changed while being read: {path}")
+        except FileNotFoundError as exc:
+            if not file_opened:
+                return None
+            raise ConfigError(f"repository config changed while being read: {path}") from exc
+        except ConfigError:
+            raise
+        except OSError as exc:
+            raise ConfigError(
+                f"repository config escapes repository root or uses an unsafe link: {path}"
+            ) from exc
+        finally:
+            for descriptor in reversed(descriptors):
+                with suppress(OSError):
+                    os.close(descriptor)
+    else:
+        candidate = root.joinpath(*relative.parts)
+        try:
+            expected = candidate.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise ConfigError(f"cannot inspect repository config {path}: {exc}") from exc
+        if (
+            not stat.S_ISREG(expected.st_mode)
+            or stat.S_ISLNK(expected.st_mode)
+            or _is_reparse_point(expected)
+        ):
+            raise ConfigError(
+                f"repository config escapes repository root or uses an unsafe link: {path}"
+            )
+        try:
+            current_directory = root
+            for component in relative.parts[:-1]:
+                current_directory /= component
+                component_metadata = current_directory.lstat()
+                if (
+                    not stat.S_ISDIR(component_metadata.st_mode)
+                    or stat.S_ISLNK(component_metadata.st_mode)
+                    or _is_reparse_point(component_metadata)
+                ):
+                    raise ConfigError(
+                        f"repository config escapes repository root or uses an unsafe link: {path}"
+                    )
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(root)
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+            descriptor = os.open(candidate, flags)
+            try:
+                opened = os.fstat(descriptor)
+                opened_path = descriptor_path(descriptor)
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or _is_reparse_point(opened)
+                    or not _same_config_state(expected, opened)
+                    or opened_path is None
+                    or not opened_path.is_relative_to(root)
+                ):
+                    raise ConfigError(f"repository config changed while being opened: {path}")
+                if opened.st_size > MAX_CONFIG_BYTES:
+                    raise ConfigError(
+                        f"repository config exceeds the {MAX_CONFIG_BYTES}-byte limit: {path}"
+                    )
+                raw = _read_config_descriptor(descriptor)
+                finished = os.fstat(descriptor)
+            finally:
+                os.close(descriptor)
+            current = candidate.lstat()
+            current_resolved = candidate.resolve(strict=True)
+            current_resolved.relative_to(root)
+            if (
+                stat.S_ISLNK(current.st_mode)
+                or _is_reparse_point(current)
+                or not _same_config_state(opened, finished)
+                or not _same_config_state(finished, current)
+            ):
+                raise ConfigError(f"repository config changed while being read: {path}")
+        except ConfigError:
+            raise
+        except (OSError, ValueError) as exc:
+            raise ConfigError(
+                f"repository config escapes repository root or uses an unsafe link: {path}"
+            ) from exc
+
+    if len(raw) > MAX_CONFIG_BYTES:
+        raise ConfigError(f"repository config exceeds the {MAX_CONFIG_BYTES}-byte limit: {path}")
+    return raw
 
 
 def _read_config_bytes(path: Path, *, source: str) -> bytes:

--- a/src/repolocus/core/service.py
+++ b/src/repolocus/core/service.py
@@ -104,6 +104,12 @@ class RepoLocusService:
         self.settings = settings or Settings.load()
         self.scanner = scanner or RepositoryScanner(
             max_file_bytes=self.settings.max_file_bytes,
+            max_repository_files=self.settings.max_repository_files,
+            max_repository_bytes=self.settings.max_repository_bytes,
+            max_directory_depth=self.settings.max_directory_depth,
+            max_repository_chunks=self.settings.max_repository_chunks,
+            max_repository_symbols=self.settings.max_repository_symbols,
+            max_scan_seconds=self.settings.max_scan_seconds,
         )
         self.privacy = privacy or PrivacyStore()
 
@@ -112,20 +118,37 @@ class RepoLocusService:
         root: Path | str = ".",
         *,
         expected_generation: int | None = None,
+        _materialize_files: bool = False,
     ) -> ScanOperation:
-        """Refresh the index, retrying only scans not pinned to a generation."""
+        """Refresh the index, retrying only scans not pinned to a generation.
+
+        Unchanged files in the returned operation carry metadata and cached fact
+        counts, not materialized source text/chunks/symbols. Consumers that need
+        facts should query the committed index through map, diagram, or evidence.
+        """
 
         repo = self._repository(root)
         with RepositoryIndex.open(repo) as index:
             for attempt in range(_SCAN_ATTEMPTS):
-                snapshot = index.snapshot()
+                snapshot = (
+                    index.snapshot()
+                    if _materialize_files
+                    else index.manifest_snapshot(
+                        max_files=self.scanner.max_repository_files,
+                    )
+                )
                 self._require_generation(snapshot.generation, expected_generation)
                 cached_files: dict[str, ScannedFile] = {}
                 if snapshot.analysis_version == self.scanner.analysis_version:
-                    cached_files = {file.path: file for file in snapshot.files}
+                    cached_files = {
+                        file.path: file
+                        for file in snapshot.files
+                        if file.provenance == "source" and not file.stale
+                    }
                 result = self.scanner.scan(
                     repo,
                     cached_files=cached_files,
+                    trusted_cache=True,
                     base_generation=snapshot.generation,
                 )
                 try:
@@ -142,30 +165,29 @@ class RepoLocusService:
         root: Path | str,
         refresh: RefreshMode,
         expected_generation: int | None,
+        *,
+        materialize_files: bool = True,
     ) -> ScanOperation:
         mode = self._refresh_mode(refresh)
         repo = self._repository(root)
-        if mode == "always":
-            return self.scan(repo, expected_generation=expected_generation)
+        if mode in {"auto", "always"}:
+            return self.scan(
+                repo,
+                expected_generation=expected_generation,
+                _materialize_files=materialize_files,
+            )
 
         with RepositoryIndex.open(repo) as index:
-            snapshot = index.snapshot()
-            self._require_generation(snapshot.generation, expected_generation)
-            if self._valid_snapshot(snapshot):
-                return self._snapshot_operation(repo, index.db_path, snapshot)
-            if mode == "never" and self._compatible_snapshot(snapshot):
-                return self._snapshot_operation(repo, index.db_path, snapshot)
-        if mode == "never":
-            raise RuntimeError(
-                "no valid index snapshot is available; refresh the repository before querying"
+            snapshot = (
+                index.snapshot()
+                if materialize_files
+                else index.manifest_snapshot(max_files=self.scanner.max_repository_files)
             )
-        return self.scan(repo, expected_generation=expected_generation)
-
-    def _valid_snapshot(self, snapshot: IndexSnapshot) -> bool:
-        return (
-            self._compatible_snapshot(snapshot)
-            and not snapshot.temporarily_unreadable
-            and not any(file.stale for file in snapshot.files)
+            self._require_generation(snapshot.generation, expected_generation)
+            if self._compatible_snapshot(snapshot):
+                return self._snapshot_operation(repo, index.db_path, snapshot)
+        raise RuntimeError(
+            "no valid index snapshot is available; refresh the repository before querying"
         )
 
     def _compatible_snapshot(self, snapshot: IndexSnapshot) -> bool:
@@ -239,9 +261,17 @@ class RepoLocusService:
         *,
         refresh: RefreshMode = "auto",
         expected_generation: int | None = None,
+        destination: Path | str | None = None,
     ) -> tuple[str, ScanOperation]:
+        """Generate a map with links relative to *destination* when supplied.
+
+        Without a destination, links remain repository-root-relative for API
+        and stdout consumers; ``ScanOperation.to_dict()`` exposes that root.
+        """
+
         operation = self._operation(root, refresh, expected_generation)
-        return ProjectMapGenerator().generate(operation.result), operation
+        output = self._generation_destination(operation.result.root, destination)
+        return ProjectMapGenerator().generate(operation.result, destination=output), operation
 
     def diagram(
         self,
@@ -249,9 +279,25 @@ class RepoLocusService:
         *,
         refresh: RefreshMode = "auto",
         expected_generation: int | None = None,
+        destination: Path | str | None = None,
     ) -> tuple[str, ScanOperation]:
+        """Generate a diagram using the same source-link contract as :meth:`map`."""
+
         operation = self._operation(root, refresh, expected_generation)
-        return MermaidGenerator().generate(operation.result), operation
+        output = self._generation_destination(operation.result.root, destination)
+        return MermaidGenerator().generate(operation.result, destination=output), operation
+
+    @staticmethod
+    def _generation_destination(
+        root: Path,
+        destination: Path | str | None,
+    ) -> Path | None:
+        if destination is None:
+            return None
+        requested = Path(destination).expanduser()
+        if not requested.is_absolute():
+            requested = root / requested
+        return requested.resolve(strict=False)
 
     def evidence(
         self,
@@ -266,7 +312,12 @@ class RepoLocusService:
             raise ValueError("question must not be empty")
         if len(question) > 4_000:
             raise ValueError("question must not exceed 4000 characters")
-        operation = self._operation(root, refresh, expected_generation)
+        operation = self._operation(
+            root,
+            refresh,
+            expected_generation,
+            materialize_files=False,
+        )
         with RepositoryIndex.open(operation.result.root) as index:
             self._require_generation(index.generation(), operation.update.generation)
             evidence = RetrievalEngine(
@@ -328,7 +379,9 @@ class RepoLocusService:
             paths=tuple(dict.fromkeys(item.path for item in bounded)),
             fragment_count=len(bounded),
             estimated_tokens=self._estimated_tokens(bounded),
-            redaction_count=redaction_count,
+            redaction_count=(
+                redaction_count + (request_plan.redaction_count if request_plan is not None else 0)
+            ),
             model=chosen_model,
             endpoint=endpoint,
             payload_bytes=len(request_plan.body) if request_plan is not None else 0,

--- a/src/repolocus/generators/mermaid.py
+++ b/src/repolocus/generators/mermaid.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import html
+import os
 import re
 from collections import Counter, defaultdict
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from urllib.parse import quote
 
 from repolocus.models import Dependency, ScannedFile, ScanResult
@@ -49,8 +50,11 @@ def _markdown_cell(value: str) -> str:
     )
 
 
-def _source_link(path: str, line: int) -> str:
-    escaped = quote(path, safe="/._-")
+def _source_link(path: str, line: int, prefix: str = "") -> str:
+    target = PurePosixPath(path)
+    if prefix:
+        target = PurePosixPath(prefix) / target
+    escaped = quote(target.as_posix(), safe="/._-")
     visible = html.escape(escape_untrusted_display(f"{path}:{line}"), quote=False)
     visible = visible.replace("\\", "\\\\")
     for marker in ("[", "]", "|"):
@@ -95,7 +99,15 @@ class MermaidGenerator:
         self.max_nodes = max(2, max_nodes)
         self.max_edges = max(1, max_edges)
 
-    def generate(self, result: ScanResult) -> str:
+    def generate(
+        self,
+        result: ScanResult,
+        *,
+        destination: Path | str | None = None,
+    ) -> str:
+        """Render a graph with repository-root-relative links by default."""
+
+        link_prefix = self._link_prefix(result.root, destination)
         source = self.generate_source(result)
         valid, reason = validate_mermaid(source)
         if not valid:
@@ -103,7 +115,12 @@ class MermaidGenerator:
             valid, fallback_reason = validate_mermaid(source)
             if not valid:  # pragma: no cover - defensive invariant
                 raise ValueError(f"could not produce valid Mermaid: {reason}; {fallback_reason}")
-        evidence = self._evidence_table(result)
+        evidence = self._evidence_table(result, link_prefix)
+        link_contract = (
+            "Source links are relative to this generated document."
+            if destination is not None
+            else "Source links are repository-root-relative."
+        )
         return "\n".join(
             [
                 "# Architecture",
@@ -112,6 +129,7 @@ class MermaidGenerator:
                 "",
                 "This graph is a static approximation. Nodes and edges are derived from "
                 "indexed paths and import statements; runtime dispatch may differ.",
+                link_contract,
                 "",
                 "```mermaid",
                 source.rstrip(),
@@ -123,6 +141,17 @@ class MermaidGenerator:
                 "",
             ]
         )
+
+    @staticmethod
+    def _link_prefix(root: Path, destination: Path | str | None) -> str:
+        if destination is None:
+            return ""
+        requested = Path(destination).expanduser()
+        if not requested.is_absolute():
+            requested = root / requested
+        requested = requested.resolve(strict=False)
+        relative_root = Path(os.path.relpath(root, start=requested.parent)).as_posix()
+        return "" if relative_root == "." else relative_root
 
     def generate_source(self, result: ScanResult) -> str:
         selected, ranked_edges = self._graph_facts(result)
@@ -218,7 +247,7 @@ class MermaidGenerator:
             lines.append(f'    {_node_id(group)}["{_escape_label(group)}"]')
         return "\n".join(lines) + "\n"
 
-    def _evidence_table(self, result: ScanResult) -> str:
+    def _evidence_table(self, result: ScanResult, link_prefix: str = "") -> str:
         witnesses: dict[str, tuple[str, int]] = {}
         for file in sorted(result.files, key=lambda item: item.path):
             group = _group(file.path)
@@ -230,7 +259,7 @@ class MermaidGenerator:
             return "No source files were indexed."
         lines = ["### Node evidence", "", "| Node | Representative source |", "|---|---|"]
         for group, (path, line) in sorted(witnesses.items()):
-            lines.append(f"| `{_markdown_cell(group)}` | {_source_link(path, line)} |")
+            lines.append(f"| `{_markdown_cell(group)}` | {_source_link(path, line, link_prefix)} |")
         _selected, ranked_edges = self._graph_facts(result)
         lines.extend(
             [
@@ -247,6 +276,7 @@ class MermaidGenerator:
             edge = f"{source_group} -> {target_group}"
             lines.append(
                 f"| `{_markdown_cell(edge)}` | `{_markdown_cell(dependency.target)}` | "
-                f"{_source_link(dependency.source_path, dependency.line)} | {count} |"
+                f"{_source_link(dependency.source_path, dependency.line, link_prefix)} | "
+                f"{count} |"
             )
         return "\n".join(lines)

--- a/src/repolocus/generators/project_map.py
+++ b/src/repolocus/generators/project_map.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from html import escape as html_escape
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from urllib.parse import quote
 
 from repolocus import __version__
@@ -29,12 +31,37 @@ _CONFIG_NAMES = {
 }
 
 
-def _citation(path: str, line: int, label: str | None = None) -> str:
-    """Return a repository-relative Markdown line link."""
+@dataclass(frozen=True, slots=True)
+class _SourceLinks:
+    """Translate repository paths into links from one generated document."""
 
-    visible = _markdown_text(label or f"{path}:{line}")
-    escaped = quote(path, safe="/._-")
-    return f"[{visible}]({escaped}#L{line})"
+    prefix: str = ""
+    destination_supplied: bool = False
+
+    @classmethod
+    def for_output(cls, root: Path, destination: Path | str | None) -> _SourceLinks:
+        if destination is None:
+            return cls()
+        requested = Path(destination).expanduser()
+        if not requested.is_absolute():
+            requested = root / requested
+        requested = requested.resolve(strict=False)
+        relative_root = Path(os.path.relpath(root, start=requested.parent)).as_posix()
+        return cls("" if relative_root == "." else relative_root, True)
+
+    def citation(self, path: str, line: int, label: str | None = None) -> str:
+        visible = _markdown_text(label or f"{path}:{line}")
+        target = PurePosixPath(path)
+        if self.prefix:
+            target = PurePosixPath(self.prefix) / target
+        escaped = quote(target.as_posix(), safe="/._-")
+        return f"[{visible}]({escaped}#L{line})"
+
+    @property
+    def description(self) -> str:
+        if self.destination_supplied:
+            return "generated-document-relative"
+        return "repository-root-relative"
 
 
 def _markdown_text(value: str) -> str:
@@ -117,7 +144,15 @@ def _first_line_for(file: ScannedFile) -> int:
 class ProjectMapGenerator:
     """Render a conservative map from facts observed during a repository scan."""
 
-    def generate(self, result: ScanResult) -> str:
+    def generate(
+        self,
+        result: ScanResult,
+        *,
+        destination: Path | str | None = None,
+    ) -> str:
+        """Render the map, defaulting to repository-root-relative source links."""
+
+        links = _SourceLinks.for_output(result.root, destination)
         files = sorted(result.files, key=lambda item: item.path)
         by_path = {item.path: item for item in files}
         lines: list[str] = [
@@ -126,21 +161,26 @@ class ProjectMapGenerator:
             f"<!-- Generator: RepoLocus {__version__}; deterministic source map. -->",
             "",
         ]
-        lines.extend(self._overview(result, by_path))
-        lines.extend(self._quick_start(files))
-        lines.extend(self._layout(files))
-        lines.extend(self._entry_points(files))
-        lines.extend(self._modules(files))
-        lines.extend(self._runtime_flow(files))
-        lines.extend(self._dependencies(files))
-        lines.extend(self._configuration(files))
-        lines.extend(self._tests(files))
-        lines.extend(self._risks(result, files))
-        lines.extend(self._reading_order(files))
-        lines.extend(self._metadata(result))
+        lines.extend(self._overview(result, by_path, links))
+        lines.extend(self._quick_start(files, links))
+        lines.extend(self._layout(files, links))
+        lines.extend(self._entry_points(files, links))
+        lines.extend(self._modules(files, links))
+        lines.extend(self._runtime_flow(files, links))
+        lines.extend(self._dependencies(files, links))
+        lines.extend(self._configuration(files, links))
+        lines.extend(self._tests(files, links))
+        lines.extend(self._risks(result, files, links))
+        lines.extend(self._reading_order(files, links))
+        lines.extend(self._metadata(result, links))
         return "\n".join(lines).rstrip() + "\n"
 
-    def _overview(self, result: ScanResult, by_path: dict[str, ScannedFile]) -> list[str]:
+    def _overview(
+        self,
+        result: ScanResult,
+        by_path: dict[str, ScannedFile],
+        links: _SourceLinks,
+    ) -> list[str]:
         readme = next((by_path[name] for name in _README_NAMES if name in by_path), None)
         if readme:
             paragraph = _first_content_paragraph(readme)
@@ -149,7 +189,7 @@ class ProjectMapGenerator:
                 return [
                     "## What this repository does",
                     "",
-                    f"**Confirmed:** {text} ({_citation(readme.path, line)})",
+                    f"**Confirmed:** {text} ({links.citation(readme.path, line)})",
                     "",
                 ]
         languages = Counter(file.language for file in result.files if file.language != "Text")
@@ -162,7 +202,7 @@ class ProjectMapGenerator:
             "",
         ]
 
-    def _quick_start(self, files: list[ScannedFile]) -> list[str]:
+    def _quick_start(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         candidates = [
             file
             for file in files
@@ -175,11 +215,11 @@ class ProjectMapGenerator:
             return output
         for file in candidates[:5]:
             line = _first_line_for(file)
-            output.append(f"- **Confirmed:** Start with {_citation(file.path, line)}.")
+            output.append(f"- **Confirmed:** Start with {links.citation(file.path, line)}.")
         output.append("")
         return output
 
-    def _layout(self, files: list[ScannedFile]) -> list[str]:
+    def _layout(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         groups: dict[str, list[ScannedFile]] = defaultdict(list)
         for file in files:
             groups[_top_group(file.path)].append(file)
@@ -196,12 +236,12 @@ class ProjectMapGenerator:
             witness = min(grouped, key=lambda item: item.path)
             output.append(
                 f"| {_code(group)} | {len(grouped)} | {_markdown_text(language_text)} | "
-                f"{_citation(witness.path, _first_line_for(witness))} |"
+                f"{links.citation(witness.path, _first_line_for(witness))} |"
             )
         output.append("")
         return output
 
-    def _entry_points(self, files: list[ScannedFile]) -> list[str]:
+    def _entry_points(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         entries = [file for file in files if file.is_entry_point]
         output = ["## Main entry points", ""]
         if not entries:
@@ -220,12 +260,12 @@ class ProjectMapGenerator:
             line = symbol.start_line if symbol else _first_line_for(file)
             output.append(
                 f"- **Confirmed:** {_code(file.path)} matches an entry-point convention "
-                f"({_citation(file.path, line)})."
+                f"({links.citation(file.path, line)})."
             )
         output.append("")
         return output
 
-    def _modules(self, files: list[ScannedFile]) -> list[str]:
+    def _modules(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         groups: dict[str, list[ScannedFile]] = defaultdict(list)
         for file in files:
             groups[_top_group(file.path)].append(file)
@@ -238,14 +278,14 @@ class ProjectMapGenerator:
                 f"- **Inferred:** {_code(group)} is a module area with "
                 f"{len(grouped)} indexed files "
                 f"and {symbol_count} extracted symbols; representative source: "
-                f"{_citation(witness.path, _first_line_for(witness))}."
+                f"{links.citation(witness.path, _first_line_for(witness))}."
             )
         if not ranked:
             output.append("**Needs review:** The scan did not index any source modules.")
         output.append("")
         return output
 
-    def _runtime_flow(self, files: list[ScannedFile]) -> list[str]:
+    def _runtime_flow(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         entries = [file for file in files if file.is_entry_point]
         output = ["## Runtime and data flow", ""]
         flows = 0
@@ -257,7 +297,7 @@ class ProjectMapGenerator:
             output.append(
                 f"- **Inferred:** {_code(entry.path)} begins a static dependency flow toward "
                 f"{targets} "
-                f"({_citation(entry.path, deps[0].line)})."
+                f"({links.citation(entry.path, deps[0].line)})."
             )
             flows += 1
         if not flows:
@@ -268,7 +308,7 @@ class ProjectMapGenerator:
         output.append("")
         return output
 
-    def _dependencies(self, files: list[ScannedFile]) -> list[str]:
+    def _dependencies(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         dependencies: list[Dependency] = [dep for file in files for dep in file.dependencies]
         local_roots: set[str] = set()
         for file in files:
@@ -298,7 +338,9 @@ class ProjectMapGenerator:
         output.extend(["| Dependency | References | Evidence |", "|---|---:|---|"])
         for target, count in target_counts.most_common(20):
             dep = first[target]
-            output.append(f"| {_code(target)} | {count} | {_citation(dep.source_path, dep.line)} |")
+            output.append(
+                f"| {_code(target)} | {count} | {links.citation(dep.source_path, dep.line)} |"
+            )
         output.append("")
         return output
 
@@ -314,7 +356,7 @@ class ProjectMapGenerator:
         root = re.split(r"[./]", target, maxsplit=1)[0].casefold()
         return bool(root and root not in local_roots and root not in standard_library)
 
-    def _configuration(self, files: list[ScannedFile]) -> list[str]:
+    def _configuration(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         configs = [file for file in files if _is_config(file.path)]
         output = ["## Configuration and environment", ""]
         if not configs:
@@ -323,12 +365,12 @@ class ProjectMapGenerator:
         for file in configs[:20]:
             output.append(
                 f"- **Confirmed:** {_code(file.path)} is a configuration or build file "
-                f"({_citation(file.path, _first_line_for(file))})."
+                f"({links.citation(file.path, _first_line_for(file))})."
             )
         output.append("")
         return output
 
-    def _tests(self, files: list[ScannedFile]) -> list[str]:
+    def _tests(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         tests = [file for file in files if _is_test(file.path)]
         output = ["## Tests and quality gates", ""]
         if not tests:
@@ -342,19 +384,25 @@ class ProjectMapGenerator:
             witness = witness_by_group[group]
             output.append(
                 f"- **Confirmed:** {_code(group)} contains {count} test-like files; example: "
-                f"{_citation(witness.path, _first_line_for(witness))}."
+                f"{links.citation(witness.path, _first_line_for(witness))}."
             )
         output.append("")
         return output
 
-    def _risks(self, result: ScanResult, files: list[ScannedFile]) -> list[str]:
+    def _risks(
+        self,
+        result: ScanResult,
+        files: list[ScannedFile],
+        links: _SourceLinks,
+    ) -> list[str]:
         output = ["## High-change or high-risk areas", ""]
         largest = sorted(files, key=lambda file: (-file.line_count, file.path))[:5]
         for file in largest:
             output.append(
                 f"- **Inferred:** {_code(file.path)} is relatively large "
                 f"({file.line_count} lines) and "
-                f"may deserve focused review ({_citation(file.path, _first_line_for(file))})."
+                f"may deserve focused review "
+                f"({links.citation(file.path, _first_line_for(file))})."
             )
         if result.stats.skipped:
             detail = ", ".join(
@@ -372,7 +420,7 @@ class ProjectMapGenerator:
         output.append("")
         return output
 
-    def _reading_order(self, files: list[ScannedFile]) -> list[str]:
+    def _reading_order(self, files: list[ScannedFile], links: _SourceLinks) -> list[str]:
         readmes = [
             file for file in files if PurePosixPath(file.path).name.lower().startswith("readme")
         ]
@@ -409,7 +457,8 @@ class ProjectMapGenerator:
             elif file.symbols:
                 reason = "core symbols and module boundaries"
             output.append(
-                f"{number}. **Inferred:** Read {_citation(file.path, _first_line_for(file))} for "
+                f"{number}. **Inferred:** Read "
+                f"{links.citation(file.path, _first_line_for(file))} for "
                 f"{reason}."
             )
         if not selected:
@@ -417,7 +466,7 @@ class ProjectMapGenerator:
         output.append("")
         return output
 
-    def _metadata(self, result: ScanResult) -> list[str]:
+    def _metadata(self, result: ScanResult, links: _SourceLinks) -> list[str]:
         language_text = ", ".join(
             f"{name} ({count})" for name, count in sorted(result.stats.languages.items())
         )
@@ -429,6 +478,7 @@ class ProjectMapGenerator:
             f"- Indexed files: {result.stats.indexed_files}",
             f"- Indexed bytes: {result.stats.indexed_bytes}",
             f"- Languages: {language_text or 'none'}",
+            f"- Source link base: {links.description}",
             "- Evidence labels: **Confirmed** = direct source fact; **Inferred** = deterministic "
             "static-analysis inference; **Needs review** = insufficient or incomplete evidence.",
             "",

--- a/src/repolocus/index/store.py
+++ b/src/repolocus/index/store.py
@@ -30,9 +30,11 @@ from repolocus.models import (
     ScanResult,
     Symbol,
 )
+from repolocus.security.identity import filesystem_identity
 
-SCHEMA_VERSION = 3
-INDEX_FORMAT_VERSION = "3"
+SCHEMA_VERSION = 4
+INDEX_FORMAT_VERSION = "4"
+_PROVENANCE_SCHEMA_VERSION = 3
 # The product rename did not change the SQLite schema. Keep the original format
 # magic so existing valid indexes remain recognizable when explicitly opened.
 APPLICATION_ID = 0x4456504C  # "DVPL"
@@ -98,6 +100,21 @@ def _canonical_root(root: Path) -> Path:
     return resolved
 
 
+def _repository_identity(root: Path) -> str:
+    """Return a stable identity for the directory currently mounted at *root*."""
+
+    try:
+        metadata = root.lstat()
+    except OSError as exc:
+        raise IndexFormatError(f"repository root cannot be identified: {root}") from exc
+    try:
+        return filesystem_identity(metadata)
+    except ValueError as exc:
+        raise IndexFormatError(
+            "the filesystem does not expose a stable repository identity"
+        ) from exc
+
+
 def _root_key(root: Path) -> str:
     canonical = os.path.normcase(str(root))
     return hashlib.sha256(canonical.encode("utf-8", errors="surrogatepass")).hexdigest()
@@ -160,6 +177,14 @@ def _literal_query_tokens(query: str) -> frozenset[str]:
     return frozenset(literal_query_terms(query))
 
 
+def _literal_query_token_groups(query: str) -> tuple[tuple[str, ...], ...]:
+    """Return literal groups that expanded terms may not satisfy."""
+
+    from repolocus.retrieval.terms import literal_query_term_groups
+
+    return literal_query_term_groups(query)
+
+
 def _validate_relative_path(value: str) -> None:
     if not value or "\x00" in value or "\\" in value:
         raise ValueError(f"invalid indexed path: {value!r}")
@@ -176,6 +201,8 @@ def _validate_scanned_file(file: ScannedFile) -> None:
         raise ValueError(f"negative file metadata for {file.path}")
     if file.mtime_ns < 0 or file.ctime_ns < 0:
         raise ValueError(f"negative file timestamp for {file.path}")
+    if file.cached_chunk_count < 0 or file.cached_symbol_count < 0:
+        raise ValueError(f"negative cached fact count for {file.path}")
     if file.provenance not in {"source", "generated"}:
         raise ValueError(f"invalid provenance for {file.path}")
     if file.stale:
@@ -311,6 +338,7 @@ class RepositoryIndex:
 
     def __init__(self, root: Path, database_path: Path) -> None:
         self._root = root
+        self._repository_identity = _repository_identity(root)
         self._database_path = database_path
         self._lock = threading.RLock()
         self._closed = False
@@ -419,8 +447,14 @@ class RepositoryIndex:
                         missing = ", ".join(sorted(_V2_REQUIRED_TABLES - tables))
                         raise IndexFormatError(f"index schema is incomplete; missing: {missing}")
                     self._migrate_v2_to_v3()
-                    version = SCHEMA_VERSION
+                    version = _PROVENANCE_SCHEMA_VERSION
                     tables.add("chunk_terms")
+                if version == _PROVENANCE_SCHEMA_VERSION:
+                    if not _REQUIRED_TABLES.issubset(tables):
+                        missing = ", ".join(sorted(_REQUIRED_TABLES - tables))
+                        raise IndexFormatError(f"index schema is incomplete; missing: {missing}")
+                    self._migrate_v3_to_v4()
+                    version = SCHEMA_VERSION
                 elif version != SCHEMA_VERSION:
                     raise IndexFormatError(
                         f"unsupported index schema {version}; expected {SCHEMA_VERSION}"
@@ -435,6 +469,8 @@ class RepositoryIndex:
                 )
             if metadata.get("index_format_version") != INDEX_FORMAT_VERSION:
                 raise IndexFormatError("index format version is incompatible")
+            if metadata.get("repository_identity") != self._repository_identity:
+                self._rebind_repository_identity(self._repository_identity)
         except sqlite3.Error as exc:
             raise IndexFormatError(f"invalid SQLite index at {self._database_path}: {exc}") from exc
 
@@ -446,7 +482,7 @@ class RepositoryIndex:
                 # Another process may have completed the migration while this
                 # connection waited for BEGIN IMMEDIATE.
                 current_version = int(self._connection.execute("PRAGMA user_version").fetchone()[0])
-                if current_version == SCHEMA_VERSION:
+                if current_version in {_PROVENANCE_SCHEMA_VERSION, SCHEMA_VERSION}:
                     return
                 if current_version != 2:
                     raise IndexFormatError(
@@ -464,10 +500,8 @@ class RepositoryIndex:
 
                 generated_paths = [
                     str(row["path"])
-                    for row in self._connection.execute(
-                        "SELECT path, text FROM files WHERE lower(language) = 'markdown'"
-                    )
-                    if is_generated_document(str(row["text"]), "markdown")
+                    for row in self._connection.execute("SELECT path, text FROM files")
+                    if is_generated_document(str(row["text"]))
                 ]
                 self._connection.executemany(
                     "UPDATE files SET provenance = 'generated' WHERE path = ?",
@@ -513,13 +547,91 @@ class RepositoryIndex:
                     ON CONFLICT(key) DO UPDATE SET value = excluded.value
                     """,
                     (
+                        ("schema_version", str(_PROVENANCE_SCHEMA_VERSION)),
+                        ("index_format_version", str(_PROVENANCE_SCHEMA_VERSION)),
+                    ),
+                )
+                self._connection.execute(f"PRAGMA user_version = {_PROVENANCE_SCHEMA_VERSION}")
+        except sqlite3.Error as exc:
+            raise IndexFormatError(f"could not migrate v2 index: {exc}") from exc
+
+    def _migrate_v3_to_v4(self) -> None:
+        """Invalidate path-only facts before binding the index to this directory."""
+
+        try:
+            with self._transaction():
+                current_version = int(self._connection.execute("PRAGMA user_version").fetchone()[0])
+                if current_version == SCHEMA_VERSION:
+                    return
+                if current_version != _PROVENANCE_SCHEMA_VERSION:
+                    raise IndexFormatError(
+                        f"unsupported index schema {current_version}; "
+                        f"expected {_PROVENANCE_SCHEMA_VERSION}"
+                    )
+                generation = self._generation_in_transaction()
+                self._clear_repository_facts()
+                self._connection.executemany(
+                    """
+                    INSERT INTO meta(key, value) VALUES (?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    (
                         ("schema_version", str(SCHEMA_VERSION)),
                         ("index_format_version", INDEX_FORMAT_VERSION),
+                        ("analysis_version", ""),
+                        ("generation", str(generation + 1)),
+                        ("repository_identity", self._repository_identity),
                     ),
                 )
                 self._connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         except sqlite3.Error as exc:
-            raise IndexFormatError(f"could not migrate v2 index: {exc}") from exc
+            raise IndexFormatError(f"could not migrate v3 index: {exc}") from exc
+
+    def _generation_in_transaction(self) -> int:
+        row = self._connection.execute("SELECT value FROM meta WHERE key = 'generation'").fetchone()
+        try:
+            generation = int(row["value"]) if row else 0
+        except (TypeError, ValueError) as exc:
+            raise IndexFormatError("index generation metadata is invalid") from exc
+        if generation < 0:
+            raise IndexFormatError("index generation metadata is invalid")
+        return generation
+
+    def _clear_repository_facts(self) -> None:
+        self._connection.execute("DELETE FROM files")
+        self._connection.execute(
+            "DELETE FROM meta WHERE key LIKE 'last_scan_%' OR key LIKE 'last_update_%'"
+        )
+
+    def _rebind_repository_identity(self, identity: str) -> None:
+        """Fail closed when the canonical path now names a different directory."""
+
+        with self._lock, self._transaction():
+            metadata = {
+                str(row["key"]): str(row["value"])
+                for row in self._connection.execute("SELECT key, value FROM meta")
+            }
+            if metadata.get("repository_identity") == identity:
+                return
+            generation = self._generation_in_transaction()
+            self._clear_repository_facts()
+            self._connection.executemany(
+                """
+                INSERT INTO meta(key, value) VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """,
+                (
+                    ("analysis_version", ""),
+                    ("generation", str(generation + 1)),
+                    ("repository_identity", identity),
+                ),
+            )
+
+    def _ensure_repository_identity(self) -> None:
+        identity = _repository_identity(self._root)
+        if identity != self._repository_identity:
+            self._rebind_repository_identity(identity)
+            self._repository_identity = identity
 
     def _create_fts_triggers(self) -> None:
         for statement in (
@@ -661,6 +773,7 @@ class RepositoryIndex:
                         ("index_format_version", INDEX_FORMAT_VERSION),
                         ("analysis_version", ""),
                         ("generation", "0"),
+                        ("repository_identity", self._repository_identity),
                     ),
                 )
                 self._connection.execute(f"PRAGMA application_id = {APPLICATION_ID}")
@@ -674,9 +787,13 @@ class RepositoryIndex:
         """Apply a complete scan using SHA256 values for incremental invalidation."""
 
         self._ensure_open()
+        self._ensure_repository_identity()
         scan_root = _canonical_root(scan.root)
         if scan_root != self._root:
             raise ValueError(f"scan root {scan_root} does not match index root {self._root}")
+        scan_identity = scan.repository_identity or _repository_identity(scan_root)
+        if scan_identity != self._repository_identity:
+            raise StaleScanError("repository identity changed after the scan started")
         incoming: dict[str, ScannedFile] = {}
         incomplete_paths = tuple(sorted(set(scan.temporarily_unreadable)))
         skipped_summary, warning_summary = _snapshot_scan_metadata(scan)
@@ -712,12 +829,17 @@ class RepositoryIndex:
                     f"scan generation {scan.base_generation} is stale; "
                     f"current generation is {current_generation}"
                 )
+            if _repository_identity(self._root) != scan_identity:
+                raise StaleScanError("repository identity changed while committing the scan")
             current = {
                 str(row["path"]): (
                     str(row["sha256"]).casefold(),
                     str(row["provenance"]),
+                    bool(row["stale"]),
                 )
-                for row in self._connection.execute("SELECT path, sha256, provenance FROM files")
+                for row in self._connection.execute(
+                    "SELECT path, sha256, provenance, stale FROM files"
+                )
             }
             incoming_paths = set(incoming)
             current_paths = set(current)
@@ -735,6 +857,7 @@ class RepositoryIndex:
                     analysis_changed
                     or incoming[path].sha256.casefold() != current[path][0]
                     or incoming[path].provenance != current[path][1]
+                    or current[path][2]
                 )
             )
             unchanged_paths = sorted((incoming_paths & current_paths) - set(changed))
@@ -785,6 +908,9 @@ class RepositoryIndex:
                 """,
                 sorted(metadata.items()),
             )
+
+            if _repository_identity(self._root) != scan_identity:
+                raise StaleScanError("repository identity changed while committing the scan")
 
         return IndexUpdate(
             added=len(added),
@@ -919,9 +1045,29 @@ class RepositoryIndex:
         return generation
 
     def snapshot(self) -> IndexSnapshot:
-        """Read cache facts and their CAS generation from one SQLite snapshot."""
+        """Read full cache facts and their CAS generation from one SQLite snapshot."""
+
+        return self._snapshot(manifest_only=False)
+
+    def manifest_snapshot(self, *, max_files: int | None = None) -> IndexSnapshot:
+        """Read only file metadata needed for an incremental scan.
+
+        Text, symbols, dependencies, and chunks stay in SQLite for unchanged
+        paths; changed files are read and reparsed by the scanner.
+        """
+
+        return self._snapshot(manifest_only=True, max_manifest_files=max_files)
+
+    def _snapshot(
+        self,
+        *,
+        manifest_only: bool,
+        max_manifest_files: int | None = None,
+    ) -> IndexSnapshot:
+        """Read one generation-consistent full or metadata-only snapshot."""
 
         self._ensure_open()
+        self._ensure_repository_identity()
         with self._lock:
             self._connection.execute("BEGIN")
             try:
@@ -934,7 +1080,11 @@ class RepositoryIndex:
                     raise IndexFormatError("index generation metadata is invalid")
                 analysis_version = metadata.get("analysis_version", "")
                 skipped, warnings, incomplete = _decode_snapshot_state(metadata)
-                files = tuple(self.get_files())
+                files = tuple(
+                    self.get_file_manifest(max_files=max_manifest_files)
+                    if manifest_only
+                    else self.get_files()
+                )
             except BaseException:
                 self._connection.rollback()
                 raise
@@ -1045,6 +1195,49 @@ class RepositoryIndex:
             symbol=str(row["symbol"]),
         )
 
+    def get_file_manifest(self, *, max_files: int | None = None) -> list[ScannedFile]:
+        """Return bounded per-file metadata without loading source text or parser facts."""
+
+        self._ensure_open()
+        if max_files is not None and (
+            isinstance(max_files, bool) or not isinstance(max_files, int) or max_files <= 0
+        ):
+            raise ValueError("max_files must be a positive integer or None")
+        query = """
+            SELECT f.path, f.language, f.size_bytes, f.sha256, f.line_count,
+                   f.is_entry_point, f.mtime_ns, f.ctime_ns, f.provenance, f.stale,
+                   (SELECT count(*) FROM chunks AS c WHERE c.file_path = f.path)
+                       AS cached_chunk_count,
+                   (SELECT count(*) FROM symbols AS s WHERE s.file_path = f.path)
+                       AS cached_symbol_count
+            FROM files AS f
+            ORDER BY f.path
+        """
+        parameters: tuple[int, ...] = ()
+        if max_files is not None:
+            query += " LIMIT ?"
+            parameters = (max_files,)
+        with self._lock:
+            rows = self._connection.execute(query, parameters).fetchall()
+        return [
+            ScannedFile(
+                path=str(row["path"]),
+                language=str(row["language"]),
+                size_bytes=int(row["size_bytes"]),
+                sha256=str(row["sha256"]),
+                line_count=int(row["line_count"]),
+                text="",
+                is_entry_point=bool(row["is_entry_point"]),
+                mtime_ns=int(row["mtime_ns"]),
+                ctime_ns=int(row["ctime_ns"]),
+                provenance=str(row["provenance"]),  # type: ignore[arg-type]
+                stale=bool(row["stale"]),
+                cached_chunk_count=int(row["cached_chunk_count"]),
+                cached_symbol_count=int(row["cached_symbol_count"]),
+            )
+            for row in rows
+        ]
+
     def get_files(self) -> list[ScannedFile]:
         self._ensure_open()
         with self._lock:
@@ -1077,6 +1270,8 @@ class RepositoryIndex:
                 ctime_ns=int(row["ctime_ns"]),
                 provenance=str(row["provenance"]),  # type: ignore[arg-type]
                 stale=bool(row["stale"]),
+                cached_chunk_count=len(chunks_by_path[str(row["path"])]),
+                cached_symbol_count=len(symbols_by_path[str(row["path"])]),
             )
             for row in file_rows
         ]
@@ -1105,10 +1300,41 @@ class RepositoryIndex:
         )
         fts_tokens = tokens[:1] if identifier_query else tokens
         expression = " OR ".join(f'"{token}"' for token in fts_tokens)
-        minimum_term_matches = max(1, len(_literal_query_tokens(query)))
+        literal_groups = _literal_query_token_groups(query)
+        from repolocus.retrieval.terms import is_cjk_term
+
+        cjk_groups = [group for group in literal_groups if is_cjk_term(group[0])]
+        non_cjk_literals = [group[0] for group in literal_groups if not is_cjk_term(group[0])]
+        if identifier_query and non_cjk_literals:
+            # A snake_case or camelCase lookup names one concrete identifier.
+            # Requiring only two decomposed parts would let
+            # ``old_unique_value`` match ``new_unique_value``.
+            non_cjk_literals = non_cjk_literals[:1]
+        coverage_clauses: list[str] = []
+        coverage_parameters: list[str | int] = []
+        if non_cjk_literals:
+            placeholders = ", ".join("?" for _ in non_cjk_literals)
+            coverage_clauses.append(
+                "(SELECT count(*) FROM chunk_terms AS required_term "  # nosec B608
+                "WHERE required_term.chunk_id = c.id "
+                f"AND required_term.term IN ({placeholders})"
+                ") >= ?"
+            )
+            coverage_parameters.extend(non_cjk_literals)
+            coverage_parameters.append(min(2, len(non_cjk_literals)))
+        for group in cjk_groups:
+            placeholders = ", ".join("?" for _ in group)
+            coverage_clauses.append(
+                "(SELECT count(*) FROM chunk_terms AS required_term "  # nosec B608
+                "WHERE required_term.chunk_id = c.id "
+                f"AND required_term.term IN ({placeholders})"
+                ") >= ?"
+            )
+            coverage_parameters.extend(group)
+            coverage_parameters.append(min(2, len(group)))
+        literal_coverage = " AND ".join(coverage_clauses) or "1 = 1"
         with self._lock:
-            fts_rows = self._connection.execute(
-                """
+            fts_query_template = """
                 SELECT c.*, bm25(chunks_fts, 2.0, 5.0, 1.0) AS fts_rank
                 FROM chunks_fts
                 JOIN chunks AS c ON c.id = chunks_fts.rowid
@@ -1116,10 +1342,15 @@ class RepositoryIndex:
                 WHERE chunks_fts MATCH ?
                   AND f.provenance = 'source'
                   AND f.stale = 0
+                  AND %s
                 ORDER BY fts_rank, c.file_path, c.start_line, c.ordinal
                 LIMIT ?
-                """,
-                (expression, min(int(limit), 500)),
+                """
+            # Only generated SQLite parameter markers are interpolated; every value stays bound.
+            fts_query = fts_query_template % literal_coverage  # nosec B608
+            fts_rows = self._connection.execute(
+                fts_query,
+                (expression, *coverage_parameters, min(int(limit), 500)),
             ).fetchall()
             placeholders = ", ".join("?" for _ in tokens)
             # Only generated SQLite parameter markers are interpolated; every value stays bound.
@@ -1131,15 +1362,15 @@ class RepositoryIndex:
                 WHERE t.term IN (%s)
                   AND f.provenance = 'source'
                   AND f.stale = 0
+                  AND %s
                 GROUP BY c.id
-                HAVING count(*) >= ?
                 ORDER BY term_matches DESC, c.file_path, c.start_line, c.ordinal
                 LIMIT ?
                 """
-            term_query = term_query_template % placeholders  # nosec B608
+            term_query = term_query_template % (placeholders, literal_coverage)  # nosec B608
             term_rows = self._connection.execute(
                 term_query,
-                (*tokens, minimum_term_matches, min(int(limit), 500)),
+                (*tokens, *coverage_parameters, min(int(limit), 500)),
             ).fetchall()
         hits: dict[int, IndexedChunkHit] = {}
         for row in fts_rows:

--- a/src/repolocus/models.py
+++ b/src/repolocus/models.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 Confidence = Literal["confirmed", "inferred", "needs_review"]
 Provenance = Literal["source", "generated"]
-ANALYSIS_VERSION = "2"
+ANALYSIS_VERSION = "3"
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,6 +77,8 @@ class ScannedFile:
     ctime_ns: int = 0
     provenance: Provenance = "source"
     stale: bool = False
+    cached_chunk_count: int = 0
+    cached_symbol_count: int = 0
 
 
 @dataclass(slots=True)
@@ -104,6 +106,7 @@ class ScanResult:
     analysis_version: str = ANALYSIS_VERSION
     temporarily_unreadable: tuple[str, ...] = ()
     base_generation: int | None = None
+    repository_identity: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/repolocus/providers/http.py
+++ b/src/repolocus/providers/http.py
@@ -7,13 +7,14 @@ import math
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
+from time import monotonic
 from typing import Any
 from urllib.parse import urlsplit
 
 import httpx
 
 from repolocus.security.network import is_loopback_url
-from repolocus.security.redaction import redact_text
+from repolocus.security.redaction import contains_likely_secret, redact_secrets_with_count
 
 from .base import (
     ModelProvider,
@@ -21,6 +22,11 @@ from .base import (
     ProviderRequestError,
     ProviderResponseError,
 )
+
+_MAX_REQUEST_BYTES = 8 * 1024 * 1024
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+_MAX_JSON_DEPTH = 64
+_MAX_JSON_NODES = 100_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +37,15 @@ class ProviderRequestPlan:
     model: str
     endpoint: str
     body: bytes
+    redaction_count: int = 0
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.redaction_count, bool)
+            or not isinstance(self.redaction_count, int)
+            or self.redaction_count < 0
+        ):
+            raise ValueError("redaction_count must be a non-negative integer")
 
 
 def build_provider_request_plan(
@@ -50,8 +65,8 @@ def build_provider_request_plan(
     if not clean_model:
         raise ProviderConfigurationError("model name must not be empty")
     normalised_base = _normalise_base_url(base_url)
-    redacted_system = redact_text(system_prompt)
-    redacted_user = redact_text(user_prompt)
+    redacted_system, system_redactions = redact_secrets_with_count(system_prompt)
+    redacted_user, user_redactions = redact_secrets_with_count(user_prompt)
     if family == "ollama":
         endpoint = _append_endpoint(normalised_base, "/api/chat", accepted_suffix="/api/chat")
         payload: Mapping[str, Any] = {
@@ -96,7 +111,77 @@ def build_provider_request_plan(
         separators=(",", ":"),
         allow_nan=False,
     ).encode("utf-8")
-    return ProviderRequestPlan(family, clean_model, endpoint, body)
+    return ProviderRequestPlan(
+        family,
+        clean_model,
+        endpoint,
+        body,
+        system_redactions + user_redactions,
+    )
+
+
+def _walk_json(value: object) -> list[str]:
+    strings: list[str] = []
+    stack: list[tuple[object, int]] = [(value, 0)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
+            raise ValueError("JSON structure exceeds the configured complexity limit")
+        if isinstance(current, str):
+            strings.append(current)
+        elif isinstance(current, Mapping):
+            stack.extend((key, depth + 1) for key in current)
+            stack.extend((item, depth + 1) for item in current.values())
+        elif isinstance(current, list):
+            stack.extend((item, depth + 1) for item in current)
+    return strings
+
+
+def _validate_outbound_body(body: bytes) -> None:
+    """Reject a malformed or secret-bearing body immediately before transport."""
+
+    if not isinstance(body, bytes) or len(body) > _MAX_REQUEST_BYTES:
+        raise ProviderConfigurationError("prepared provider request body is invalid or too large")
+    try:
+        raw_text = body.decode("utf-8")
+        data = json.loads(raw_text)
+        strings = _walk_json(data)
+    except (UnicodeDecodeError, ValueError, RecursionError) as exc:
+        raise ProviderConfigurationError("prepared provider request body is not safe JSON") from exc
+    if not isinstance(data, Mapping):
+        raise ProviderConfigurationError("prepared provider request body must be a JSON object")
+    if contains_likely_secret(raw_text) or any(contains_likely_secret(value) for value in strings):
+        raise ProviderConfigurationError(
+            "prepared provider request was blocked because credential-like content remained"
+        )
+
+
+def _validate_response_headers(response: httpx.Response) -> None:
+    media_type = response.headers.get("content-type", "").split(";", 1)[0].strip().casefold()
+    if media_type != "application/json" and not media_type.endswith("+json"):
+        raise ProviderResponseError("provider returned a non-JSON content type")
+    content_length = response.headers.get("content-length")
+    if content_length is None:
+        return
+    try:
+        declared = int(content_length, 10)
+    except ValueError as exc:
+        raise ProviderResponseError("provider returned an invalid Content-Length") from exc
+    if declared < 0:
+        raise ProviderResponseError("provider returned an invalid Content-Length")
+    if declared > _MAX_RESPONSE_BYTES:
+        raise ProviderResponseError(
+            f"provider response exceeds the {_MAX_RESPONSE_BYTES}-byte limit"
+        )
+
+
+def _validate_json_shape(data: Mapping[str, Any], *, provider: str) -> None:
+    try:
+        _walk_json(data)
+    except ValueError as exc:
+        raise ProviderResponseError(f"{provider} returned overly complex JSON") from exc
 
 
 class _HTTPProvider(ModelProvider):
@@ -129,13 +214,53 @@ class _HTTPProvider(ModelProvider):
         headers: Mapping[str, str],
         body: bytes,
     ) -> Mapping[str, Any]:
+        _validate_outbound_body(body)
+        deadline = monotonic() + self.timeout
         try:
-            with httpx.Client(
-                timeout=httpx.Timeout(self.timeout),
-                transport=self._transport,
-                trust_env=not is_loopback_url(self.base_url),
-            ) as client:
-                response = client.post(endpoint, headers=headers, content=body)
+            with (
+                httpx.Client(
+                    timeout=httpx.Timeout(self.timeout),
+                    transport=self._transport,
+                    trust_env=not is_loopback_url(self.base_url),
+                ) as client,
+                client.stream("POST", endpoint, headers=headers, content=body) as response,
+            ):
+                if monotonic() > deadline:
+                    raise ProviderRequestError(
+                        f"{self.name} request exceeded the {self.timeout:g}-second "
+                        "elapsed-time deadline; it was not retried"
+                    )
+                if response.status_code >= 400:
+                    if response.status_code in {401, 403}:
+                        detail = "authentication was rejected"
+                    elif response.status_code == 429:
+                        detail = "rate limit or quota was exceeded"
+                    else:
+                        detail = f"HTTP {response.status_code}"
+                    raise ProviderRequestError(
+                        f"{self.name} request failed: {detail}; the request was not retried"
+                    )
+                _validate_response_headers(response)
+                blocks: list[bytes] = []
+                received = 0
+                for block in response.iter_bytes():
+                    if monotonic() > deadline:
+                        raise ProviderRequestError(
+                            f"{self.name} request exceeded the {self.timeout:g}-second "
+                            "elapsed-time deadline; it was not retried"
+                        )
+                    received += len(block)
+                    if received > _MAX_RESPONSE_BYTES:
+                        raise ProviderResponseError(
+                            f"{self.name} response exceeded the {_MAX_RESPONSE_BYTES}-byte limit"
+                        )
+                    blocks.append(block)
+                if monotonic() > deadline:
+                    raise ProviderRequestError(
+                        f"{self.name} request exceeded the {self.timeout:g}-second "
+                        "elapsed-time deadline; it was not retried"
+                    )
+                response_body = b"".join(blocks)
         except httpx.TimeoutException as exc:
             raise ProviderRequestError(
                 f"{self.name} request timed out after {self.timeout:g} seconds; it was not retried"
@@ -144,23 +269,13 @@ class _HTTPProvider(ModelProvider):
             raise ProviderRequestError(
                 f"could not reach {self.name} provider; check its URL and network access"
             ) from exc
-
-        if response.status_code >= 400:
-            if response.status_code in {401, 403}:
-                detail = "authentication was rejected"
-            elif response.status_code == 429:
-                detail = "rate limit or quota was exceeded"
-            else:
-                detail = f"HTTP {response.status_code}"
-            raise ProviderRequestError(
-                f"{self.name} request failed: {detail}; the request was not retried"
-            )
         try:
-            data = response.json()
-        except ValueError as exc:
+            data = json.loads(response_body)
+        except (ValueError, RecursionError) as exc:
             raise ProviderResponseError(f"{self.name} returned invalid JSON") from exc
         if not isinstance(data, Mapping):
             raise ProviderResponseError(f"{self.name} returned a non-object JSON response")
+        _validate_json_shape(data, provider=self.name)
         return data
 
 

--- a/src/repolocus/retrieval/terms.py
+++ b/src/repolocus/retrieval/terms.py
@@ -71,6 +71,23 @@ def _cjk_ngrams(value: str) -> tuple[str, ...]:
     return tuple(terms)
 
 
+def _cjk_coverage_terms(value: str) -> tuple[str, ...]:
+    """Return bounded, position-spread anchors for one contiguous CJK run.
+
+    Overlapping n-grams are highly correlated: ``配置在`` alone contains three
+    generated terms for a longer question that starts the same way.  Coverage
+    therefore uses the complete run plus at most three bigrams spread across
+    its beginning, middle, and end.  Ranking may still use every n-gram.
+    """
+
+    if len(value) <= 2:
+        return (value,)
+    positions = {0, len(value) - 2}
+    if len(value) >= 5:
+        positions.add((len(value) - 2) // 2)
+    return tuple(dict.fromkeys((value, *(value[index : index + 2] for index in sorted(positions)))))
+
+
 def _lexical_terms(text: str, *, maximum: int) -> tuple[str, ...]:
     if not isinstance(text, str) or maximum <= 0:
         return ()
@@ -97,6 +114,64 @@ def literal_query_terms(query: str, *, maximum: int = 64) -> tuple[str, ...]:
     """Return only terms written by the user, without synonym expansion."""
 
     return _lexical_terms(query, maximum=maximum)
+
+
+def is_cjk_term(term: str) -> bool:
+    """Return whether a normalized term consists entirely of one CJK run."""
+
+    return isinstance(term, str) and _CJK_RUN.fullmatch(term) is not None
+
+
+def literal_query_term_groups(
+    query: str,
+    *,
+    maximum: int = 64,
+) -> tuple[tuple[str, ...], ...]:
+    """Return the literal coverage groups required for a retrieval candidate.
+
+    Non-CJK terms remain singleton groups so the index can apply a bounded
+    coverage ratio across them. Each contiguous CJK run is represented by one
+    group containing position-spread anchors, because counting every overlapping
+    bigram and trigram would overstate coverage of one small matching fragment.
+    """
+
+    literal = literal_query_terms(query, maximum=maximum)
+    if not literal:
+        return ()
+    available = set(literal)
+    normalized = unicodedata.normalize("NFKC", query)
+    cjk_groups: list[tuple[str, ...]] = []
+    for match in _CJK_RUN.finditer(normalized):
+        candidates = _cjk_coverage_terms(match.group(0))
+        group: list[str] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            term = _normalized(candidate)[:128]
+            if term in available and term not in seen:
+                seen.add(term)
+                group.append(term)
+        if group:
+            cjk_groups.append(tuple(group))
+
+    groups: list[tuple[str, ...]] = []
+    emitted_cjk_groups: set[int] = set()
+    for term in literal:
+        matching_groups = [index for index, group in enumerate(cjk_groups) if term in group]
+        if matching_groups:
+            for index in matching_groups:
+                if index not in emitted_cjk_groups:
+                    emitted_cjk_groups.add(index)
+                    groups.append(cjk_groups[index])
+            continue
+        if _CJK_RUN.search(term):
+            # Mixed CJK/non-CJK lexical tokens are represented by their
+            # independently generated components.  If bounding left no CJK
+            # component, retain the mixed token as a fail-closed requirement.
+            if not cjk_groups:
+                groups.append((term,))
+            continue
+        groups.append((term,))
+    return tuple(groups)
 
 
 def _morphological_expansions(term: str) -> tuple[str, ...]:

--- a/src/repolocus/scanner/filters.py
+++ b/src/repolocus/scanner/filters.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import math
 import re
-from collections import Counter
 from pathlib import Path, PurePosixPath
+
+from repolocus.security.secrets import contains_high_confidence_secret
 
 LANGUAGE_EXTENSIONS: dict[str, str] = {
     ".py": "python",
@@ -59,12 +59,18 @@ _GENERATED_MARKER = re.compile(
 )
 
 
-def is_generated_document(text: str, language: str) -> bool:
-    """Recognize only exact RepoLocus headers near a Markdown document start."""
+def is_generated_document(text: str, language: str | None = None) -> bool:
+    """Recognize an exact RepoLocus header near any supported document start.
 
-    if language != "markdown":
-        return False
-    return any(_GENERATED_MARKER.fullmatch(line) for line in text[:4096].splitlines()[:16])
+    ``language`` is retained for caller compatibility, but deliberately does not
+    gate detection.  Generated Markdown can be copied or renamed to another
+    scanner-supported extension, and must not become source evidence merely
+    because its filename changed.
+    """
+
+    del language
+    prefix = text[:4096].encode("utf-8", errors="replace")[:4096].decode("utf-8", errors="ignore")
+    return any(_GENERATED_MARKER.fullmatch(line) for line in prefix.splitlines()[:16])
 
 
 CONFIG_FILENAMES = frozenset(
@@ -214,36 +220,6 @@ _SENSITIVE_SUFFIXES = (
     ".tfstate",
 )
 
-_HIGH_CONFIDENCE_SECRET_PATTERNS = tuple(
-    re.compile(pattern, re.IGNORECASE | re.MULTILINE)
-    for pattern in (
-        r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----",
-        r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b",
-        r"\bgh[pousr]_[A-Za-z0-9]{30,}\b",
-        r"\bgithub_pat_[A-Za-z0-9_]{50,}\b",
-        r"\bglpat-[A-Za-z0-9_-]{20,}\b",
-        r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
-        r"\bAIza[0-9A-Za-z_-]{35}\b",
-        r"\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b",
-        r"\bhf_[A-Za-z0-9]{20,}\b",
-        r"\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b",
-        r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{8,}\b",
-        r"[a-z][a-z0-9+.-]*://[^\s/:@]+:[^\s/@]+@[^\s/]+",
-    )
-)
-
-_QUOTED_ASSIGNMENT_RE = re.compile(
-    r"(?im)[\"']?(?:password|passwd|pwd|secret|client_secret|api[_-]?key|access[_-]?token|"
-    r"auth[_-]?token|private[_-]?key|hf[_-]?token|database[_-]?url|db[_-]?url|dsn)"
-    r"[\"']?\s*[:=]\s*(?:[rubf]{0,2})"
-    r"(?P<quote>[\"'])(?P<value>[^\r\n\"']{4,})(?P=quote)"
-)
-_BARE_ASSIGNMENT_RE = re.compile(
-    r"(?im)^[ \t]*(?:export\s+)?(?:password|passwd|pwd|secret|client_secret|api[_-]?key|"
-    r"access[_-]?token|auth[_-]?token|private[_-]?key|hf[_-]?token|database[_-]?url|"
-    r"db[_-]?url|dsn)\s*[:=]\s*(?P<value>[^\s#;,]{4,})"
-)
-
 
 def detect_language(path: str | Path) -> str | None:
     """Return the supported language for *path*, if any."""
@@ -320,53 +296,10 @@ def is_binary(data: bytes) -> bool:
     return control_count / max(1, len(decoded)) > 0.02
 
 
-def _entropy(value: str) -> float:
-    counts = Counter(value)
-    length = len(value)
-    return -sum((count / length) * math.log2(count / length) for count in counts.values())
-
-
-def _plausible_assigned_secret(value: str) -> bool:
-    stripped = value.strip()
-    lowered = stripped.casefold()
-    if len(stripped) < 8 or len(stripped) > 4_096:
-        return False
-    placeholder_fragments = (
-        "${",
-        "{{",
-        "<your",
-        "changeme",
-        "change_me",
-        "dummy",
-        "example",
-        "fake",
-        "env.get",
-        "getenv",
-        "os.environ",
-        "placeholder",
-        "process.env",
-        "redacted",
-        "replace_me",
-        "sample",
-        "your_",
-    )
-    if any(fragment in lowered for fragment in placeholder_fragments):
-        return False
-    if lowered in {"password", "secret", "undefined", "none", "null"}:
-        return False
-    if len(set(stripped)) <= 2:
-        return False
-    return _entropy(stripped) >= 2.5
-
-
 def contains_likely_secret(text: str) -> bool:
     """Detect high-confidence credentials without returning their value."""
 
-    if any(pattern.search(text) for pattern in _HIGH_CONFIDENCE_SECRET_PATTERNS):
-        return True
-    assignments = list(_QUOTED_ASSIGNMENT_RE.finditer(text))
-    assignments.extend(_BARE_ASSIGNMENT_RE.finditer(text))
-    return any(_plausible_assigned_secret(match.group("value")) for match in assignments)
+    return contains_high_confidence_secret(text)
 
 
 looks_like_secret = contains_likely_secret

--- a/src/repolocus/scanner/repository.py
+++ b/src/repolocus/scanner/repository.py
@@ -34,6 +34,7 @@ DEFAULT_MAX_REPOSITORY_SYMBOLS = 500_000
 DEFAULT_MAX_SCAN_SECONDS = 120
 
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+_IS_WINDOWS = os.name == "nt"
 _USE_DIRECTORY_FDS = (
     os.name == "posix"
     and os.open in os.supports_dir_fd
@@ -123,6 +124,14 @@ def _same_file_state(first: os.stat_result, second: os.stat_result) -> bool:
     return _same_content_state(first, second) and first.st_ctime_ns == second.st_ctime_ns
 
 
+def _same_post_close_state(first: os.stat_result, second: os.stat_result) -> bool:
+    """Compare path metadata across the Windows handle-close boundary."""
+
+    return _same_content_state(first, second) and (
+        _IS_WINDOWS or first.st_ctime_ns == second.st_ctime_ns
+    )
+
+
 def _is_stable_unpinned_directory(
     directory: Path,
     root: Path,
@@ -198,6 +207,8 @@ def _safe_read_at(
             else "unreadable"
         )
         return None, None, reason
+    accepted_payload: bytes | None = None
+    preclose_path: os.stat_result | None = None
     try:
         try:
             opened = os.fstat(descriptor)
@@ -237,11 +248,27 @@ def _safe_read_at(
             or not _same_file_state(expected, current)
         ):
             return None, None, "changed_during_scan"
-        # Persist path-derived timestamps. On Windows, handle and path ctime
-        # semantics differ, and the next trusted-cache comparison is path-based.
-        return payload, current, None
+        accepted_payload = payload
+        preclose_path = current
     finally:
         os.close(descriptor)
+
+    if accepted_payload is None or preclose_path is None:  # pragma: no cover - control flow
+        raise RuntimeError("safe read completed without an accepted snapshot")
+    try:
+        if directory_fd is None:
+            persisted = os.stat(target, follow_symlinks=False)
+        else:
+            persisted = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+    except OSError:
+        return None, None, "changed_during_scan"
+    if (
+        not stat.S_ISREG(persisted.st_mode)
+        or _is_reparse_point(persisted)
+        or not _same_post_close_state(preclose_path, persisted)
+    ):
+        return None, None, "changed_during_scan"
+    return accepted_payload, persisted, None
 
 
 def _safe_read(path: Path, limit: int) -> tuple[bytes | None, str | None]:

--- a/src/repolocus/scanner/repository.py
+++ b/src/repolocus/scanner/repository.py
@@ -124,8 +124,8 @@ def _same_file_state(first: os.stat_result, second: os.stat_result) -> bool:
     return _same_content_state(first, second) and first.st_ctime_ns == second.st_ctime_ns
 
 
-def _same_post_close_state(first: os.stat_result, second: os.stat_result) -> bool:
-    """Compare path metadata across the Windows handle-close boundary."""
+def _same_portable_path_state(first: os.stat_result, second: os.stat_result) -> bool:
+    """Compare path metadata without treating Windows ctime as a change token."""
 
     return _same_content_state(first, second) and (
         _IS_WINDOWS or first.st_ctime_ns == second.st_ctime_ns
@@ -265,7 +265,7 @@ def _safe_read_at(
     if (
         not stat.S_ISREG(persisted.st_mode)
         or _is_reparse_point(persisted)
-        or not _same_post_close_state(preclose_path, persisted)
+        or not _same_portable_path_state(preclose_path, persisted)
     ):
         return None, None, "changed_during_scan"
     return accepted_payload, persisted, None
@@ -309,7 +309,7 @@ def _metadata_still_matches_at(
     return (
         stat.S_ISREG(current.st_mode)
         and not _is_reparse_point(current)
-        and _same_file_state(expected, current)
+        and _same_portable_path_state(expected, current)
     )
 
 

--- a/src/repolocus/scanner/repository.py
+++ b/src/repolocus/scanner/repository.py
@@ -237,7 +237,9 @@ def _safe_read_at(
             or not _same_file_state(expected, current)
         ):
             return None, None, "changed_during_scan"
-        return payload, finished, None
+        # Persist path-derived timestamps. On Windows, handle and path ctime
+        # semantics differ, and the next trusted-cache comparison is path-based.
+        return payload, current, None
     finally:
         os.close(descriptor)
 

--- a/src/repolocus/scanner/repository.py
+++ b/src/repolocus/scanner/repository.py
@@ -7,8 +7,9 @@ import hashlib
 import os
 import stat
 from collections.abc import Mapping
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
+from time import monotonic
 
 from repolocus.models import ANALYSIS_VERSION, ScannedFile, ScanResult, ScanStats
 from repolocus.parsers import DEFAULT_REGISTRY, ParseResult, ParserRegistry
@@ -21,9 +22,16 @@ from repolocus.scanner.filters import (
     is_sensitive_path,
 )
 from repolocus.scanner.ignore import IgnoreRules
+from repolocus.security.identity import descriptor_path, filesystem_identity
 
 DEFAULT_MAX_FILE_BYTES = 1_000_000
 DEFAULT_MAX_IGNORE_BYTES = 256_000
+DEFAULT_MAX_REPOSITORY_FILES = 100_000
+DEFAULT_MAX_REPOSITORY_BYTES = 512_000_000
+DEFAULT_MAX_DIRECTORY_DEPTH = 64
+DEFAULT_MAX_REPOSITORY_CHUNKS = 500_000
+DEFAULT_MAX_REPOSITORY_SYMBOLS = 500_000
+DEFAULT_MAX_SCAN_SECONDS = 120
 
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 _USE_DIRECTORY_FDS = (
@@ -32,6 +40,57 @@ _USE_DIRECTORY_FDS = (
     and os.stat in os.supports_dir_fd
     and os.scandir in os.supports_fd
 )
+
+
+@dataclass(slots=True)
+class _ScanBudget:
+    max_entries: int
+    max_bytes: int
+    max_chunks: int
+    max_symbols: int
+    deadline: float
+    entries: int = 0
+    bytes_seen: int = 0
+    chunks: int = 0
+    symbols: int = 0
+    exhausted_reason: str | None = None
+    reported: bool = False
+
+    def check_deadline(self) -> bool:
+        if self.exhausted_reason is None and monotonic() > self.deadline:
+            self.exhausted_reason = "scan deadline"
+        return self.exhausted_reason is None
+
+    def observe_entry(self) -> bool:
+        if not self.check_deadline():
+            return False
+        if self.entries + 1 > self.max_entries:
+            self.exhausted_reason = "repository file/entry count"
+            return False
+        self.entries += 1
+        return True
+
+    def observe_bytes(self, size: int) -> bool:
+        if not self.check_deadline():
+            return False
+        if self.bytes_seen + size > self.max_bytes:
+            self.exhausted_reason = "repository byte count"
+            return False
+        self.bytes_seen += size
+        return True
+
+    def observe_facts(self, chunks: int, symbols: int) -> bool:
+        if not self.check_deadline():
+            return False
+        if self.chunks + chunks > self.max_chunks:
+            self.exhausted_reason = "repository chunk count"
+            return False
+        if self.symbols + symbols > self.max_symbols:
+            self.exhausted_reason = "repository symbol count"
+            return False
+        self.chunks += chunks
+        self.symbols += symbols
+        return True
 
 
 def _is_within(path: Path, root: Path) -> bool:
@@ -64,6 +123,37 @@ def _same_file_state(first: os.stat_result, second: os.stat_result) -> bool:
     return _same_content_state(first, second) and first.st_ctime_ns == second.st_ctime_ns
 
 
+def _is_stable_unpinned_directory(
+    directory: Path,
+    root: Path,
+    expected: os.stat_result,
+) -> bool:
+    """Validate a path-based directory traversal against its enumerated identity."""
+
+    try:
+        before = directory.lstat()
+    except OSError:
+        return False
+    if (
+        not stat.S_ISDIR(before.st_mode)
+        or _is_reparse_point(before)
+        or not _same_identity(expected, before)
+    ):
+        return False
+    try:
+        resolved = directory.resolve(strict=True)
+        after = directory.lstat()
+    except (OSError, RuntimeError):
+        return False
+    return (
+        _is_within(resolved, root)
+        and stat.S_ISDIR(after.st_mode)
+        and not _is_reparse_point(after)
+        and _same_identity(expected, after)
+        and _same_identity(before, after)
+    )
+
+
 def _read_descriptor(descriptor: int, limit: int) -> tuple[bytes | None, str | None]:
     blocks: list[bytes] = []
     remaining = limit + 1
@@ -87,6 +177,7 @@ def _safe_read_at(
     *,
     directory: Path,
     directory_fd: int | None,
+    root: Path | None = None,
 ) -> tuple[bytes | None, os.stat_result | None, str | None]:
     """Open and read one enumerated file without resolving a path component twice."""
 
@@ -118,6 +209,13 @@ def _safe_read_at(
             or not _same_identity(expected, opened)
         ):
             return None, None, "changed_during_scan"
+        # A pinned directory descriptor already confines POSIX openat reads.
+        # Descriptor-path attestation is required only for the path-based
+        # fallback (and on Windows), where it closes the final open race.
+        if root is not None and directory_fd is None:
+            opened_path = descriptor_path(descriptor)
+            if opened_path is None or not _is_within(opened_path, root):
+                return None, None, "changed_during_scan"
         if opened.st_size > limit:
             return None, None, "oversize"
         payload, reason = _read_descriptor(descriptor, limit)
@@ -161,6 +259,29 @@ def _safe_read(path: Path, limit: int) -> tuple[bytes | None, str | None]:
         directory_fd=None,
     )
     return payload, reason
+
+
+def _metadata_still_matches_at(
+    name: str,
+    expected: os.stat_result,
+    *,
+    directory: Path,
+    directory_fd: int | None,
+) -> bool:
+    """Revalidate one metadata-only cache hit without opening its contents."""
+
+    try:
+        if directory_fd is None:
+            current = os.stat(directory / name, follow_symlinks=False)
+        else:
+            current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(current.st_mode)
+        and not _is_reparse_point(current)
+        and _same_file_state(expected, current)
+    )
 
 
 def _open_directory_at(
@@ -246,6 +367,12 @@ class RepositoryScanner:
         max_chunk_lines: int = 160,
         max_chunk_chars: int = 16_000,
         max_ignore_bytes: int = DEFAULT_MAX_IGNORE_BYTES,
+        max_repository_files: int = DEFAULT_MAX_REPOSITORY_FILES,
+        max_repository_bytes: int = DEFAULT_MAX_REPOSITORY_BYTES,
+        max_directory_depth: int = DEFAULT_MAX_DIRECTORY_DEPTH,
+        max_repository_chunks: int = DEFAULT_MAX_REPOSITORY_CHUNKS,
+        max_repository_symbols: int = DEFAULT_MAX_REPOSITORY_SYMBOLS,
+        max_scan_seconds: int = DEFAULT_MAX_SCAN_SECONDS,
         parser_registry: ParserRegistry | None = None,
         analysis_version: str = ANALYSIS_VERSION,
     ) -> None:
@@ -255,12 +382,28 @@ class RepositoryScanner:
             raise ValueError("max_ignore_bytes must be positive")
         if max_chunk_lines <= 0 or max_chunk_chars <= 0:
             raise ValueError("chunk limits must be positive")
+        for name, value in (
+            ("max_repository_files", max_repository_files),
+            ("max_repository_bytes", max_repository_bytes),
+            ("max_directory_depth", max_directory_depth),
+            ("max_repository_chunks", max_repository_chunks),
+            ("max_repository_symbols", max_repository_symbols),
+            ("max_scan_seconds", max_scan_seconds),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
         if not analysis_version or len(analysis_version) > 96:
             raise ValueError("analysis_version must be a short non-empty string")
         self.max_file_bytes = max_file_bytes
         self.max_ignore_bytes = max_ignore_bytes
         self.max_chunk_lines = max_chunk_lines
         self.max_chunk_chars = max_chunk_chars
+        self.max_repository_files = max_repository_files
+        self.max_repository_bytes = max_repository_bytes
+        self.max_directory_depth = max_directory_depth
+        self.max_repository_chunks = max_repository_chunks
+        self.max_repository_symbols = max_repository_symbols
+        self.max_scan_seconds = max_scan_seconds
         self.parser_registry = parser_registry or DEFAULT_REGISTRY
         self.analysis_version = (
             f"{analysis_version}:lines={max_chunk_lines}:chars={max_chunk_chars}"
@@ -271,6 +414,7 @@ class RepositoryScanner:
         root: Path | str,
         *,
         cached_files: Mapping[str, ScannedFile] | None = None,
+        trusted_cache: bool = False,
         base_generation: int | None = None,
     ) -> ScanResult:
         """Return a stable scan of *root*.
@@ -284,6 +428,8 @@ class RepositoryScanner:
             isinstance(base_generation, bool) or base_generation < 0
         ):
             raise ValueError("base_generation must be a non-negative integer or None")
+        if not isinstance(trusted_cache, bool):
+            raise ValueError("trusted_cache must be true or false")
         supplied_root = Path(root).expanduser().absolute()
         try:
             root_metadata = supplied_root.lstat()
@@ -294,12 +440,23 @@ class RepositoryScanner:
         if not stat.S_ISDIR(root_metadata.st_mode):
             raise ValueError("repository root must be a directory")
         resolved_root = supplied_root.resolve(strict=True)
+        try:
+            root_identity = filesystem_identity(root_metadata)
+        except ValueError as exc:
+            raise ValueError("repository root has no stable filesystem identity") from exc
 
         files: list[ScannedFile] = []
         stats = ScanStats()
         warnings: list[str] = []
         temporarily_unreadable: set[str] = set()
         reusable = cached_files or {}
+        budget = _ScanBudget(
+            max_entries=self.max_repository_files,
+            max_bytes=self.max_repository_bytes,
+            max_chunks=self.max_repository_chunks,
+            max_symbols=self.max_repository_symbols,
+            deadline=monotonic() + self.max_scan_seconds,
+        )
         root_fd: int | None = None
         if _USE_DIRECTORY_FDS:
             flags = os.O_RDONLY
@@ -325,6 +482,7 @@ class RepositoryScanner:
                 resolved_root,
                 resolved_root,
                 root_fd,
+                root_metadata,
                 PurePosixPath(),
                 IgnoreRules(),
                 files,
@@ -332,10 +490,26 @@ class RepositoryScanner:
                 warnings,
                 temporarily_unreadable,
                 reusable,
+                trusted_cache,
+                budget,
             )
         finally:
             if root_fd is not None:
                 os.close(root_fd)
+        try:
+            final_root_metadata = supplied_root.lstat()
+        except OSError:
+            final_root_metadata = None
+        if (
+            final_root_metadata is None
+            or not stat.S_ISDIR(final_root_metadata.st_mode)
+            or _is_reparse_point(final_root_metadata)
+            or not _same_identity(root_metadata, final_root_metadata)
+        ):
+            files.clear()
+            stats = ScanStats(skipped={"changed_during_scan": 1})
+            warnings = ["repository root changed during scan"]
+            temporarily_unreadable = {"."}
         files.sort(key=lambda item: item.path)
         warnings.sort()
         return ScanResult(
@@ -346,10 +520,12 @@ class RepositoryScanner:
             analysis_version=self.analysis_version,
             temporarily_unreadable=tuple(sorted(temporarily_unreadable)),
             base_generation=base_generation,
+            repository_identity=root_identity,
         )
 
     def _load_local_ignore(
         self,
+        root: Path,
         directory: Path,
         directory_fd: int | None,
         relative_directory: PurePosixPath,
@@ -382,6 +558,7 @@ class RepositoryScanner:
             metadata,
             directory=directory,
             directory_fd=directory_fd,
+            root=root,
         )
         if payload is None:
             location = (relative_directory / ".gitignore").as_posix()
@@ -402,6 +579,7 @@ class RepositoryScanner:
         root: Path,
         directory: Path,
         directory_fd: int | None,
+        expected_directory: os.stat_result,
         relative_directory: PurePosixPath,
         inherited_rules: IgnoreRules,
         files: list[ScannedFile],
@@ -409,8 +587,90 @@ class RepositoryScanner:
         warnings: list[str],
         temporarily_unreadable: set[str],
         cached_files: Mapping[str, ScannedFile],
+        trusted_cache: bool,
+        budget: _ScanBudget,
     ) -> None:
+        file_checkpoint = len(files)
+        warning_checkpoint = len(warnings)
+        unreadable_checkpoint = set(temporarily_unreadable)
+        stats_checkpoint = (
+            stats.discovered_files,
+            stats.indexed_files,
+            stats.indexed_bytes,
+            dict(stats.languages),
+            dict(stats.skipped),
+        )
+        directory_location = relative_directory.as_posix() or "."
+
+        def stop_for_global_budget() -> None:
+            temporarily_unreadable.add(".")
+            if not budget.reported:
+                budget.reported = True
+                stats.skip("repository_budget")
+                warnings.append(
+                    f"repository scan stopped at {budget.exhausted_reason or 'a hard limit'}"
+                )
+
+        def discard_changed_directory() -> None:
+            del files[file_checkpoint:]
+            del warnings[warning_checkpoint:]
+            temporarily_unreadable.clear()
+            temporarily_unreadable.update(unreadable_checkpoint)
+            (
+                stats.discovered_files,
+                stats.indexed_files,
+                stats.indexed_bytes,
+                languages,
+                skipped,
+            ) = stats_checkpoint
+            stats.languages.clear()
+            stats.languages.update(languages)
+            stats.skipped.clear()
+            stats.skipped.update(skipped)
+            stats.skip("changed_during_scan")
+            warnings.append(f"directory changed during scan: {directory_location}")
+            temporarily_unreadable.add(directory_location)
+            if budget.exhausted_reason is not None:
+                # A rollback removes the first budget diagnostic as well. Let
+                # the global marker be emitted again so callers retain both
+                # independent reasons that this scan is incomplete.
+                budget.reported = False
+                stop_for_global_budget()
+
+        def directory_is_stable() -> bool:
+            # A descriptor pins the opened directory object, but it does not
+            # prove that the repository-relative path still names that object.
+            # Revalidate the path binding as well so a rename followed by a
+            # replacement cannot make facts from the detached directory fresh.
+            if not _is_stable_unpinned_directory(directory, root, expected_directory):
+                return False
+            if directory_fd is None:
+                return True
+            try:
+                opened_directory = os.fstat(directory_fd)
+            except OSError:
+                return False
+            return (
+                stat.S_ISDIR(opened_directory.st_mode)
+                and not _is_reparse_point(opened_directory)
+                and _same_identity(expected_directory, opened_directory)
+            )
+
+        # A path-based traversal must validate the identity and root boundary
+        # before opening a local ignore file or enumerating any children.
+        if len(relative_directory.parts) > self.max_directory_depth:
+            stats.skip("max_directory_depth")
+            warnings.append(f"maximum directory depth reached: {directory_location}")
+            temporarily_unreadable.add(directory_location)
+            return
+        if not budget.check_deadline():
+            stop_for_global_budget()
+            return
+        if not directory_is_stable():
+            discard_changed_directory()
+            return
         rules = self._load_local_ignore(
+            root,
             directory,
             directory_fd,
             relative_directory,
@@ -418,21 +678,44 @@ class RepositoryScanner:
             warnings,
             temporarily_unreadable,
         )
+        if not directory_is_stable():
+            discard_changed_directory()
+            return
         if rules is None:
             stats.skip("unreadable_ignore")
             return
         try:
             scan_target: int | Path = directory_fd if directory_fd is not None else directory
             with os.scandir(scan_target) as iterator:
-                entries = sorted(iterator, key=lambda entry: entry.name)
+                entries = []
+                for entry in iterator:
+                    if not budget.observe_entry():
+                        stop_for_global_budget()
+                        return
+                    entries.append(entry)
+                entries.sort(key=lambda entry: entry.name)
         except OSError:
-            location = relative_directory.as_posix() or "."
+            if not directory_is_stable():
+                discard_changed_directory()
+                return
             stats.skip("unreadable")
-            warnings.append(f"could not list directory: {location}")
-            temporarily_unreadable.add(location)
+            warnings.append(f"could not list directory: {directory_location}")
+            temporarily_unreadable.add(directory_location)
+            return
+        if not directory_is_stable():
+            discard_changed_directory()
+            return
+        if not budget.check_deadline():
+            stop_for_global_budget()
             return
 
         for entry in entries:
+            if not budget.check_deadline():
+                stop_for_global_budget()
+                return
+            if not directory_is_stable():
+                discard_changed_directory()
+                return
             relative_path = relative_directory / entry.name
             display_path = relative_path.as_posix()
             absolute_path = directory / entry.name
@@ -443,6 +726,9 @@ class RepositoryScanner:
                 else:
                     metadata = os.stat(entry.name, dir_fd=directory_fd, follow_symlinks=False)
             except OSError:
+                if not directory_is_stable():
+                    discard_changed_directory()
+                    return
                 stats.discovered_files += 1
                 stats.skip("unreadable")
                 warnings.append(f"could not inspect path: {display_path}")
@@ -457,6 +743,10 @@ class RepositoryScanner:
                     warnings.append(f"outside-root symlink skipped: {display_path}")
                 else:
                     warnings.append(f"symlink skipped: {display_path}")
+                # The entry may have replaced a previously indexed file or
+                # directory. Never interpret that old subtree as a confirmed
+                # deletion when the current object cannot be traversed.
+                temporarily_unreadable.add(display_path)
                 continue
 
             if stat.S_ISDIR(metadata.st_mode):
@@ -474,23 +764,12 @@ class RepositoryScanner:
                         warnings.append(f"could not safely open directory: {display_path}")
                         temporarily_unreadable.add(display_path)
                         continue
-                else:
-                    try:
-                        resolved_directory = absolute_path.resolve(strict=True)
-                    except OSError:
-                        stats.skip("unreadable")
-                        warnings.append(f"could not resolve directory: {display_path}")
-                        temporarily_unreadable.add(display_path)
-                        continue
-                    if not _is_within(resolved_directory, root):
-                        stats.skip("outside_root")
-                        warnings.append(f"outside-root directory skipped: {display_path}")
-                        continue
                 try:
                     self._walk(
                         root,
                         absolute_path,
                         child_fd,
+                        metadata,
                         relative_path,
                         rules,
                         files,
@@ -498,10 +777,18 @@ class RepositoryScanner:
                         warnings,
                         temporarily_unreadable,
                         cached_files,
+                        trusted_cache,
+                        budget,
                     )
                 finally:
                     if child_fd is not None:
                         os.close(child_fd)
+                if not directory_is_stable():
+                    discard_changed_directory()
+                    return
+                if budget.exhausted_reason is not None:
+                    stop_for_global_budget()
+                    return
                 continue
 
             stats.discovered_files += 1
@@ -535,19 +822,67 @@ class RepositoryScanner:
                     warnings.append(f"could not resolve file: {display_path}")
                     temporarily_unreadable.add(display_path)
                     continue
+                if not directory_is_stable():
+                    discard_changed_directory()
+                    return
                 if not _is_within(resolved_file, root):
-                    stats.skip("outside_root")
-                    warnings.append(f"outside-root file skipped: {display_path}")
+                    stats.skip("changed_during_scan")
+                    warnings.append(f"file changed during scan: {display_path}")
+                    temporarily_unreadable.add(display_path)
                     continue
 
             cached = cached_files.get(display_path)
+            if not budget.observe_bytes(metadata.st_size):
+                stop_for_global_budget()
+                return
+            # Service-provided cache entries are bound to the same repository
+            # identity and analysis version. Exact metadata matches can therefore
+            # reuse parser facts without reading and hashing unchanged contents.
+            if (
+                trusted_cache
+                and cached is not None
+                and cached.provenance == "source"
+                and not cached.stale
+                and cached.language == language
+                and cached.size_bytes == metadata.st_size
+                and cached.mtime_ns == metadata.st_mtime_ns
+                and cached.ctime_ns == metadata.st_ctime_ns
+                and _metadata_still_matches_at(
+                    entry.name,
+                    metadata,
+                    directory=directory,
+                    directory_fd=directory_fd,
+                )
+            ):
+                cached_chunks = (
+                    len(cached.chunks) or cached.cached_chunk_count or int(bool(cached.text))
+                )
+                cached_symbols = len(cached.symbols) or cached.cached_symbol_count
+                if not budget.observe_facts(cached_chunks, cached_symbols):
+                    stop_for_global_budget()
+                    return
+                if not directory_is_stable():
+                    discard_changed_directory()
+                    return
+                files.append(replace(cached, provenance="source", stale=False))
+                stats.indexed_files += 1
+                stats.indexed_bytes += cached.size_bytes
+                stats.languages[language] = stats.languages.get(language, 0) + 1
+                continue
             payload, post_read_metadata, read_error = _safe_read_at(
                 entry.name,
                 self.max_file_bytes,
                 metadata,
                 directory=directory,
                 directory_fd=directory_fd,
+                root=root,
             )
+            if not directory_is_stable():
+                discard_changed_directory()
+                return
+            if not budget.check_deadline():
+                stop_for_global_budget()
+                return
             if payload is None:
                 stats.skip(read_error or "unreadable")
                 if read_error == "changed_during_scan":
@@ -582,10 +917,19 @@ class RepositoryScanner:
                 continue
             if (
                 cached is not None
+                and cached.provenance == "source"
+                and not cached.stale
                 and cached.language == language
                 and cached.size_bytes == len(payload)
                 and cached.sha256.casefold() == digest
             ):
+                cached_chunks = (
+                    len(cached.chunks) or cached.cached_chunk_count or int(bool(cached.text))
+                )
+                cached_symbols = len(cached.symbols) or cached.cached_symbol_count
+                if not budget.observe_facts(cached_chunks, cached_symbols):
+                    stop_for_global_budget()
+                    return
                 files.append(
                     replace(
                         cached,
@@ -608,6 +952,20 @@ class RepositoryScanner:
                     max_chunk_lines=self.max_chunk_lines,
                     max_chunk_chars=self.max_chunk_chars,
                 )
+            except Exception as exc:  # Parser plugins are an isolation boundary.
+                stats.skip("parse_error")
+                warnings.append(f"parse failed ({type(exc).__name__}) for file: {display_path}")
+                temporarily_unreadable.add(display_path)
+                continue
+
+            if not budget.check_deadline():
+                stop_for_global_budget()
+                return
+            parsed_chunks = len(parsed.chunks) or int(bool(text))
+            if not budget.observe_facts(parsed_chunks, len(parsed.symbols)):
+                stop_for_global_budget()
+                return
+            try:
                 _validate_parse_result(
                     parsed,
                     path=display_path,
@@ -642,6 +1000,12 @@ class RepositoryScanner:
             stats.indexed_files += 1
             stats.indexed_bytes += len(payload)
             stats.languages[language] = stats.languages.get(language, 0) + 1
+
+        if not directory_is_stable():
+            discard_changed_directory()
+            return
+        if not budget.check_deadline():
+            stop_for_global_budget()
 
     @staticmethod
     def _symlink_reason(path: Path, root: Path) -> str:

--- a/src/repolocus/scanner/repository.py
+++ b/src/repolocus/scanner/repository.py
@@ -124,14 +124,6 @@ def _same_file_state(first: os.stat_result, second: os.stat_result) -> bool:
     return _same_content_state(first, second) and first.st_ctime_ns == second.st_ctime_ns
 
 
-def _same_portable_path_state(first: os.stat_result, second: os.stat_result) -> bool:
-    """Compare path metadata without treating Windows ctime as a change token."""
-
-    return _same_content_state(first, second) and (
-        _IS_WINDOWS or first.st_ctime_ns == second.st_ctime_ns
-    )
-
-
 def _is_stable_unpinned_directory(
     directory: Path,
     root: Path,
@@ -192,6 +184,7 @@ def _safe_read_at(
 
     flags = os.O_RDONLY
     flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_BINARY", 0)
     flags |= getattr(os, "O_NOFOLLOW", 0)
     flags |= getattr(os, "O_NONBLOCK", 0)
     target: str | Path = name if directory_fd is not None else directory / name
@@ -265,7 +258,7 @@ def _safe_read_at(
     if (
         not stat.S_ISREG(persisted.st_mode)
         or _is_reparse_point(persisted)
-        or not _same_portable_path_state(preclose_path, persisted)
+        or not _same_file_state(preclose_path, persisted)
     ):
         return None, None, "changed_during_scan"
     return accepted_payload, persisted, None
@@ -309,7 +302,7 @@ def _metadata_still_matches_at(
     return (
         stat.S_ISREG(current.st_mode)
         and not _is_reparse_point(current)
-        and _same_portable_path_state(expected, current)
+        and _same_file_state(expected, current)
     )
 
 
@@ -934,6 +927,10 @@ class RepositoryScanner:
                 stats.skip("binary")
                 warnings.append(f"non-UTF-8 file skipped: {display_path}")
                 continue
+            if _IS_WINDOWS:
+                # Binary descriptor reads preserve on-disk bytes for size and hashing;
+                # normalize the CRLF translation previously supplied by the CRT.
+                text = text.replace("\r\n", "\n")
             if is_generated_document(text, language):
                 stats.skip("generated")
                 continue

--- a/src/repolocus/security/__init__.py
+++ b/src/repolocus/security/__init__.py
@@ -20,6 +20,7 @@ from .redaction import (
     redact_secrets_with_count,
     redact_text,
 )
+from .secrets import SecretMatch, contains_high_confidence_secret, find_likely_secrets
 
 __all__ = [
     "CloudSendPreview",
@@ -27,11 +28,14 @@ __all__ = [
     "PathSecurityError",
     "PrivacyStore",
     "PrivacyStoreError",
+    "SecretMatch",
     "build_cloud_send_preview",
     "canonical_endpoint",
+    "contains_high_confidence_secret",
     "contains_likely_secret",
     "ensure_within_root",
     "escape_untrusted_display",
+    "find_likely_secrets",
     "has_unsafe_display_controls",
     "is_local_provider",
     "is_loopback_url",

--- a/src/repolocus/security/identity.py
+++ b/src/repolocus/security/identity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import sys
 from pathlib import Path
 
 _FILESYSTEM_IDENTITY_VERSION = "1"
@@ -49,6 +50,17 @@ def descriptor_path(descriptor: int) -> Path | None:
                 value = value[4:]
             return Path(value)
         except (ImportError, OSError, ValueError):
+            return None
+    if sys.platform == "darwin":  # pragma: no cover - exercised on macOS CI
+        try:
+            import fcntl
+
+            buffer = fcntl.fcntl(descriptor, fcntl.F_GETPATH, b"\0" * 1024)
+            encoded_path = buffer.split(b"\0", 1)[0]
+            if not encoded_path:
+                return None
+            return Path(os.fsdecode(encoded_path)).resolve(strict=True)
+        except (AttributeError, ImportError, OSError, RuntimeError, ValueError):
             return None
     proc_path = Path(f"/proc/self/fd/{descriptor}")
     try:

--- a/src/repolocus/security/identity.py
+++ b/src/repolocus/security/identity.py
@@ -1,0 +1,60 @@
+"""Stable filesystem identities shared by scanning and indexing."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+_FILESYSTEM_IDENTITY_VERSION = "1"
+
+
+def filesystem_identity(metadata: os.stat_result) -> str:
+    """Return a versioned opaque identity for one opened filesystem object."""
+
+    device = int(metadata.st_dev)
+    inode = int(metadata.st_ino)
+    if device == 0 and inode == 0:
+        raise ValueError("the filesystem does not expose a stable object identity")
+    payload = f"{_FILESYSTEM_IDENTITY_VERSION}\0{device}\0{inode}".encode("ascii")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def descriptor_path(descriptor: int) -> Path | None:
+    """Resolve the filesystem object actually opened by a descriptor."""
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        try:
+            import ctypes
+            import msvcrt
+            from ctypes import wintypes
+
+            function = ctypes.windll.kernel32.GetFinalPathNameByHandleW  # type: ignore[attr-defined]
+            function.argtypes = (
+                wintypes.HANDLE,
+                wintypes.LPWSTR,
+                wintypes.DWORD,
+                wintypes.DWORD,
+            )
+            function.restype = wintypes.DWORD
+            handle = wintypes.HANDLE(msvcrt.get_osfhandle(descriptor))
+            buffer = ctypes.create_unicode_buffer(32_768)
+            length = function(handle, buffer, len(buffer), 0)
+            if not length or length >= len(buffer):
+                return None
+            value = buffer.value
+            if value.startswith("\\\\?\\UNC\\"):
+                value = "\\\\" + value[8:]
+            elif value.startswith("\\\\?\\"):
+                value = value[4:]
+            return Path(value)
+        except (ImportError, OSError, ValueError):
+            return None
+    proc_path = Path(f"/proc/self/fd/{descriptor}")
+    try:
+        return proc_path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+
+
+__all__ = ["descriptor_path", "filesystem_identity"]

--- a/src/repolocus/security/privacy.py
+++ b/src/repolocus/security/privacy.py
@@ -6,6 +6,7 @@ import hashlib
 import ipaddress
 import json
 import os
+import stat
 import tempfile
 import threading
 from collections.abc import Iterable, Mapping
@@ -21,6 +22,8 @@ from .redaction import redact_secrets_with_count
 
 _STATE_LOCKS_GUARD = threading.Lock()
 _STATE_LOCKS: dict[str, threading.RLock] = {}
+_STATE_VERSION = 3
+_REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 
 
 class PrivacyStoreError(RuntimeError):
@@ -138,12 +141,13 @@ class PrivacyStore:
     def status(self, root: Path | str) -> dict[str, bool]:
         """Return remembered provider grants for ``root``."""
 
-        root_path = self._root(root)
+        root_path, identity = self._repository_context(root)
         self._ensure_outside_repository(root_path)
         with self._locked_state():
             state = self._read()
-        entry = state["repositories"].get(_repository_id(root_path), {})
-        if entry.get("path") != str(root_path):
+        _require_same_repository_identity(root_path, identity)
+        entry = state["repositories"].get(_repository_id(root_path, identity), {})
+        if not _entry_matches(entry, root_path, identity):
             return {}
         providers = entry.get("providers", {})
         if not isinstance(providers, dict):
@@ -157,12 +161,13 @@ class PrivacyStore:
     def grant_details(self, root: Path | str) -> dict[str, tuple[str, ...]]:
         """Return canonical endpoint identities for remembered provider grants."""
 
-        root_path = self._root(root)
+        root_path, identity = self._repository_context(root)
         self._ensure_outside_repository(root_path)
         with self._locked_state():
             state = self._read()
-        entry = state["repositories"].get(_repository_id(root_path), {})
-        if entry.get("path") != str(root_path):
+        _require_same_repository_identity(root_path, identity)
+        entry = state["repositories"].get(_repository_id(root_path, identity), {})
+        if not _entry_matches(entry, root_path, identity):
             return {}
         providers = entry.get("providers", {})
         if not isinstance(providers, dict):
@@ -182,29 +187,32 @@ class PrivacyStore:
         if endpoint is None:
             raise PrivacyStoreError("a canonical endpoint is required for remembered cloud consent")
         endpoint_identity = canonical_endpoint(endpoint)
-        root_path = self._root(root)
+        root_path, identity = self._repository_context(root)
         self._ensure_outside_repository(root_path)
         with self._locked_state():
             state = self._read()
             repository = state["repositories"].setdefault(
-                _repository_id(root_path), {"path": str(root_path), "providers": {}}
+                _repository_id(root_path, identity),
+                {"path": str(root_path), "identity": identity, "providers": {}},
             )
             repository["path"] = str(root_path)
+            repository["identity"] = identity
             providers = repository.setdefault("providers", {})
             endpoints = providers.setdefault(family, {})
             if not isinstance(endpoints, dict):
                 raise PrivacyStoreError("privacy state contains an invalid endpoint grants table")
             endpoints[endpoint_identity] = {"granted_at": datetime.now(timezone.utc).isoformat()}
+            _require_same_repository_identity(root_path, identity)
             self._write(state)
 
     def revoke(self, root: Path | str, provider: str | None = None) -> None:
         """Revoke one provider grant, or all grants for a repository."""
 
-        root_path = self._root(root)
+        root_path, identity = self._repository_context(root)
         self._ensure_outside_repository(root_path)
         with self._locked_state():
             state = self._read()
-            repository_id = _repository_id(root_path)
+            repository_id = _repository_id(root_path, identity)
             if provider is None:
                 state["repositories"].pop(repository_id, None)
             else:
@@ -216,6 +224,7 @@ class PrivacyStore:
                         providers.pop(family, None)
                         if not providers:
                             state["repositories"].pop(repository_id, None)
+            _require_same_repository_identity(root_path, identity)
             self._write(state)
 
     def is_allowed(
@@ -232,12 +241,13 @@ class PrivacyStore:
         if endpoint is None:
             return False
         endpoint_identity = canonical_endpoint(endpoint)
-        root_path = self._root(root)
+        root_path, identity = self._repository_context(root)
         self._ensure_outside_repository(root_path)
         with self._locked_state():
             state = self._read()
-        entry = state["repositories"].get(_repository_id(root_path), {})
-        if entry.get("path") != str(root_path):
+        _require_same_repository_identity(root_path, identity)
+        entry = state["repositories"].get(_repository_id(root_path, identity), {})
+        if not _entry_matches(entry, root_path, identity):
             return False
         providers = entry.get("providers", {})
         if not isinstance(providers, dict):
@@ -248,14 +258,25 @@ class PrivacyStore:
         return endpoint_identity in endpoints
 
     @staticmethod
-    def _root(root: Path | str) -> Path:
+    def _repository_context(root: Path | str) -> tuple[Path, dict[str, object]]:
         try:
-            path = Path(root).expanduser().resolve(strict=True)
+            supplied = Path(root).expanduser().absolute()
+            supplied_metadata = supplied.lstat()
+            path = supplied.resolve(strict=True)
+            metadata = path.lstat()
         except (OSError, RuntimeError) as exc:
             raise PrivacyStoreError(f"repository root cannot be resolved: {root}") from exc
-        if not path.is_dir():
+        if (
+            stat.S_ISLNK(supplied_metadata.st_mode)
+            or _is_reparse_point(supplied_metadata)
+            or not stat.S_ISDIR(supplied_metadata.st_mode)
+            or not stat.S_ISDIR(metadata.st_mode)
+        ):
             raise PrivacyStoreError(f"repository root is not a directory: {path}")
-        return path
+        if not _same_identity(supplied_metadata, metadata):
+            raise PrivacyStoreError("repository root changed while its identity was inspected")
+        identity = _repository_identity(path, metadata)
+        return path, identity
 
     def _ensure_outside_repository(self, root: Path) -> None:
         state_path = self.path.expanduser().resolve(strict=False)
@@ -297,12 +318,12 @@ class PrivacyStore:
     def _read(self) -> dict[str, Any]:
         path = self.path.expanduser()
         if not path.exists():
-            return {"version": 2, "repositories": {}}
+            return {"version": _STATE_VERSION, "repositories": {}}
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise PrivacyStoreError(f"cannot read privacy state {path}: {exc}") from exc
-        if not isinstance(data, dict) or data.get("version") not in {1, 2}:
+        if not isinstance(data, dict) or data.get("version") not in {1, 2, _STATE_VERSION}:
             raise PrivacyStoreError("privacy state has an unsupported format")
         repositories = data.get("repositories")
         if not isinstance(repositories, dict):
@@ -313,21 +334,16 @@ class PrivacyStore:
             providers = repository.get("providers", {})
             if not isinstance(providers, dict):
                 raise PrivacyStoreError("privacy state contains an invalid providers table")
-        if data.get("version") == 1:
-            # Family-only grants cannot be safely attached to the endpoint that
-            # happens to be configured during an upgrade.  Migrate fail-closed;
-            # the next explicit grant writes a v2 endpoint-bound record.
-            return {
-                "version": 2,
-                "repositories": {
-                    repository_id: {
-                        "path": repository.get("path", ""),
-                        "providers": {},
-                    }
-                    for repository_id, repository in repositories.items()
-                },
-            }
+        if data.get("version") in {1, 2}:
+            # Older grants were bound only to a path (and v1 only to a provider
+            # family). They cannot be safely attached to the repository object
+            # currently occupying that path, so migration deliberately drops them.
+            return {"version": _STATE_VERSION, "repositories": {}}
         for repository in repositories.values():
+            if not isinstance(repository.get("path"), str) or not _valid_repository_identity(
+                repository.get("identity")
+            ):
+                raise PrivacyStoreError("privacy state contains an invalid repository identity")
             providers = repository.get("providers", {})
             for endpoints in providers.values():
                 if not isinstance(endpoints, dict):
@@ -376,8 +392,108 @@ class PrivacyStore:
             raise PrivacyStoreError(f"cannot write privacy state {path}: {exc}") from exc
 
 
-def _repository_id(root: Path) -> str:
-    return hashlib.sha256(str(root).encode("utf-8")).hexdigest()
+def _is_reparse_point(metadata: os.stat_result) -> bool:
+    return bool(getattr(metadata, "st_file_attributes", 0) & _REPARSE_POINT)
+
+
+def _same_identity(first: os.stat_result, second: os.stat_result) -> bool:
+    return (first.st_dev, first.st_ino) == (second.st_dev, second.st_ino)
+
+
+def _marker_identity(root: Path) -> dict[str, object]:
+    marker = root / ".git"
+    try:
+        metadata = marker.lstat()
+    except FileNotFoundError:
+        return {"kind": "missing"}
+    except OSError as exc:
+        raise PrivacyStoreError("repository marker cannot be inspected") from exc
+    if stat.S_ISLNK(metadata.st_mode) or _is_reparse_point(metadata):
+        kind = "link"
+    elif stat.S_ISDIR(metadata.st_mode):
+        kind = "directory"
+    elif stat.S_ISREG(metadata.st_mode):
+        kind = "file"
+    else:
+        kind = "special"
+    return {
+        "kind": kind,
+        "device": str(metadata.st_dev),
+        "inode": str(metadata.st_ino),
+    }
+
+
+def _repository_identity(
+    root: Path,
+    metadata: os.stat_result | None = None,
+) -> dict[str, object]:
+    before = metadata if metadata is not None else root.lstat()
+    marker = _marker_identity(root)
+    try:
+        after = root.lstat()
+        marker_after = _marker_identity(root)
+    except OSError as exc:
+        raise PrivacyStoreError("repository identity changed while it was inspected") from exc
+    if (
+        not stat.S_ISDIR(after.st_mode)
+        or _is_reparse_point(after)
+        or not _same_identity(before, after)
+        or marker != marker_after
+    ):
+        raise PrivacyStoreError("repository identity changed while it was inspected")
+    return {
+        "root_device": str(after.st_dev),
+        "root_inode": str(after.st_ino),
+        "git_marker": marker,
+    }
+
+
+def _valid_repository_identity(value: object) -> bool:
+    if not isinstance(value, dict) or set(value) != {
+        "root_device",
+        "root_inode",
+        "git_marker",
+    }:
+        return False
+    if not all(isinstance(value[key], str) and value[key] for key in ("root_device", "root_inode")):
+        return False
+    marker = value["git_marker"]
+    if not isinstance(marker, dict) or marker.get("kind") not in {
+        "missing",
+        "directory",
+        "file",
+        "link",
+        "special",
+    }:
+        return False
+    if marker["kind"] == "missing":
+        return set(marker) == {"kind"}
+    return set(marker) == {"kind", "device", "inode"} and all(
+        isinstance(marker[key], str) and marker[key] for key in ("device", "inode")
+    )
+
+
+def _require_same_repository_identity(root: Path, expected: Mapping[str, object]) -> None:
+    if _repository_identity(root) != expected:
+        raise PrivacyStoreError("repository identity changed before consent state was written")
+
+
+def _entry_matches(entry: object, root: Path, identity: Mapping[str, object]) -> bool:
+    return (
+        isinstance(entry, dict)
+        and entry.get("path") == str(root)
+        and entry.get("identity") == identity
+    )
+
+
+def _repository_id(root: Path, identity: Mapping[str, object]) -> str:
+    payload = json.dumps(
+        {"path": os.path.normcase(str(root)), "identity": identity},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8", errors="surrogatepass")).hexdigest()
 
 
 def require_provider_consent(

--- a/src/repolocus/security/redaction.py
+++ b/src/repolocus/security/redaction.py
@@ -2,90 +2,35 @@
 
 from __future__ import annotations
 
-import re
-from collections.abc import Callable
-
-REDACTION_MARKER = "[REDACTED]"
-
-_PRIVATE_KEY = re.compile(
-    r"-----BEGIN(?: [A-Z0-9]+)* PRIVATE KEY-----.*?"
-    r"-----END(?: [A-Z0-9]+)* PRIVATE KEY-----",
-    re.DOTALL,
-)
-_ASSIGNMENT = re.compile(
-    r"(?P<prefix>[\"']?(?:api[_-]?key|access[_-]?key|secret(?:[_-]?key)?|"
-    r"auth[_-]?token|access[_-]?token|refresh[_-]?token|password|passwd|hf[_-]?token|"
-    r"database[_-]?url|db[_-]?url|dsn)"
-    r"[\"']?\s*[:=]\s*)"
-    r"(?:(?P<quote>[\"'])(?P<quoted>.*?)(?P=quote)|(?P<bare>[^\s,;#}]+))",
-    re.IGNORECASE,
-)
-_URL_PASSWORD = re.compile(
-    r"(?P<prefix>[a-z][a-z0-9+.-]*://[^\s/:@]+:)(?P<secret>[^\s/@]+)(?=@)",
-    re.IGNORECASE,
-)
-_BEARER = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}")
-_KNOWN_TOKENS = re.compile(
-    r"(?:"
-    r"sk-(?:ant-)?[A-Za-z0-9_-]{16,}|"
-    r"github_pat_[A-Za-z0-9_]{20,}|"
-    r"hf_[A-Za-z0-9]{20,}|"
-    r"gh[pousr]_[A-Za-z0-9]{20,}|"
-    r"AKIA[0-9A-Z]{16}|"
-    r"AIza[0-9A-Za-z_-]{30,}|"
-    r"xox[baprs]-[A-Za-z0-9-]{10,}"
-    r")"
+from .secrets import (
+    REDACTION_MARKER,
+    contains_likely_secret,
+    redact_likely_secrets,
 )
 
 
 def redact_secrets(text: str) -> tuple[str, int]:
     """Return redacted text and the number of likely credential matches."""
 
-    return redact_secrets_with_count(text)
+    return redact_likely_secrets(text)
 
 
 def redact_text(text: str) -> str:
     """Return only the redacted text for presentation-oriented callers."""
 
-    return redact_secrets_with_count(text)[0]
+    return redact_likely_secrets(text)[0]
 
 
 def redact_secrets_with_count(text: str) -> tuple[str, int]:
     """Return redacted text and the number of matched secret occurrences."""
 
-    if not isinstance(text, str):
-        raise TypeError("text must be a string")
-    count = 0
-
-    def replace(pattern: re.Pattern[str], value: str, repl: Callable[[re.Match[str]], str]) -> str:
-        nonlocal count
-
-        def counted(match: re.Match[str]) -> str:
-            nonlocal count
-            count += 1
-            return repl(match)
-
-        return pattern.sub(counted, value)
-
-    redacted = replace(_PRIVATE_KEY, text, lambda _match: REDACTION_MARKER)
-
-    def assignment_replacement(match: re.Match[str]) -> str:
-        quote = match.group("quote") or ""
-        return f"{match.group('prefix')}{quote}{REDACTION_MARKER}{quote}"
-
-    redacted = replace(_ASSIGNMENT, redacted, assignment_replacement)
-    redacted = replace(
-        _URL_PASSWORD,
-        redacted,
-        lambda match: f"{match.group('prefix')}{REDACTION_MARKER}",
-    )
-    redacted = replace(_BEARER, redacted, lambda _match: f"Bearer {REDACTION_MARKER}")
-    redacted = replace(_KNOWN_TOKENS, redacted, lambda _match: REDACTION_MARKER)
-    return redacted, count
+    return redact_likely_secrets(text)
 
 
-def contains_likely_secret(text: str) -> bool:
-    """Return whether redaction would change ``text``."""
-
-    _, count = redact_secrets_with_count(text)
-    return count > 0
+__all__ = [
+    "REDACTION_MARKER",
+    "contains_likely_secret",
+    "redact_secrets",
+    "redact_secrets_with_count",
+    "redact_text",
+]

--- a/src/repolocus/security/secrets.py
+++ b/src/repolocus/security/secrets.py
@@ -1,0 +1,239 @@
+"""Shared typed detection and redaction of likely credentials.
+
+The repository scanner and provider boundary intentionally use this single
+rule set.  Scanner callers can restrict matches to high-confidence values,
+while transport redaction also covers contextual assignments.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Literal
+
+REDACTION_MARKER = "[REDACTED]"
+
+SecretConfidence = Literal["contextual", "high"]
+
+
+@dataclass(frozen=True, slots=True)
+class SecretMatch:
+    """Location and classification of a secret without retaining its value."""
+
+    kind: str
+    start: int
+    end: int
+    confidence: SecretConfidence
+
+
+_PRIVATE_KEY = re.compile(
+    r"(?P<secret>-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY(?: BLOCK)?-----.*?"
+    r"(?:-----END (?:[A-Z0-9]+ )*PRIVATE KEY(?: BLOCK)?-----|\Z))",
+    re.IGNORECASE | re.DOTALL,
+)
+_HIGH_CONFIDENCE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("private_key", _PRIVATE_KEY),
+    ("aws_access_key", re.compile(r"\b(?P<secret>(?:AKIA|ASIA)[0-9A-Z]{16})\b", re.IGNORECASE)),
+    (
+        "github_token",
+        re.compile(r"\b(?P<secret>gh[pousr]_[A-Za-z0-9]{20,})\b", re.IGNORECASE),
+    ),
+    (
+        "github_fine_grained_token",
+        re.compile(r"\b(?P<secret>github_pat_[A-Za-z0-9_]{20,})\b", re.IGNORECASE),
+    ),
+    (
+        "gitlab_token",
+        re.compile(r"\b(?P<secret>glpat-[A-Za-z0-9_-]{20,})\b", re.IGNORECASE),
+    ),
+    (
+        "slack_token",
+        re.compile(r"\b(?P<secret>xox[baprs]-[A-Za-z0-9-]{10,})\b", re.IGNORECASE),
+    ),
+    (
+        "google_api_key",
+        re.compile(r"\b(?P<secret>AIza[0-9A-Za-z_-]{30,})\b", re.IGNORECASE),
+    ),
+    (
+        "provider_api_key",
+        re.compile(
+            r"\b(?P<secret>sk-(?:(?:proj|svcacct|ant)-)?[A-Za-z0-9_-]{16,})\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "hugging_face_token",
+        re.compile(r"\b(?P<secret>hf_[A-Za-z0-9]{20,})\b", re.IGNORECASE),
+    ),
+    (
+        "stripe_live_key",
+        re.compile(r"\b(?P<secret>(?:sk|rk)_live_[A-Za-z0-9]{16,})\b", re.IGNORECASE),
+    ),
+    (
+        "jwt",
+        re.compile(
+            r"\b(?P<secret>eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\."
+            r"[A-Za-z0-9_-]{8,})\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+_URL_PASSWORD = re.compile(
+    r"[a-z][a-z0-9+.-]*://[^\s/:@]+:(?P<secret>[^\s/@]+)(?=@)",
+    re.IGNORECASE,
+)
+_BEARER = re.compile(r"(?i)\bBearer\s+(?P<secret>[A-Za-z0-9._~+/=-]{12,})")
+_ASSIGNMENT_NAMES = (
+    r"password|passwd|pwd|secret(?:[_-]?key)?|client[_-]?secret|api[_-]?key|"
+    r"access[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|"
+    r"private[_-]?key|hf[_-]?token|database[_-]?url|db[_-]?url|dsn"
+)
+_QUOTED_ASSIGNMENT = re.compile(
+    rf"(?im)[\"']?(?:{_ASSIGNMENT_NAMES})[\"']?\s*[:=]\s*(?:[rubf]{{0,2}})"
+    r"(?P<quote>[\"'])(?P<secret>[^\r\n\"']*)(?P=quote)"
+)
+_BARE_ASSIGNMENT = re.compile(
+    rf"(?im)^[ \t]*(?:export\s+)?(?:{_ASSIGNMENT_NAMES})\s*[:=]\s*"
+    r"(?P<secret>(?![\"'])[^\s#;,}]+)"
+)
+_PLACEHOLDER_FRAGMENTS = (
+    "${",
+    "{{",
+    "<your",
+    "changeme",
+    "change_me",
+    "dummy",
+    "example",
+    "fake",
+    "env.get",
+    "getenv",
+    "os.environ",
+    "placeholder",
+    "process.env",
+    "redacted",
+    "replace_me",
+    "sample",
+    "your_",
+)
+
+
+def _entropy(value: str) -> float:
+    counts = Counter(value)
+    length = len(value)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())
+
+
+def _plausible_assigned_secret(value: str) -> bool:
+    stripped = value.strip()
+    lowered = stripped.casefold()
+    if len(stripped) < 8 or len(stripped) > 4_096:
+        return False
+    if any(fragment in lowered for fragment in _PLACEHOLDER_FRAGMENTS):
+        return False
+    if lowered in {"password", "secret", "undefined", "none", "null"}:
+        return False
+    if len(set(stripped)) <= 2:
+        return False
+    return _entropy(stripped) >= 2.5
+
+
+def _match_from_group(
+    kind: str,
+    match: re.Match[str],
+    confidence: SecretConfidence,
+) -> SecretMatch | None:
+    start, end = match.span("secret")
+    if start == end:
+        return None
+    return SecretMatch(kind, start, end, confidence)
+
+
+def _normalise_matches(matches: list[SecretMatch]) -> tuple[SecretMatch, ...]:
+    """Collapse overlapping rules so each transported occurrence is counted once."""
+
+    ordered = sorted(matches, key=lambda item: (item.start, -item.end, item.kind))
+    normalised: list[SecretMatch] = []
+    for candidate in ordered:
+        if not normalised or candidate.start >= normalised[-1].end:
+            normalised.append(candidate)
+            continue
+        previous = normalised[-1]
+        confidence: SecretConfidence = (
+            "high" if "high" in {previous.confidence, candidate.confidence} else "contextual"
+        )
+        kind = candidate.kind if candidate.confidence == "high" else previous.kind
+        normalised[-1] = SecretMatch(
+            kind=kind,
+            start=previous.start,
+            end=max(previous.end, candidate.end),
+            confidence=confidence,
+        )
+    return tuple(normalised)
+
+
+def find_likely_secrets(text: str) -> tuple[SecretMatch, ...]:
+    """Return non-overlapping typed matches without exposing their values."""
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    matches: list[SecretMatch] = []
+    for kind, pattern in _HIGH_CONFIDENCE_PATTERNS:
+        matches.extend(
+            candidate
+            for match in pattern.finditer(text)
+            if (candidate := _match_from_group(kind, match, "high")) is not None
+        )
+    for kind, pattern in (("url_password", _URL_PASSWORD), ("bearer_token", _BEARER)):
+        for match in pattern.finditer(text):
+            if match.group("secret") == REDACTION_MARKER:
+                continue
+            candidate = _match_from_group(kind, match, "high")
+            if candidate is not None:
+                matches.append(candidate)
+    for pattern in (_QUOTED_ASSIGNMENT, _BARE_ASSIGNMENT):
+        for match in pattern.finditer(text):
+            value = match.group("secret")
+            if value.strip() == REDACTION_MARKER:
+                continue
+            confidence: SecretConfidence = (
+                "high" if _plausible_assigned_secret(value) else "contextual"
+            )
+            candidate = _match_from_group("credential_assignment", match, confidence)
+            if candidate is not None:
+                matches.append(candidate)
+    return _normalise_matches(matches)
+
+
+def contains_high_confidence_secret(text: str) -> bool:
+    """Return whether scanner-grade, high-confidence evidence is present."""
+
+    return any(match.confidence == "high" for match in find_likely_secrets(text))
+
+
+def contains_likely_secret(text: str) -> bool:
+    """Return whether transport redaction would change ``text``."""
+
+    return bool(find_likely_secrets(text))
+
+
+def redact_likely_secrets(text: str) -> tuple[str, int]:
+    """Redact every shared detector match and return the occurrence count."""
+
+    matches = find_likely_secrets(text)
+    redacted = text
+    for match in reversed(matches):
+        redacted = redacted[: match.start] + REDACTION_MARKER + redacted[match.end :]
+    return redacted, len(matches)
+
+
+__all__ = [
+    "REDACTION_MARKER",
+    "SecretConfidence",
+    "SecretMatch",
+    "contains_high_confidence_secret",
+    "contains_likely_secret",
+    "find_likely_secrets",
+    "redact_likely_secrets",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
+from urllib.parse import unquote
 
 from typer.testing import CliRunner
 
@@ -230,6 +232,43 @@ def test_generated_output_migrates_the_pre_rename_marker(
     generated = output.read_text(encoding="utf-8")
     assert "Generator: RepoLocus" in generated
     assert "Generator: DevPilot" not in generated
+
+
+def test_generated_commands_require_markdown_outputs_and_fix_nested_links(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    rejected = runner.invoke(
+        app,
+        ["map", str(sample_repo), "--output", "generated-map.py"],
+    )
+    mapped = runner.invoke(
+        app,
+        ["map", str(sample_repo), "--output", "docs/generated/PROJECT_MAP.md"],
+    )
+    diagrammed = runner.invoke(
+        app,
+        ["diagram", str(sample_repo), "--output", "docs/generated/ARCHITECTURE.md"],
+    )
+
+    assert rejected.exit_code == 1
+    assert "must use a Markdown suffix" in rejected.output
+    assert not (sample_repo / "generated-map.py").exists()
+    assert mapped.exit_code == 0, mapped.output
+    project_map = (sample_repo / "docs/generated/PROJECT_MAP.md").read_text(encoding="utf-8")
+    assert "(../../src/demo/config.py#L1)" in project_map
+    assert "Source link base: generated-document-relative" in project_map
+    assert diagrammed.exit_code == 0, diagrammed.output
+    architecture = (sample_repo / "docs/generated/ARCHITECTURE.md").read_text(encoding="utf-8")
+    assert "(../../src/demo/config.py#L1)" in architecture
+    assert "Source links are relative to this generated document." in architecture
+    for output_path, document in (
+        (sample_repo / "docs/generated/PROJECT_MAP.md", project_map),
+        (sample_repo / "docs/generated/ARCHITECTURE.md", architecture),
+    ):
+        match = re.search(r"\(([^)#]+config\.py)#L1\)", document)
+        assert match is not None
+        assert (output_path.parent / unquote(match.group(1))).resolve(strict=True).is_file()
 
 
 def test_privacy_status_defaults_to_no_grants(sample_repo: Path, isolated_user_dirs: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -307,7 +308,7 @@ def test_repository_config_fallback_rejects_intermediate_links(
     external.mkdir()
     (external / "config.toml").write_text("max_file_bytes = 1\n", encoding="utf-8")
     (repo / ".repolocus").symlink_to(external, target_is_directory=True)
-    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0)
+    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0, raising=False)
 
     with pytest.raises(ConfigError, match=r"unsafe link|escapes repository root"):
         Settings.load(repo, environ={}, user_config_path=tmp_path / "missing.toml")
@@ -321,7 +322,7 @@ def test_repository_config_identity_checked_fallback_reads_one_snapshot(
 
     config = tmp_path / ".repolocus.toml"
     config.write_text("max_file_bytes = 7000\n", encoding="utf-8")
-    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0)
+    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0, raising=False)
 
     settings = Settings.load(
         tmp_path,
@@ -330,6 +331,62 @@ def test_repository_config_identity_checked_fallback_reads_one_snapshot(
     )
 
     assert settings.max_file_bytes == 7000
+
+
+def test_repository_config_compares_path_and_handle_metadata_portably(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus import config as config_module
+
+    config = tmp_path / ".repolocus.toml"
+    config.write_text("max_file_bytes = 7000\n", encoding="utf-8")
+    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0, raising=False)
+    original_fstat = config_module.os.fstat
+
+    def windows_like_fstat(descriptor: int) -> SimpleNamespace:
+        metadata = original_fstat(descriptor)
+        return SimpleNamespace(
+            st_mode=metadata.st_mode,
+            st_dev=metadata.st_dev,
+            st_ino=metadata.st_ino,
+            st_size=metadata.st_size,
+            st_mtime_ns=metadata.st_mtime_ns,
+            st_ctime_ns=metadata.st_ctime_ns + 1,
+        )
+
+    monkeypatch.setattr(config_module.os, "fstat", windows_like_fstat)
+
+    settings = Settings.load(
+        tmp_path,
+        environ={},
+        user_config_path=tmp_path / "missing.toml",
+    )
+
+    assert settings.max_file_bytes == 7000
+
+
+def test_repository_config_read_error_after_open_is_reported_as_changed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus import config as config_module
+
+    config = tmp_path / ".repolocus.toml"
+    config.write_text("max_file_bytes = 7000\n", encoding="utf-8")
+    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0, raising=False)
+
+    def fail_read(_descriptor: int) -> bytes:
+        raise OSError(32, "file is in use")
+
+    monkeypatch.setattr(config_module, "_read_config_descriptor", fail_read)
+
+    with pytest.raises(ConfigError, match="changed while being read"):
+        Settings.load(
+            tmp_path,
+            environ={},
+            user_config_path=tmp_path / "missing.toml",
+        )
 
 
 @pytest.mark.parametrize("value", ["sometimes", "", "2"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -333,6 +333,19 @@ def test_repository_config_identity_checked_fallback_reads_one_snapshot(
     assert settings.max_file_bytes == 7000
 
 
+def test_repository_config_does_not_treat_ctrl_z_as_eof(tmp_path: Path) -> None:
+    (tmp_path / ".repolocus.toml").write_bytes(
+        b"max_file_bytes = 7000\r\n\x1aignored_if_read_in_text_mode"
+    )
+
+    with pytest.raises(ConfigError, match="invalid TOML"):
+        Settings.load(
+            tmp_path,
+            environ={},
+            user_config_path=tmp_path / "missing.toml",
+        )
+
+
 def test_repository_config_compares_path_and_handle_metadata_portably(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,12 @@ def test_defaults_are_local_first_and_telemetry_is_off(tmp_path: Path) -> None:
     assert settings.telemetry is False
     assert settings.max_file_bytes == 1_000_000
     assert settings.context_char_budget == 24_000
+    assert settings.max_repository_files == 100_000
+    assert settings.max_repository_bytes == 512_000_000
+    assert settings.max_directory_depth == 64
+    assert settings.max_repository_chunks == 500_000
+    assert settings.max_repository_symbols == 500_000
+    assert settings.max_scan_seconds == 120
     assert settings.query_synonym_map == {}
 
 
@@ -146,6 +152,35 @@ def test_repository_limits_can_only_tighten_user_limits(tmp_path: Path) -> None:
     assert settings.max_file_bytes == 1000
 
 
+def test_repository_scan_budgets_are_tightenable_and_environment_configurable(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".repolocus.toml").write_text(
+        """
+max_repository_files = 20
+max_repository_bytes = 3000
+max_directory_depth = 7
+max_repository_chunks = 80
+max_repository_symbols = 90
+max_scan_seconds = 4
+""",
+        encoding="utf-8",
+    )
+
+    settings = Settings.load(
+        tmp_path,
+        environ={"REPOLOCUS_MAX_REPOSITORY_FILES": "12"},
+        user_config_path=tmp_path / "missing.toml",
+    )
+
+    assert settings.max_repository_files == 12
+    assert settings.max_repository_bytes == 3000
+    assert settings.max_directory_depth == 7
+    assert settings.max_repository_chunks == 80
+    assert settings.max_repository_symbols == 90
+    assert settings.max_scan_seconds == 4
+
+
 @pytest.mark.parametrize("key", ["api_key", "openai_api_key", "access_token", "password"])
 def test_toml_credentials_are_rejected(tmp_path: Path, key: str) -> None:
     config = tmp_path / "config.toml"
@@ -164,6 +199,137 @@ def test_repo_config_symlink_cannot_escape_root(tmp_path: Path) -> None:
 
     with pytest.raises(ConfigError, match="escapes repository root"):
         Settings.load(repo, environ={}, user_config_path=tmp_path / "missing.toml")
+
+
+def test_repository_config_swap_after_open_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus import config as config_module
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = repo / ".repolocus.toml"
+    config.write_text("max_file_bytes = 8000\n", encoding="utf-8")
+    external = tmp_path / "external.toml"
+    external.write_text("max_file_bytes = 1\n", encoding="utf-8")
+    original_read = config_module._read_config_descriptor
+    swapped = False
+
+    def swap_after_read(descriptor: int) -> bytes:
+        nonlocal swapped
+        raw = original_read(descriptor)
+        if not swapped:
+            swapped = True
+            config.rename(repo / "original-config.toml")
+            config.symlink_to(external)
+        return raw
+
+    monkeypatch.setattr(config_module, "_read_config_descriptor", swap_after_read)
+
+    with pytest.raises(ConfigError, match="changed while being read"):
+        Settings.load(repo, environ={}, user_config_path=tmp_path / "missing.toml")
+
+
+def test_pyproject_declaration_and_parse_share_one_pinned_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus import config as config_module
+
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.repolocus]\nmax_file_bytes = 5000\n",
+        encoding="utf-8",
+    )
+    original_read = config_module._read_config_descriptor
+    reads = 0
+
+    def count_read(descriptor: int) -> bytes:
+        nonlocal reads
+        reads += 1
+        return original_read(descriptor)
+
+    monkeypatch.setattr(config_module, "_read_config_descriptor", count_read)
+
+    settings = Settings.load(
+        tmp_path,
+        environ={},
+        user_config_path=tmp_path / "missing.toml",
+    )
+
+    assert settings.max_file_bytes == 5000
+    assert reads == 1
+
+
+def test_repository_config_deleted_after_read_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus import config as config_module
+
+    config = tmp_path / ".repolocus.toml"
+    config.write_text("max_file_bytes = 8000\n", encoding="utf-8")
+    original_read = config_module._read_config_descriptor
+
+    def delete_after_read(descriptor: int) -> bytes:
+        raw = original_read(descriptor)
+        config.unlink()
+        return raw
+
+    monkeypatch.setattr(config_module, "_read_config_descriptor", delete_after_read)
+
+    with pytest.raises(ConfigError, match="changed while being read"):
+        Settings.load(tmp_path, environ={}, user_config_path=tmp_path / "missing.toml")
+
+
+def test_repository_config_path_requires_a_repository_root(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text("max_file_bytes = 8000\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="root is required"):
+        Settings.load(
+            root=None,
+            repo_config_path=config,
+            environ={},
+            user_config_path=tmp_path / "missing.toml",
+        )
+
+
+def test_repository_config_fallback_rejects_intermediate_links(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus import config as config_module
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "config.toml").write_text("max_file_bytes = 1\n", encoding="utf-8")
+    (repo / ".repolocus").symlink_to(external, target_is_directory=True)
+    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0)
+
+    with pytest.raises(ConfigError, match=r"unsafe link|escapes repository root"):
+        Settings.load(repo, environ={}, user_config_path=tmp_path / "missing.toml")
+
+
+def test_repository_config_identity_checked_fallback_reads_one_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus import config as config_module
+
+    config = tmp_path / ".repolocus.toml"
+    config.write_text("max_file_bytes = 7000\n", encoding="utf-8")
+    monkeypatch.setattr(config_module.os, "O_NOFOLLOW", 0)
+
+    settings = Settings.load(
+        tmp_path,
+        environ={},
+        user_config_path=tmp_path / "missing.toml",
+    )
+
+    assert settings.max_file_bytes == 7000
 
 
 @pytest.mark.parametrize("value", ["sometimes", "", "2"])

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -34,6 +34,7 @@ def test_evaluation_reports_complete_ranked_and_no_answer_metrics() -> None:
                 ],
                 "none": [],
                 "miss": [],
+                "spurious": [Evidence("irrelevant.py", 1, 1, "x", 1)],
             }
             return fixtures[question][:limit]
 
@@ -46,17 +47,98 @@ def test_evaluation_reports_complete_ranked_and_no_answer_metrics() -> None:
         },
         {"question": "none", "expected_paths": [], "language": "zh"},
         {"question": "miss", "expected_paths": ["missing.py"], "language": "en"},
+        {"question": "spurious", "expected_paths": [], "language": "zh"},
     ]
 
     outcomes, metrics = _evaluation_script().evaluate_cases(FakeRetrieval(), cases, limit=5)
 
     assert outcomes[0]["all_expected_paths"] is True
     assert outcomes[0]["citation_recall"] == 1.0
-    assert metrics["macro_recall_at_k"] == 0.666667
-    assert metrics["all_expected_paths_rate"] == 0.666667
+    assert outcomes[1]["recall_at_k"] is None
+    assert outcomes[1]["reciprocal_rank"] is None
+    assert outcomes[1]["ndcg_at_k"] is None
+    assert metrics["cases"] == 4
+    assert metrics["answerable_cases"] == 2
+    assert metrics["no_answer_cases"] == 2
+    assert metrics["macro_recall_at_k"] == 0.5
+    assert metrics["mrr"] == 0.5
+    assert metrics["all_expected_paths_rate"] == 0.5
     assert metrics["no_answer_precision"] == 0.5
-    assert metrics["no_answer_accuracy"] == 1.0
+    assert metrics["no_answer_recall"] == 0.5
+    assert metrics["no_answer_f1"] == 0.5
+    assert metrics["no_answer_accuracy"] == 0.5
     assert metrics["by_language"]["en"]["cases"] == 2  # type: ignore[index]
+    assert metrics["by_language"]["zh"]["answerable_cases"] == 0  # type: ignore[index]
+    assert metrics["by_language"]["zh"]["macro_recall_at_k"] is None  # type: ignore[index]
+    assert metrics["by_query_type"]["unspecified"]["cases"] == 4  # type: ignore[index]
+
+
+def test_correct_no_answer_padding_cannot_inflate_answerable_metrics() -> None:
+    class FakeRetrieval:
+        def search(self, question: str, limit: int) -> list[Evidence]:
+            if question == "hit":
+                return [Evidence("answer.py", 1, 1, "answer", 1)][:limit]
+            return []
+
+    answerable = [
+        {"question": "hit", "expected_paths": ["answer.py"]},
+        {"question": "miss", "expected_paths": ["missing.py"]},
+    ]
+    negatives = [
+        {"question": f"meaningful absent question {index}", "expected_paths": []}
+        for index in range(100)
+    ]
+    evaluation = _evaluation_script()
+
+    _, baseline = evaluation.evaluate_cases(FakeRetrieval(), answerable, limit=5)
+    _, padded = evaluation.evaluate_cases(FakeRetrieval(), answerable + negatives, limit=5)
+
+    for metric in (
+        "macro_recall_at_k",
+        "mrr",
+        "mean_ndcg_at_k",
+        "any_expected_path_rate",
+        "all_expected_paths_rate",
+    ):
+        assert padded[metric] == baseline[metric]
+    assert padded["answerable_cases"] == 2
+    assert padded["no_answer_cases"] == 100
+
+
+def test_no_answer_only_cases_do_not_report_retrieval_quality() -> None:
+    class EmptyRetrieval:
+        def search(self, question: str, limit: int) -> list[Evidence]:
+            return []
+
+    _, metrics = _evaluation_script().evaluate_cases(
+        EmptyRetrieval(),
+        [{"question": "meaningful but absent", "expected_paths": [], "language": "en"}],
+        limit=5,
+    )
+
+    assert metrics["answerable_cases"] == 0
+    assert metrics["macro_recall_at_k"] is None
+    assert metrics["mrr"] is None
+    assert metrics["mean_ndcg_at_k"] is None
+    assert metrics["any_expected_path_rate"] is None
+    assert metrics["all_expected_paths_rate"] is None
+    assert metrics["no_answer_recall"] == 1.0
+
+
+def test_spurious_answers_report_zero_no_answer_precision_and_f1() -> None:
+    class SpuriousRetrieval:
+        def search(self, question: str, limit: int) -> list[Evidence]:
+            return [Evidence("wrong.py", 1, 1, "wrong", 1)][:limit]
+
+    _, metrics = _evaluation_script().evaluate_cases(
+        SpuriousRetrieval(),
+        [{"question": "meaningful but absent", "expected_paths": [], "language": "en"}],
+        limit=5,
+    )
+
+    assert metrics["no_answer_precision"] == 0.0
+    assert metrics["no_answer_recall"] == 0.0
+    assert metrics["no_answer_f1"] == 0.0
 
 
 def test_ndcg_penalizes_missing_relevant_results_up_to_cutoff() -> None:
@@ -69,17 +151,21 @@ def test_repository_question_set_keeps_top_five_path_hit_rate(
     isolated_user_dirs: Path,
 ) -> None:
     repository = Path(__file__).resolve().parents[1]
-    cases = json.loads((repository / "evaluation" / "questions.json").read_text(encoding="utf-8"))
+    cases = json.loads(
+        (repository / "evaluation" / "questions.dataset").read_text(encoding="utf-8")
+    )
     RepoLocusService(Settings(model="local")).scan(repository)
 
-    answerable = [case for case in cases if case["expected_paths"]]
-    passed = 0
     with RepositoryIndex.open(repository) as index:
         retrieval = RetrievalEngine(index)
-        for case in answerable:
-            returned = {item.path for item in retrieval.search(case["question"], limit=5)}
-            if returned.intersection(case["expected_paths"]):
-                passed += 1
+        outcomes, metrics = _evaluation_script().evaluate_cases(retrieval, cases, limit=5)
 
     assert len(cases) >= 10
-    assert passed / len(answerable) >= 0.9
+    assert metrics["any_expected_path_rate"] >= 0.9  # type: ignore[operator]
+    assert metrics["macro_recall_at_k"] >= 0.8  # type: ignore[operator]
+    assert metrics["mrr"] >= 0.7  # type: ignore[operator]
+    assert metrics["no_answer_f1"] == 1.0
+    assert metrics["citation_recall"] == 1.0
+    assert metrics["by_language"]["zh"]["macro_recall_at_k"] == 1.0  # type: ignore[index]
+    assert metrics["by_query_type"]["identifier"]["answerable_cases"] >= 1  # type: ignore[index,operator]
+    assert all(outcome["language"] in {"en", "zh"} for outcome in outcomes)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,4 +1,6 @@
+import re
 from pathlib import Path
+from urllib.parse import unquote
 
 from repolocus.generators import MermaidGenerator, ProjectMapGenerator, validate_mermaid
 from repolocus.models import Chunk, Dependency, ScannedFile, ScanResult, ScanStats, Symbol
@@ -96,6 +98,29 @@ def test_mermaid_document_keeps_source_evidence() -> None:
     assert "```mermaid" in document
     assert "## Source evidence" in document
     assert "[src/app/main.py:1](src/app/main.py#L1)" in document
+
+
+def test_nested_generated_documents_use_destination_relative_source_links(tmp_path: Path) -> None:
+    result = _result()
+    result.root = tmp_path
+    for file in result.files:
+        source = tmp_path / file.path
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(file.text or "fixture\n", encoding="utf-8")
+    destination = tmp_path / "docs/generated/output.md"
+    destination.parent.mkdir(parents=True)
+
+    project_map = ProjectMapGenerator().generate(result, destination=destination)
+    diagram = MermaidGenerator().generate(result, destination=destination)
+
+    assert "[src/app/main.py:3](../../src/app/main.py#L3)" in project_map
+    assert "Source link base: generated-document-relative" in project_map
+    assert "[src/app/main.py:1](../../src/app/main.py#L1)" in diagram
+    assert "Source links are relative to this generated document." in diagram
+    for document, line in ((project_map, 3), (diagram, 1)):
+        match = re.search(rf"\[src/app/main\.py:{line}\]\(([^)#]+)#L{line}\)", document)
+        assert match is not None
+        assert (destination.parent / unquote(match.group(1))).resolve(strict=True).is_file()
 
 
 def test_every_mermaid_edge_has_import_evidence() -> None:

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -91,7 +91,7 @@ def test_path_boundary_rejects_a_regular_file_as_root(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "state",
     [
-        {"version": 3, "repositories": {}},
+        {"version": 4, "repositories": {}},
         {"version": 1, "repositories": []},
     ],
 )

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -27,6 +27,7 @@ from repolocus.models import (
     ScanStats,
     Symbol,
 )
+from repolocus.scanner import RepositoryScanner
 
 
 def _file(
@@ -63,6 +64,26 @@ def _file(
 
 def _scan(root: Path, *files: ScannedFile) -> ScanResult:
     return ScanResult(root=root, files=list(files), stats=ScanStats())
+
+
+def test_manifest_snapshot_does_not_materialize_text_or_parser_facts(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    source = _file("app.py", "def main():\n    return 1\n", symbol="main")
+
+    with RepositoryIndex.open(repository, tmp_path / "cache") as index:
+        index.update(_scan(repository, source))
+        snapshot = index.manifest_snapshot()
+
+    assert len(snapshot.files) == 1
+    manifest = snapshot.files[0]
+    assert manifest.path == "app.py"
+    assert manifest.text == ""
+    assert manifest.symbols == ()
+    assert manifest.dependencies == ()
+    assert manifest.chunks == ()
+    assert manifest.cached_symbol_count == 1
+    assert manifest.cached_chunk_count == 1
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions use mode bits")
@@ -177,6 +198,82 @@ def test_incremental_update_round_trip_and_removal(tmp_path: Path) -> None:
     with RepositoryIndex.open(repository, cache) as reopened:
         assert [file.path for file in reopened.get_files()] == ["app.py", "new.py"]
         assert reopened.get_metadata()["last_update_removed"] == "1"
+
+
+def test_manifest_query_never_reads_stored_source_text(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    with RepositoryIndex.open(repository, tmp_path / "cache") as index:
+        index.update(_scan(repository, _file("source.py", "VALUE = 1\n")))
+
+        def deny_text_read(
+            action: int,
+            table: str | None,
+            column: str | None,
+            _database: str | None,
+            _trigger: str | None,
+        ) -> int:
+            if action == sqlite3.SQLITE_READ and table == "files" and column == "text":
+                return sqlite3.SQLITE_DENY
+            return sqlite3.SQLITE_OK
+
+        index._connection.set_authorizer(deny_text_read)
+        try:
+            manifest = index.get_file_manifest()
+        finally:
+            index._connection.set_authorizer(None)
+
+    assert [file.path for file in manifest] == ["source.py"]
+    assert manifest[0].text == ""
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX symlinks")
+def test_directory_replaced_by_symlink_retains_old_facts_as_stale(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    nested = repository / "nested"
+    nested.mkdir(parents=True)
+    (nested / "value.py").write_text("VALUE = 'old'\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "value.py").write_text("VALUE = 'outside'\n", encoding="utf-8")
+    scanner = RepositoryScanner()
+
+    with RepositoryIndex.open(repository, tmp_path / "cache") as index:
+        initial_scan = scanner.scan(repository)
+        initial = index.update(initial_scan)
+        nested.rename(tmp_path / "old-nested")
+        nested.symlink_to(outside, target_is_directory=True)
+
+        changed_scan = scanner.scan(
+            repository,
+            cached_files={file.path: file for file in initial_scan.files},
+            trusted_cache=True,
+            base_generation=initial.generation,
+        )
+        changed = index.update(changed_scan)
+        retained = index.get_files()
+
+    assert "nested" in changed_scan.temporarily_unreadable
+    assert changed.removed == 0
+    assert changed.stale == 1
+    assert [(file.path, file.stale) for file in retained] == [("nested/value.py", True)]
+
+
+def test_scan_commit_rejects_repository_replaced_after_scan(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "old.py").write_text("OLD = 1\n", encoding="utf-8")
+    scan = RepositoryScanner().scan(repository)
+
+    with RepositoryIndex.open(repository, tmp_path / "cache") as index:
+        repository.rename(tmp_path / "old-repository")
+        repository.mkdir()
+        (repository / "new.py").write_text("NEW = 1\n", encoding="utf-8")
+
+        with pytest.raises(StaleScanError, match="identity changed"):
+            index.update(scan)
+
+        assert index.get_files() == []
 
 
 def test_file_text_becomes_fallback_chunk(tmp_path: Path) -> None:
@@ -327,7 +424,8 @@ def test_incomplete_scan_retains_old_facts_as_stale_until_refreshed(tmp_path: Pa
                 base_generation=retained.generation,
             )
         )
-        assert refreshed.unchanged == 1
+        assert refreshed.changed == 1
+        assert refreshed.unchanged == 0
         assert refreshed.stale == 0
         assert index.get_files()[0].stale is False
         assert index.search_chunks("KEEP_ME")[0].chunk.path == "src/keep.py"
@@ -400,17 +498,14 @@ def test_generated_provenance_round_trips_but_is_not_retrieved_by_default(
         assert index.find_symbol_chunks("UNIQUE_GENERATED_ASSERTION") == []
 
 
-def test_v2_index_is_migrated_without_losing_existing_facts(tmp_path: Path) -> None:
+def test_v2_index_migration_invalidates_untrusted_existing_facts(tmp_path: Path) -> None:
     repository = tmp_path / "repository"
     repository.mkdir()
     cache = tmp_path / "cache"
     source = _file("one.py", "VALUE = 1\n")
-    generated = replace(
-        _file(
-            "PROJECT_MAP.md",
-            "# Project Map\n\n<!-- Generator: RepoLocus 0.1.2; deterministic source map. -->\n",
-        ),
-        language="markdown",
+    generated = _file(
+        "renamed-generated.py",
+        "# Project Map\n\n<!-- Generator: RepoLocus 0.1.2; deterministic source map. -->\n",
     )
     prose = replace(
         _file(
@@ -428,26 +523,102 @@ def test_v2_index_is_migrated_without_losing_existing_facts(tmp_path: Path) -> N
     connection.execute("ALTER TABLE files DROP COLUMN provenance")
     connection.execute("DROP TABLE chunk_terms")
     connection.execute("DELETE FROM meta WHERE key = 'generation'")
+    connection.execute("DELETE FROM meta WHERE key = 'repository_identity'")
     connection.execute("UPDATE meta SET value = '2' WHERE key = 'schema_version'")
     connection.execute("UPDATE meta SET value = '2' WHERE key = 'index_format_version'")
     connection.execute("PRAGMA user_version = 2")
     connection.commit()
+    connection.row_factory = sqlite3.Row
+    v2_migrator = object.__new__(RepositoryIndex)
+    v2_migrator._connection = connection
+    v2_migrator._migrate_v2_to_v3()
+    migrated_provenance = {
+        str(row["path"]): str(row["provenance"])
+        for row in connection.execute("SELECT path, provenance FROM files")
+    }
+    assert migrated_provenance["renamed-generated.py"] == "generated"
+    assert migrated_provenance["notes.md"] == "source"
     connection.close()
 
     with RepositoryIndex.open(repository, cache) as migrated:
-        files = {file.path: file for file in migrated.get_files()}
+        metadata = migrated.get_metadata()
 
-        assert files["one.py"].text == source.text
-        assert files["one.py"].provenance == "source"
-        assert files["one.py"].stale is False
-        assert files["PROJECT_MAP.md"].provenance == "generated"
-        assert files["notes.md"].provenance == "source"
-        assert migrated.generation() == 0
-        assert migrated.get_metadata()["schema_version"] == "3"
-        assert migrated.search_chunks("VALUE")[0].chunk.path == "one.py"
+        assert migrated.get_files() == []
+        assert migrated.get_symbols() == []
+        assert migrated.search_chunks("VALUE") == []
+        assert migrated.generation() == 1
+        assert metadata["analysis_version"] == ""
+        assert metadata["schema_version"] == "4"
+        assert metadata["index_format_version"] == "4"
+        assert len(metadata["repository_identity"]) == 64
         indexes = {
             str(row[1]) for row in migrated._connection.execute("PRAGMA index_list('chunk_terms')")
         }
         assert "chunk_terms_chunk_idx" in indexes
         migrated._migrate_v2_to_v3()  # Models a waiter after another migration.
-        assert migrated.get_files()
+        assert migrated.get_files() == []
+
+
+def test_same_path_repository_replacement_invalidates_index_identity(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    cache = tmp_path / "cache"
+    old = _file("old.py", "OLD_REPOSITORY = True\n")
+
+    with RepositoryIndex.open(repository, cache) as index:
+        committed = index.update(_scan(repository, old))
+        old_identity = index.get_metadata()["repository_identity"]
+
+    repository.rename(tmp_path / "old-repository")
+    repository.mkdir()
+
+    with RepositoryIndex.open(repository, cache) as replacement:
+        metadata = replacement.get_metadata()
+
+        assert replacement.get_files() == []
+        assert replacement.search_chunks("OLD_REPOSITORY") == []
+        assert replacement.generation() == committed.generation + 1
+        assert metadata["analysis_version"] == ""
+        assert metadata["repository_identity"] != old_identity
+
+
+def test_restored_stale_file_replaces_same_hash_parser_facts(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    cache = tmp_path / "cache"
+    old = _file("same.py", "VALUE = 1\n", symbol="parser_v1")
+    reparsed = replace(
+        old,
+        symbols=(Symbol("parser_v2", "function", "same.py", 1, 1, "parser_v2"),),
+        chunks=(Chunk("same.py", 1, 1, old.text, "python", "parser_v2"),),
+    )
+
+    with RepositoryIndex.open(repository, cache) as index:
+        first = index.update(
+            ScanResult(repository, [old], ScanStats(), analysis_version="parser-v1")
+        )
+        incomplete = index.update(
+            ScanResult(
+                repository,
+                [],
+                ScanStats(),
+                analysis_version="parser-v2",
+                temporarily_unreadable=("same.py",),
+                base_generation=first.generation,
+            )
+        )
+
+        restored = index.update(
+            ScanResult(
+                repository,
+                [reparsed],
+                ScanStats(),
+                analysis_version="parser-v2",
+                base_generation=incomplete.generation,
+            )
+        )
+
+        assert restored.changed == 1
+        assert restored.unchanged == 0
+        assert [symbol.name for symbol in index.get_symbols()] == ["parser_v2"]
+        assert index.get_files()[0].stale is False

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -360,7 +360,7 @@ def test_provider_requires_json_content_type_and_bounded_json_depth() -> None:
             )
         ),
     )
-    with pytest.raises(ProviderResponseError, match="invalid JSON"):
+    with pytest.raises(ProviderResponseError, match=r"(?:invalid|overly complex) JSON"):
         recursive.generate("System", "Question")
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -13,6 +13,7 @@ from repolocus.providers import (
     OpenAICompatibleProvider,
     ProviderConfigurationError,
     ProviderRequestError,
+    ProviderRequestPlan,
     ProviderResponseError,
     build_provider_request_plan,
     create_provider,
@@ -245,6 +246,143 @@ def test_malformed_provider_response_has_clear_error() -> None:
     )
 
     with pytest.raises(ProviderResponseError, match="missing message"):
+        provider.generate("System", "Question")
+
+
+def test_final_transport_boundary_blocks_a_tampered_secret_body() -> None:
+    requests = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(200, json={"message": {"content": "unexpected"}})
+
+    provider = OllamaProvider("model", transport=httpx.MockTransport(handler))
+    plan = ProviderRequestPlan(
+        "ollama",
+        "model",
+        "http://127.0.0.1:11434/api/chat",
+        json.dumps(
+            {
+                "model": "model",
+                "messages": [
+                    {"role": "user", "content": "ASIA1234567890ABCDEF"},
+                ],
+            }
+        ).encode(),
+    )
+
+    with pytest.raises(ProviderConfigurationError, match="credential-like content"):
+        provider.generate_prepared(plan)
+    assert requests == 0
+
+
+def test_request_plan_reports_redactions_outside_evidence() -> None:
+    plan = build_provider_request_plan(
+        "openai",
+        "model",
+        base_url="https://api.openai.com/v1",
+        system_prompt="System",
+        user_prompt="Check glpat-abcdefghijklmnopqrstuvwxyz1234",
+    )
+
+    assert plan.redaction_count == 1
+    assert b"glpat-" not in plan.body
+
+
+def test_provider_rejects_declared_or_streamed_oversized_responses() -> None:
+    declared = OllamaProvider(
+        "model",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(4 * 1024 * 1024 + 1),
+                },
+                content=b"{}",
+            )
+        ),
+    )
+    with pytest.raises(ProviderResponseError, match="exceeds"):
+        declared.generate("System", "Question")
+
+    class OversizedStream(httpx.SyncByteStream):
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            yield b"{" + b" " * (2 * 1024 * 1024)
+            yield b" " * (2 * 1024 * 1024) + b"}"
+
+    streamed = OllamaProvider(
+        "model",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                headers={"Content-Type": "application/json"},
+                stream=OversizedStream(),
+            )
+        ),
+    )
+    with pytest.raises(ProviderResponseError, match="exceeded"):
+        streamed.generate("System", "Question")
+
+
+def test_provider_requires_json_content_type_and_bounded_json_depth() -> None:
+    wrong_type = OllamaProvider(
+        "model",
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, content=b"{}")),
+    )
+    with pytest.raises(ProviderResponseError, match="content type"):
+        wrong_type.generate("System", "Question")
+
+    nested: object = "content"
+    for _ in range(70):
+        nested = [nested]
+    too_deep = OllamaProvider(
+        "model",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, json={"message": nested})
+        ),
+    )
+    with pytest.raises(ProviderResponseError, match="overly complex"):
+        too_deep.generate("System", "Question")
+
+    recursion_depth = 2_000
+    recursive_body = (
+        b'{"message":' + b"[" * recursion_depth + b'"content"' + b"]" * recursion_depth + b"}"
+    )
+    recursive = OllamaProvider(
+        "model",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                headers={"Content-Type": "application/json"},
+                content=recursive_body,
+            )
+        ),
+    )
+    with pytest.raises(ProviderResponseError, match="invalid JSON"):
+        recursive.generate("System", "Question")
+
+
+def test_provider_rejects_a_response_after_the_elapsed_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.providers import http as provider_http
+
+    readings = iter((10.0, 12.0))
+    monkeypatch.setattr(provider_http, "monotonic", lambda: next(readings))
+    provider = OllamaProvider(
+        "model",
+        timeout=1,
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                json={"message": {"content": "late"}},
+            )
+        ),
+    )
+
+    with pytest.raises(ProviderRequestError, match="elapsed-time deadline"):
         provider.generate("System", "Question")
 
 

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -117,16 +117,85 @@ def test_cjk_subphrases_and_identifier_parts_are_searchable(tmp_path: Path) -> N
     repository.mkdir()
     source = _source(
         "src/httpClient.py",
-        "def loadConfigValue():\n    # 配置在哪里校验\n    return True\n",
+        "def loadConfigValue():\n    # \u8fd9\u91cc\u6267\u884c\u914d\u7f6e"
+        "\u6821\u9a8c\u903b\u8f91\n    return True\n",
         "loadConfigValue",
     )
     with RepositoryIndex.open(repository, tmp_path / "cache") as index:
         index.update(ScanResult(repository, [source], ScanStats()))
         retrieval = RetrievalEngine(index)
 
-        assert retrieval.search("配置", limit=1)[0].path == "src/httpClient.py"
-        assert retrieval.search("校验", limit=1)[0].path == "src/httpClient.py"
+        assert retrieval.search("\u914d\u7f6e", limit=1)[0].path == "src/httpClient.py"
+        assert retrieval.search("\u6821\u9a8c", limit=1)[0].path == "src/httpClient.py"
         assert retrieval.search("http client", limit=1)[0].path == "src/httpClient.py"
+
+
+def test_cjk_rewrite_uses_one_ngram_group_and_keeps_non_cjk_literal_required(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    with_policy = _source(
+        "src/primary.py",
+        "def verify_policy():\n    # \u8fd9\u91cc\u6267\u884c\u914d\u7f6e"
+        "\u6821\u9a8c\u903b\u8f91\n    return policy\n",
+        "verify_policy",
+    )
+    without_policy = _source(
+        "src/secondary.py",
+        "def verify_value():\n    # \u8fd9\u91cc\u6267\u884c\u914d\u7f6e"
+        "\u6821\u9a8c\u903b\u8f91\n    return True\n",
+        "verify_value",
+    )
+    one_overlap_only = _source(
+        "src/distractor.py",
+        "def load_configuration():\n    # \u8fd9\u91cc\u53ea\u8d1f\u8d23\u914d\u7f6e\u5728"
+        "\u52a0\u8f7d\n    return True\n",
+        "load_configuration",
+    )
+    with RepositoryIndex.open(repository, tmp_path / "cache") as index:
+        index.update(
+            ScanResult(
+                repository,
+                [one_overlap_only, with_policy, without_policy],
+                ScanStats(),
+            )
+        )
+
+        cjk_query = "\u914d\u7f6e" + "\u5728\u54ea\u91cc" + "\u6821\u9a8c"
+        rewritten = index.search_chunks(cjk_query, limit=10)
+        mixed = index.search_chunks(cjk_query + " policy", limit=10)
+
+    assert {hit.chunk.path for hit in rewritten} == {
+        "src/primary.py",
+        "src/secondary.py",
+    }
+    assert [hit.chunk.path for hit in mixed] == ["src/primary.py"]
+
+
+def test_expanded_terms_cannot_substitute_for_literal_coverage(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    literal = _source(
+        "src/literal.py",
+        "def literal_match():\n    return configuration and validated\n",
+        "literal_match",
+    )
+    expanded_only = _source(
+        "src/expanded.py",
+        "def expanded_match():\n    return config and validate\n",
+        "expanded_match",
+    )
+    with RepositoryIndex.open(repository, tmp_path / "cache") as index:
+        index.update(ScanResult(repository, [literal, expanded_only], ScanStats()))
+
+        hits = index.search_chunks(
+            "configuration validated",
+            limit=10,
+            synonyms={"configuration": ("config",), "validated": ("validate",)},
+        )
+
+    assert [hit.chunk.path for hit in hits] == ["src/literal.py"]
 
 
 def test_dependency_neighbors_expand_in_both_directions(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -595,6 +595,66 @@ def test_safe_read_keeps_handle_and_path_content_states_linked(
     assert error == "changed_during_scan"
 
 
+@pytest.mark.parametrize(
+    ("mtime_delta", "ctime_delta", "expected_error"),
+    [(0, 1, None), (1, 0, "changed_during_scan")],
+)
+def test_safe_read_revalidates_metadata_collected_after_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mtime_delta: int,
+    ctime_delta: int,
+    expected_error: str | None,
+) -> None:
+    source = _write(tmp_path, "app.py", "VALUE = 1\n")
+    from repolocus.scanner import repository as scanner_repository
+
+    original_close = scanner_repository.os.close
+    original_stat = scanner_repository.os.stat
+    descriptor_closed = False
+
+    def close_and_mark(descriptor: int) -> None:
+        nonlocal descriptor_closed
+        original_close(descriptor)
+        descriptor_closed = True
+
+    def windows_like_stat(path: str | os.PathLike[str], *args, **kwargs):  # type: ignore[no-untyped-def]
+        metadata = original_stat(path, *args, **kwargs)
+        if not descriptor_closed or Path(path) != source:
+            return metadata
+        return SimpleNamespace(
+            st_mode=metadata.st_mode,
+            st_dev=metadata.st_dev,
+            st_ino=metadata.st_ino,
+            st_size=metadata.st_size,
+            st_mtime_ns=metadata.st_mtime_ns + mtime_delta,
+            st_ctime_ns=metadata.st_ctime_ns + ctime_delta,
+        )
+
+    monkeypatch.setattr(scanner_repository, "_IS_WINDOWS", True)
+    monkeypatch.setattr(scanner_repository.os, "close", close_and_mark)
+    monkeypatch.setattr(scanner_repository.os, "stat", windows_like_stat)
+    expected = source.lstat()
+
+    payload, returned_metadata, reason = scanner_repository._safe_read_at(
+        source.name,
+        100,
+        expected,
+        directory=tmp_path,
+        directory_fd=None,
+    )
+
+    if expected_error is not None:
+        assert payload is None
+        assert returned_metadata is None
+        assert reason == expected_error
+    else:
+        assert payload == b"VALUE = 1\n"
+        assert reason is None
+        assert returned_metadata is not None
+        assert returned_metadata.st_ctime_ns == expected.st_ctime_ns + ctime_delta
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows file identity semantics")
 def test_windows_path_and_handle_metadata_are_compared_consistently(tmp_path: Path) -> None:
     _write(tmp_path, ".gitignore", "*.tmp\n")
@@ -763,6 +823,9 @@ def test_trusted_incremental_cache_skips_unchanged_file_reads(
     source = _write(tmp_path, "one.py", "VALUE = 1\n")
     scanner = RepositoryScanner()
     first = scanner.scan(tmp_path)
+    settled = source.lstat()
+    assert first.files[0].mtime_ns == settled.st_mtime_ns
+    assert first.files[0].ctime_ns == settled.st_ctime_ns
     from repolocus.scanner import repository as scanner_repository
 
     original_read = scanner_repository._safe_read_at

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -14,6 +15,7 @@ from repolocus.scanner import (
     contains_likely_secret,
     detect_language,
     is_binary,
+    is_generated_document,
     is_sensitive_path,
 )
 
@@ -188,6 +190,24 @@ def test_repolocus_and_legacy_generated_markdown_are_excluded(tmp_path: Path) ->
     assert result.stats.skipped["generated"] == 3
 
 
+def test_generated_marker_is_extension_independent_and_strictly_bounded(
+    tmp_path: Path,
+) -> None:
+    marker = "<!-- Generator: RepoLocus 0.1.3; deterministic source map. -->"
+    _write(tmp_path, "renamed.py", marker + "\nself_derived = True\n")
+    _write(tmp_path, "line-16.py", ("# padding\n" * 15) + marker + "\n")
+    _write(tmp_path, "line-17.py", ("# padding\n" * 16) + marker + "\n")
+
+    result = RepositoryScanner().scan(tmp_path)
+
+    assert [file.path for file in result.files] == ["line-17.py"]
+    assert result.stats.skipped["generated"] == 2
+    assert is_generated_document(("x\n" * 16) + marker) is False
+    assert is_generated_document((" " * 4096) + marker) is False
+    assert is_generated_document(("界" * 1400) + "\n" + marker) is False
+    assert is_generated_document("Generator: RepoLocus; deterministic source map.") is False
+
+
 def test_secret_detection_is_reapplied_before_cached_fact_reuse(tmp_path: Path) -> None:
     text = 'api_key = "sk-abcdefghijklmnopqrstuvwxyz1234"\n'
     source = _write(tmp_path, "settings.py", text)
@@ -207,6 +227,22 @@ def test_secret_detection_is_reapplied_before_cached_fact_reuse(tmp_path: Path) 
 
     assert result.files == []
     assert result.stats.skipped == {"likely_secret": 1}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="dir_fd/openat is POSIX-only")
+def test_dirfd_reads_do_not_require_linux_proc_descriptor_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _write(tmp_path, "value.py", "VALUE = 1\n")
+    from repolocus.scanner import repository as scanner_repository
+
+    if not scanner_repository._USE_DIRECTORY_FDS:
+        pytest.skip("directory descriptor traversal is unavailable")
+    monkeypatch.setattr(scanner_repository, "descriptor_path", lambda _descriptor: None)
+
+    result = RepositoryScanner().scan(tmp_path)
+
+    assert [(file.path, file.text) for file in result.files] == [(source.name, "VALUE = 1\n")]
 
 
 @pytest.mark.skipif(os.name != "posix", reason="dir_fd/openat is POSIX-only")
@@ -242,6 +278,244 @@ def test_directory_swap_to_outside_symlink_is_never_followed(
     assert result.files == []
     assert result.temporarily_unreadable == ("nested",)
     assert all("stolen-outside" not in warning for warning in result.warnings)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="dir_fd/openat is POSIX-only")
+def test_open_directory_rename_and_replacement_marks_subtree_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = tmp_path / "repo"
+    nested = repository / "nested"
+    nested.mkdir(parents=True)
+    _write(repository, "nested/value.py", "VALUE = 'old'\n")
+    scanner = RepositoryScanner()
+    baseline = scanner.scan(repository)
+    cached = {file.path: file for file in baseline.files}
+    from repolocus.scanner import repository as scanner_repository
+
+    if not scanner_repository._USE_DIRECTORY_FDS:
+        pytest.skip("directory descriptor traversal is unavailable")
+    original_open_directory = scanner_repository._open_directory_at
+    swapped = False
+
+    def swap_after_open(
+        name: str, expected: os.stat_result, directory_fd: int
+    ) -> tuple[int | None, str | None]:
+        nonlocal swapped
+        descriptor, reason = original_open_directory(name, expected, directory_fd)
+        if name == "nested" and descriptor is not None and not swapped:
+            swapped = True
+            nested.rename(repository / "detached-nested")
+            nested.mkdir()
+            _write(repository, "nested/value.py", "VALUE = 'replacement'\n")
+        return descriptor, reason
+
+    monkeypatch.setattr(scanner_repository, "_open_directory_at", swap_after_open)
+
+    result = scanner.scan(
+        repository,
+        cached_files=cached,
+        trusted_cache=True,
+        base_generation=1,
+    )
+
+    assert swapped
+    assert result.files == []
+    assert result.temporarily_unreadable == ("nested",)
+    assert result.stats.skipped == {"changed_during_scan": 1}
+    assert result.warnings == ["directory changed during scan: nested"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX symlinks")
+def test_path_based_walk_revalidates_directory_before_loading_ignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = tmp_path / "repo"
+    nested = repository / "nested"
+    nested.mkdir(parents=True)
+    _write(repository, "nested/value.py", "VALUE = 'inside'\n")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _write(outside, ".gitignore", "!\n")
+    _write(outside, "value.py", "VALUE = 'stolen-outside'\n")
+    scanner = RepositoryScanner()
+    baseline = scanner.scan(repository)
+    cached = {item.path: item for item in baseline.files}
+
+    from repolocus.scanner import repository as scanner_repository
+
+    monkeypatch.setattr(scanner_repository, "_USE_DIRECTORY_FDS", False)
+    original_resolve = Path.resolve
+    original_safe_read_at = scanner_repository._safe_read_at
+    swapped = False
+    ignore_reads: list[Path] = []
+
+    def swap_after_resolve(path: Path, strict: bool = False) -> Path:
+        nonlocal swapped
+        resolved = original_resolve(path, strict=strict)
+        if path == nested and strict and not swapped:
+            swapped = True
+            nested.rename(repository / "original-nested")
+            nested.symlink_to(outside, target_is_directory=True)
+        return resolved
+
+    def track_safe_read(
+        name: str,
+        limit: int,
+        expected: os.stat_result,
+        *,
+        directory: Path,
+        directory_fd: int | None,
+        root: Path | None = None,
+    ) -> tuple[bytes | None, os.stat_result | None, str | None]:
+        if name == ".gitignore":
+            ignore_reads.append(directory)
+        return original_safe_read_at(
+            name,
+            limit,
+            expected,
+            directory=directory,
+            directory_fd=directory_fd,
+            root=root,
+        )
+
+    monkeypatch.setattr(Path, "resolve", swap_after_resolve)
+    monkeypatch.setattr(scanner_repository, "_safe_read_at", track_safe_read)
+
+    result = scanner.scan(repository, cached_files=cached)
+
+    assert swapped
+    assert ignore_reads == []
+    assert result.files == []
+    assert result.stats.skipped == {"changed_during_scan": 1}
+    assert result.temporarily_unreadable == ("nested",)
+    assert result.warnings == ["directory changed during scan: nested"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX descriptor paths")
+def test_path_based_ignore_open_verifies_the_opened_file_is_inside_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository = tmp_path / "repo"
+    nested = repository / "nested"
+    nested.mkdir(parents=True)
+    _write(repository, "nested/value.py", "VALUE = 'inside'\n")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _write(outside, ".gitignore", "*.py\n")
+    _write(outside, "value.py", "VALUE = 'outside'\n")
+    from repolocus.scanner import repository as scanner_repository
+
+    monkeypatch.setattr(scanner_repository, "_USE_DIRECTORY_FDS", False)
+    original_load = RepositoryScanner._load_local_ignore
+    original_read = scanner_repository._read_descriptor
+    payload_reads = 0
+    swapped = False
+
+    def swap_before_ignore_open(self, root, directory, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal swapped
+        if directory == nested and not swapped:
+            swapped = True
+            nested.rename(tmp_path / "old-nested")
+            nested.symlink_to(outside, target_is_directory=True)
+        return original_load(self, root, directory, *args, **kwargs)
+
+    def count_payload_reads(descriptor: int, limit: int):  # type: ignore[no-untyped-def]
+        nonlocal payload_reads
+        payload_reads += 1
+        return original_read(descriptor, limit)
+
+    monkeypatch.setattr(RepositoryScanner, "_load_local_ignore", swap_before_ignore_open)
+    monkeypatch.setattr(scanner_repository, "_read_descriptor", count_payload_reads)
+
+    result = RepositoryScanner().scan(repository)
+
+    assert swapped
+    assert payload_reads == 0
+    assert result.files == []
+    assert result.temporarily_unreadable == ("nested",)
+
+
+def test_empty_directory_deadline_is_checked_after_enumeration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.scanner import repository as scanner_repository
+
+    now = [0.0]
+    original_scandir = scanner_repository.os.scandir
+
+    class TimedScandir:
+        def __init__(self, target: int | Path) -> None:
+            self.iterator = original_scandir(target)
+
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self.iterator.__enter__()
+
+        def __exit__(self, *args):  # type: ignore[no-untyped-def]
+            result = self.iterator.__exit__(*args)
+            now[0] = 2.0
+            return result
+
+    monkeypatch.setattr(scanner_repository, "monotonic", lambda: now[0])
+    monkeypatch.setattr(scanner_repository.os, "scandir", TimedScandir)
+
+    result = RepositoryScanner(max_scan_seconds=1).scan(tmp_path)
+
+    assert result.temporarily_unreadable == (".",)
+    assert result.stats.skipped["repository_budget"] == 1
+    assert any("scan deadline" in warning for warning in result.warnings)
+
+
+def test_directory_rollback_preserves_a_global_budget_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.scanner import repository as scanner_repository
+
+    _write(tmp_path, "nested/a.py", "VALUE = 1\n")
+    _write(tmp_path, "nested/b.py", "VALUE = 2\n")
+    changed = False
+
+    class ChangeAfterSecondParse:
+        languages = frozenset({"python"})
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def parse(
+            self,
+            path: str,
+            text: str,
+            language: str,
+            **_kwargs: object,
+        ) -> ParseResult:
+            nonlocal changed
+            self.calls += 1
+            if self.calls == 2:
+                changed = True
+            return ParseResult(chunks=(Chunk(path, 1, 1, text.rstrip(), language),))
+
+    parser = ChangeAfterSecondParse()
+    registry = ParserRegistry()
+    registry.register(parser)
+    monkeypatch.setattr(scanner_repository, "_USE_DIRECTORY_FDS", False)
+    monkeypatch.setattr(
+        scanner_repository,
+        "_is_stable_unpinned_directory",
+        lambda *_args, **_kwargs: not changed,
+    )
+
+    result = RepositoryScanner(
+        parser_registry=registry,
+        max_repository_chunks=1,
+    ).scan(tmp_path)
+
+    assert result.files == []
+    assert result.stats.skipped["changed_during_scan"] == 1
+    assert result.stats.skipped["repository_budget"] == 1
+    assert result.temporarily_unreadable == (".",)
+    assert any("chunk count" in warning for warning in result.warnings)
 
 
 def test_windows_reparse_attribute_is_explicitly_recognized() -> None:
@@ -468,6 +742,139 @@ def test_unchanged_files_reuse_versioned_parser_results(tmp_path: Path) -> None:
     assert first.analysis_version == "counting-v1:lines=160:chars=16000"
 
 
+def test_trusted_incremental_cache_skips_unchanged_file_reads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write(tmp_path, "one.py", "VALUE = 1\n")
+    scanner = RepositoryScanner()
+    first = scanner.scan(tmp_path)
+    from repolocus.scanner import repository as scanner_repository
+
+    original_read = scanner_repository._safe_read_at
+
+    def reject_source_read(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == source.name:
+            raise AssertionError("unchanged trusted cache entry must not be reopened")
+        return original_read(name, *args, **kwargs)
+
+    monkeypatch.setattr(scanner_repository, "_safe_read_at", reject_source_read)
+
+    second = scanner.scan(
+        tmp_path,
+        cached_files={file.path: file for file in first.files},
+        trusted_cache=True,
+        base_generation=1,
+    )
+
+    assert second.files == first.files
+
+
+def test_trusted_incremental_cache_never_reuses_generated_rows(tmp_path: Path) -> None:
+    source = _write(tmp_path, "one.py", "VALUE = 1\n")
+    scanner = RepositoryScanner()
+    first = scanner.scan(tmp_path)
+    generated = replace(first.files[0], text="", chunks=(), symbols=(), provenance="generated")
+
+    second = scanner.scan(
+        tmp_path,
+        cached_files={generated.path: generated},
+        trusted_cache=True,
+        base_generation=1,
+    )
+
+    assert second.files[0].text == source.read_text(encoding="utf-8")
+    assert second.files[0].chunks
+    assert second.files[0].provenance == "source"
+
+
+def test_repository_file_and_byte_budgets_fail_closed(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "VALUE=1\n")
+    _write(tmp_path, "b.py", "VALUE=2\n")
+    _write(tmp_path, "c.py", "VALUE=3\n")
+
+    file_limited = RepositoryScanner(max_repository_files=2).scan(tmp_path)
+    byte_limited = RepositoryScanner(max_repository_bytes=10).scan(tmp_path)
+
+    assert file_limited.files == []
+    assert file_limited.temporarily_unreadable == (".",)
+    assert file_limited.stats.skipped["repository_budget"] == 1
+    assert len(byte_limited.files) == 1
+    assert byte_limited.temporarily_unreadable == (".",)
+    assert any("repository byte count" in warning for warning in byte_limited.warnings)
+
+
+def test_directory_and_parser_fact_budgets_mark_unscanned_content_incomplete(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, "a/b/deep.py", "def deep():\n    return 1\n")
+    depth_limited = RepositoryScanner(max_directory_depth=1).scan(tmp_path)
+
+    assert depth_limited.files == []
+    assert depth_limited.temporarily_unreadable == ("a/b",)
+    assert depth_limited.stats.skipped["max_directory_depth"] == 1
+
+    flat = tmp_path / "flat"
+    flat.mkdir()
+    _write(flat, "a.py", "def first():\n    return 1\n")
+    _write(flat, "b.py", "def second():\n    return 2\n")
+    chunk_limited = RepositoryScanner(max_repository_chunks=1).scan(flat)
+    symbol_limited = RepositoryScanner(max_repository_symbols=1).scan(flat)
+
+    assert chunk_limited.temporarily_unreadable == (".",)
+    assert symbol_limited.temporarily_unreadable == (".",)
+    assert len(chunk_limited.files) == 1
+    assert len(symbol_limited.files) == 1
+
+
+def test_scan_wall_clock_deadline_marks_the_repository_incomplete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.scanner import repository as scanner_repository
+
+    _write(tmp_path, "one.py", "VALUE = 1\n")
+    readings = iter((10.0, 12.0))
+    monkeypatch.setattr(scanner_repository, "monotonic", lambda: next(readings))
+
+    result = RepositoryScanner(max_scan_seconds=1).scan(tmp_path)
+
+    assert result.files == []
+    assert result.temporarily_unreadable == (".",)
+    assert any("scan deadline" in warning for warning in result.warnings)
+
+
+def test_stale_cached_file_is_never_reused(tmp_path: Path) -> None:
+    class CountingParser:
+        languages = frozenset({"python"})
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def parse(
+            self,
+            path: str,
+            text: str,
+            language: str,
+            **kwargs: object,
+        ) -> ParseResult:
+            self.calls += 1
+            return ParseResult(chunks=(Chunk(path, 1, 1, text.rstrip(), language),))
+
+    parser = CountingParser()
+    registry = ParserRegistry()
+    registry.register(parser)
+    _write(tmp_path, "one.py", "value=1\n")
+    scanner = RepositoryScanner(parser_registry=registry, analysis_version="counting-v1")
+    first = scanner.scan(tmp_path)
+    stale = replace(first.files[0], stale=True)
+
+    second = scanner.scan(tmp_path, cached_files={stale.path: stale})
+
+    assert parser.calls == 2
+    assert second.files[0].stale is False
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -475,6 +882,12 @@ def test_unchanged_files_reuse_versioned_parser_results(tmp_path: Path) -> None:
         {"max_file_bytes": 1, "max_ignore_bytes": 0},
         {"max_file_bytes": 1, "max_chunk_lines": 0},
         {"max_file_bytes": 1, "max_chunk_chars": 0},
+        {"max_file_bytes": 1, "max_repository_files": 0},
+        {"max_file_bytes": 1, "max_repository_bytes": 0},
+        {"max_file_bytes": 1, "max_directory_depth": 0},
+        {"max_file_bytes": 1, "max_repository_chunks": 0},
+        {"max_file_bytes": 1, "max_repository_symbols": 0},
+        {"max_file_bytes": 1, "max_scan_seconds": 0},
     ],
 )
 def test_scanner_rejects_non_positive_limits(kwargs: dict[str, int]) -> None:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -550,7 +550,7 @@ def test_safe_read_compares_metadata_from_matching_sources(
 
     payload, error = scanner_repository._safe_read(source, 100)
 
-    assert payload == b"VALUE = 1\n"
+    assert payload == source.read_bytes()
     assert error is None
 
     expected = source.lstat()
@@ -562,10 +562,21 @@ def test_safe_read_compares_metadata_from_matching_sources(
         directory_fd=None,
         root=tmp_path.resolve(),
     )
-    assert payload == b"VALUE = 1\n"
+    assert payload == source.read_bytes()
     assert reason is None
     assert returned_metadata is not None
     assert returned_metadata.st_ctime_ns == source.lstat().st_ctime_ns
+
+
+def test_safe_read_preserves_crlf_and_ctrl_z_bytes(tmp_path: Path) -> None:
+    raw = b"before\r\nafter\x1atail"
+    source = _write(tmp_path, "app.py", raw)
+    from repolocus.scanner import repository as scanner_repository
+
+    payload, error = scanner_repository._safe_read(source, 100)
+
+    assert payload == raw
+    assert error is None
 
 
 def test_safe_read_keeps_handle_and_path_content_states_linked(
@@ -597,7 +608,11 @@ def test_safe_read_keeps_handle_and_path_content_states_linked(
 
 @pytest.mark.parametrize(
     ("mtime_delta", "ctime_delta", "expected_error"),
-    [(0, 1, None), (1, 0, "changed_during_scan")],
+    [
+        (0, 0, None),
+        (0, 1, "changed_during_scan"),
+        (1, 0, "changed_during_scan"),
+    ],
 )
 def test_safe_read_revalidates_metadata_collected_after_close(
     tmp_path: Path,
@@ -649,52 +664,10 @@ def test_safe_read_revalidates_metadata_collected_after_close(
         assert returned_metadata is None
         assert reason == expected_error
     else:
-        assert payload == b"VALUE = 1\n"
+        assert payload == source.read_bytes()
         assert reason is None
         assert returned_metadata is not None
         assert returned_metadata.st_ctime_ns == expected.st_ctime_ns + ctime_delta
-
-
-@pytest.mark.parametrize(
-    ("is_windows", "mtime_delta", "expected_match"),
-    [(True, 0, True), (False, 0, False), (True, 1, False)],
-)
-def test_cache_revalidation_tolerates_only_windows_ctime_drift(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    is_windows: bool,
-    mtime_delta: int,
-    expected_match: bool,
-) -> None:
-    source = _write(tmp_path, "app.py", "VALUE = 1\n")
-    from repolocus.scanner import repository as scanner_repository
-
-    expected = source.lstat()
-    original_stat = scanner_repository.os.stat
-
-    def changed_stat(path: str | os.PathLike[str], *args, **kwargs):  # type: ignore[no-untyped-def]
-        metadata = original_stat(path, *args, **kwargs)
-        return SimpleNamespace(
-            st_mode=metadata.st_mode,
-            st_dev=metadata.st_dev,
-            st_ino=metadata.st_ino,
-            st_size=metadata.st_size,
-            st_mtime_ns=metadata.st_mtime_ns + mtime_delta,
-            st_ctime_ns=metadata.st_ctime_ns + 1,
-        )
-
-    monkeypatch.setattr(scanner_repository, "_IS_WINDOWS", is_windows)
-    monkeypatch.setattr(scanner_repository.os, "stat", changed_stat)
-
-    assert (
-        scanner_repository._metadata_still_matches_at(
-            source.name,
-            expected,
-            directory=tmp_path,
-            directory_fd=None,
-        )
-        is expected_match
-    )
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows file identity semantics")
@@ -866,6 +839,8 @@ def test_trusted_incremental_cache_skips_unchanged_file_reads(
     scanner = RepositoryScanner()
     first = scanner.scan(tmp_path)
     settled = source.lstat()
+    assert first.files[0].size_bytes == settled.st_size
+    assert first.files[0].sha256 == hashlib.sha256(source.read_bytes()).hexdigest()
     assert first.files[0].mtime_ns == settled.st_mtime_ns
     assert first.files[0].ctime_ns == settled.st_ctime_ns
     from repolocus.scanner import repository as scanner_repository

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -655,6 +655,48 @@ def test_safe_read_revalidates_metadata_collected_after_close(
         assert returned_metadata.st_ctime_ns == expected.st_ctime_ns + ctime_delta
 
 
+@pytest.mark.parametrize(
+    ("is_windows", "mtime_delta", "expected_match"),
+    [(True, 0, True), (False, 0, False), (True, 1, False)],
+)
+def test_cache_revalidation_tolerates_only_windows_ctime_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    is_windows: bool,
+    mtime_delta: int,
+    expected_match: bool,
+) -> None:
+    source = _write(tmp_path, "app.py", "VALUE = 1\n")
+    from repolocus.scanner import repository as scanner_repository
+
+    expected = source.lstat()
+    original_stat = scanner_repository.os.stat
+
+    def changed_stat(path: str | os.PathLike[str], *args, **kwargs):  # type: ignore[no-untyped-def]
+        metadata = original_stat(path, *args, **kwargs)
+        return SimpleNamespace(
+            st_mode=metadata.st_mode,
+            st_dev=metadata.st_dev,
+            st_ino=metadata.st_ino,
+            st_size=metadata.st_size,
+            st_mtime_ns=metadata.st_mtime_ns + mtime_delta,
+            st_ctime_ns=metadata.st_ctime_ns + 1,
+        )
+
+    monkeypatch.setattr(scanner_repository, "_IS_WINDOWS", is_windows)
+    monkeypatch.setattr(scanner_repository.os, "stat", changed_stat)
+
+    assert (
+        scanner_repository._metadata_still_matches_at(
+            source.name,
+            expected,
+            directory=tmp_path,
+            directory_fd=None,
+        )
+        is expected_match
+    )
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows file identity semantics")
 def test_windows_path_and_handle_metadata_are_compared_consistently(tmp_path: Path) -> None:
     _write(tmp_path, ".gitignore", "*.tmp\n")

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -553,6 +553,20 @@ def test_safe_read_compares_metadata_from_matching_sources(
     assert payload == b"VALUE = 1\n"
     assert error is None
 
+    expected = source.lstat()
+    payload, returned_metadata, reason = scanner_repository._safe_read_at(
+        source.name,
+        100,
+        expected,
+        directory=tmp_path,
+        directory_fd=None,
+        root=tmp_path.resolve(),
+    )
+    assert payload == b"VALUE = 1\n"
+    assert reason is None
+    assert returned_metadata is not None
+    assert returned_metadata.st_ctime_ns == source.lstat().st_ctime_ns
+
 
 def test_safe_read_keeps_handle_and_path_content_states_linked(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -4,7 +4,9 @@ import hashlib
 import json
 import os
 import stat
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from platformdirs import user_state_dir
@@ -34,6 +36,40 @@ def test_filesystem_identity_fails_closed_without_stable_ids() -> None:
     with pytest.raises(ValueError, match="stable object identity"):
         filesystem_identity(metadata)  # type: ignore[arg-type]
     assert descriptor_path(-1) is None
+
+
+def test_descriptor_path_uses_darwin_f_getpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import identity as identity_module
+
+    source = tmp_path / "opened.txt"
+    source.write_text("content\n", encoding="utf-8")
+    expected = source.resolve()
+    encoded = os.fsencode(expected)
+    fake_fcntl = SimpleNamespace(
+        F_GETPATH=50,
+        fcntl=lambda _descriptor, _command, buffer: (encoded + b"\0").ljust(len(buffer), b"\0"),
+    )
+    monkeypatch.setattr(identity_module.sys, "platform", "darwin")
+    monkeypatch.setitem(sys.modules, "fcntl", fake_fcntl)
+    descriptor = os.open(source, os.O_RDONLY)
+    try:
+        assert identity_module.descriptor_path(descriptor) == expected
+    finally:
+        os.close(descriptor)
+
+
+def test_descriptor_path_resolves_a_real_open_file(tmp_path: Path) -> None:
+    source = tmp_path / "opened.txt"
+    source.write_text("content\n", encoding="utf-8")
+    descriptor = os.open(source, os.O_RDONLY)
+    try:
+        opened_path = descriptor_path(descriptor)
+        assert opened_path is not None
+        assert opened_path.samefile(source)
+    finally:
+        os.close(descriptor)
 
 
 def test_canonical_path_check_accepts_descendants(tmp_path: Path) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from platformdirs import user_state_dir
 
+from repolocus.scanner import contains_likely_secret as scanner_detects_likely_secret
 from repolocus.security import (
     ConsentRequiredError,
     PathSecurityError,
@@ -17,12 +18,22 @@ from repolocus.security import (
     build_cloud_send_preview,
     canonical_endpoint,
     ensure_within_root,
+    find_likely_secrets,
     redact_secrets,
     require_provider_consent,
 )
+from repolocus.security.identity import descriptor_path, filesystem_identity
 
 OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions"
 ANTHROPIC_ENDPOINT = "https://api.anthropic.com/v1/messages"
+
+
+def test_filesystem_identity_fails_closed_without_stable_ids() -> None:
+    metadata = type("Metadata", (), {"st_dev": 0, "st_ino": 0})()
+
+    with pytest.raises(ValueError, match="stable object identity"):
+        filesystem_identity(metadata)  # type: ignore[arg-type]
+    assert descriptor_path(-1) is None
 
 
 def test_canonical_path_check_accepts_descendants(tmp_path: Path) -> None:
@@ -80,6 +91,89 @@ YWJjZA==
 -----END PRIVATE KEY-----"""
 
     assert redact_secrets(source) == ("[REDACTED]", 1)
+
+
+@pytest.mark.parametrize(
+    ("kind", "source", "secret"),
+    [
+        (
+            "private_key",
+            "-----BEGIN PRIVATE KEY-----\nYWJjZA==\n-----END PRIVATE KEY-----",
+            "YWJjZA==",
+        ),
+        ("aws_access_key", "ASIA1234567890ABCDEF", "ASIA1234567890ABCDEF"),
+        (
+            "github_token",
+            "ghp_abcdefghijklmnopqrstuvwxyz123456",
+            "ghp_abcdefghijklmnopqrstuvwxyz123456",
+        ),
+        (
+            "github_fine_grained_token",
+            "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+            "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+        ),
+        ("gitlab_token", "glpat-1234567890abcdefghij", "glpat-1234567890abcdefghij"),
+        ("slack_token", "xoxb-1234567890-abcdefghij", "xoxb-1234567890-abcdefghij"),
+        (
+            "google_api_key",
+            "AIza1234567890abcdefghijklmnopqrstuvwxyz",
+            "AIza1234567890abcdefghijklmnopqrstuvwxyz",
+        ),
+        (
+            "provider_api_key",
+            "sk-proj-abcdefghijklmnopqrstuvwxyz",
+            "sk-proj-abcdefghijklmnopqrstuvwxyz",
+        ),
+        (
+            "hugging_face_token",
+            "hf_abcdefghijklmnopqrstuvwxyz123456",
+            "hf_abcdefghijklmnopqrstuvwxyz123456",
+        ),
+        ("stripe_live_key", "sk_live_1234567890abcdef", "sk_live_1234567890abcdef"),
+        (
+            "jwt",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature123",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature123",
+        ),
+        (
+            "url_password",
+            "postgresql://alice:correct-horse@example.invalid/app",
+            "correct-horse",
+        ),
+        ("bearer_token", "Bearer abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"),
+        (
+            "credential_assignment",
+            'api_key = "v3ry-long-random-value-827364"',
+            "v3ry-long-random-value-827364",
+        ),
+    ],
+)
+def test_scanner_and_transport_secret_rules_have_parity(
+    kind: str,
+    source: str,
+    secret: str,
+) -> None:
+    assert scanner_detects_likely_secret(source)
+    matches = find_likely_secrets(source)
+    assert any(match.kind == kind and match.confidence == "high" for match in matches)
+
+    redacted, count = redact_secrets(source)
+
+    assert count == 1
+    assert secret not in redacted
+    assert not scanner_detects_likely_secret(redacted)
+
+
+def test_overlapping_assignment_and_typed_token_count_as_one_secret() -> None:
+    source = 'api_key = "sk-proj-abcdefghijklmnopqrstuvwxyz"'
+
+    redacted, count = redact_secrets(source)
+    repeated, repeated_count = redact_secrets(redacted)
+
+    assert redacted == 'api_key = "[REDACTED]"'
+    assert count == 1
+    assert repeated == redacted
+    assert repeated_count == 0
 
 
 def test_privacy_store_remembers_per_repo_provider_outside_repo(tmp_path: Path) -> None:
@@ -180,6 +274,42 @@ def test_privacy_store_revoke_all_is_repository_scoped(tmp_path: Path) -> None:
 
     assert store.status(repo_a) == {}
     assert store.status(repo_b) == {"openai": True}
+
+
+def test_remembered_consent_does_not_follow_a_replaced_repository(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_path = tmp_path / "state" / "privacy.json"
+    store = PrivacyStore(state_path)
+    store.grant(repo, "openai", OPENAI_ENDPOINT)
+
+    repo.rename(tmp_path / "old-repo")
+    repo.mkdir()
+
+    assert store.status(repo) == {}
+    assert store.is_allowed(repo, "openai", OPENAI_ENDPOINT) is False
+
+
+def test_consent_read_fails_if_repository_changes_during_state_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = PrivacyStore(tmp_path / "state" / "privacy.json")
+    store.grant(repo, "openai", OPENAI_ENDPOINT)
+    original_read = store._read
+
+    def replace_repository() -> dict[str, object]:
+        state = original_read()
+        repo.rename(tmp_path / "old-repo")
+        repo.mkdir()
+        return state
+
+    monkeypatch.setattr(store, "_read", replace_repository)
+
+    with pytest.raises(PrivacyStoreError, match="identity changed"):
+        store.is_allowed(repo, "openai", OPENAI_ENDPOINT)
 
 
 def test_privacy_store_refuses_state_inside_repository(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30,12 +30,14 @@ class RecordingScanner(RepositoryScanner):
         root: Path | str,
         *,
         cached_files: Mapping[str, ScannedFile] | None = None,
+        trusted_cache: bool = False,
         base_generation: int | None = None,
     ) -> ScanResult:
         self.calls.append((base_generation, tuple(sorted((cached_files or {}).keys()))))
         return super().scan(
             root,
             cached_files=cached_files,
+            trusted_cache=trusted_cache,
             base_generation=base_generation,
         )
 
@@ -63,6 +65,45 @@ def test_end_to_end_local_workflow_is_incremental(
     assert any(item.path == "src/demo/config.py" for item in answer.evidence)
     assert preview.fragment_count == len(answer.evidence)
     assert not (sample_repo / ".repolocus").exists()
+
+
+def test_evidence_refresh_uses_metadata_manifest_instead_of_full_snapshot(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service(sample_repo, isolated_user_dirs)
+    service.scan(sample_repo)
+
+    def unexpected_full_materialization(_index: RepositoryIndex) -> list[ScannedFile]:
+        raise AssertionError("evidence refresh must not load every indexed source and parser fact")
+
+    monkeypatch.setattr(RepositoryIndex, "get_files", unexpected_full_materialization)
+
+    evidence, operation = service.evidence("Where is load_config defined?", sample_repo)
+
+    assert any(item.path == "src/demo/config.py" for item in evidence)
+    assert operation.update.unchanged > 0
+    assert all(file.text == "" for file in operation.result.files)
+
+
+def test_explicit_scan_refresh_uses_metadata_manifest(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service(sample_repo, isolated_user_dirs)
+    service.scan(sample_repo)
+
+    def unexpected_full_materialization(_index: RepositoryIndex) -> list[ScannedFile]:
+        raise AssertionError("incremental scan must not load every stored source body")
+
+    monkeypatch.setattr(RepositoryIndex, "get_files", unexpected_full_materialization)
+
+    operation = service.scan(sample_repo)
+
+    assert operation.update.unchanged > 0
+    assert all(file.text == "" for file in operation.result.files)
 
 
 def test_changed_file_updates_only_changed_content(
@@ -262,6 +303,16 @@ def test_snapshot_operation_contains_only_fresh_source_files(
     assert operation.update.stale == 1
     assert any("excludes 1 stale file" in warning for warning in operation.result.warnings)
 
+    _document, refreshed = service.map(
+        sample_repo,
+        refresh="auto",
+        expected_generation=second.generation,
+    )
+    readme = next(file for file in refreshed.result.files if file.path == "README.md")
+    assert readme.provenance == "source"
+    assert readme.text
+    assert readme.chunks
+
 
 def test_service_rejects_a_symlink_repository_root(
     sample_repo: Path, isolated_user_dirs: Path, tmp_path: Path
@@ -274,7 +325,7 @@ def test_service_rejects_a_symlink_repository_root(
         service.scan(linked)
 
 
-def test_empty_committed_snapshot_is_valid_for_auto_refresh(
+def test_auto_refresh_scans_even_when_committed_snapshot_is_empty(
     tmp_path: Path, isolated_user_dirs: Path
 ) -> None:
     repository = tmp_path / "empty"
@@ -289,8 +340,64 @@ def test_empty_committed_snapshot_is_valid_for_auto_refresh(
     first = service.scan(repository)
     _document, cached = service.map(repository, refresh="auto")
 
-    assert len(scanner.calls) == 1
-    assert first.update.generation == cached.update.generation
+    assert len(scanner.calls) == 2
+    assert cached.update.generation == first.update.generation + 1
+
+
+def test_auto_refresh_observes_edits_while_never_is_explicit_snapshot_reuse(
+    tmp_path: Path, isolated_user_dirs: Path
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    source = repository / "value.py"
+    source.write_text("OLD_SYMBOL = 1\n", encoding="utf-8")
+    scanner = RecordingScanner()
+    service = RepoLocusService(
+        Settings(model="local"),
+        scanner=scanner,
+        privacy=PrivacyStore(isolated_user_dirs / "privacy.json"),
+    )
+
+    first, initial = service.evidence("OLD_SYMBOL", repository, refresh="auto")
+    source.write_text("NEW_SYMBOL = 2\n", encoding="utf-8")
+    stale, reused = service.evidence("OLD_SYMBOL", repository, refresh="never")
+    fresh, refreshed = service.evidence("NEW_SYMBOL", repository, refresh="auto")
+
+    assert first and stale
+    assert reused.update.generation == initial.update.generation
+    assert fresh
+    assert refreshed.update.generation == initial.update.generation + 1
+    assert len(scanner.calls) == 2
+
+
+def test_service_does_not_seed_scanner_cache_with_stale_files(
+    tmp_path: Path, isolated_user_dirs: Path
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    scanner = RecordingScanner()
+    service = RepoLocusService(
+        Settings(model="local"),
+        scanner=scanner,
+        privacy=PrivacyStore(isolated_user_dirs / "privacy.json"),
+    )
+    first = service.scan(repository)
+    with RepositoryIndex.open(repository) as index:
+        index.update(
+            ScanResult(
+                repository,
+                [],
+                ScanStats(),
+                analysis_version=scanner.analysis_version,
+                temporarily_unreadable=("value.py",),
+                base_generation=first.update.generation,
+            )
+        )
+
+    service.scan(repository)
+
+    assert scanner.calls[-1][1] == ()
 
 
 def test_cloud_call_is_stopped_before_provider_creation(
@@ -436,6 +543,23 @@ def test_context_redacts_credentials(sample_repo: Path, isolated_user_dirs: Path
     assert "abcdefghijklmnopqrstuvwxyz" not in context
     assert "[REDACTED]" in context
     assert count >= 1
+
+
+def test_cloud_preview_counts_and_removes_secrets_from_the_question(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    service = _service(sample_repo, isolated_user_dirs, model="openai/test-model")
+    token = "glpat-abcdefghijklmnopqrstuvwxyz1234"
+
+    prepared, _operation = service.prepare_ask(
+        f"Where is load_config defined? token={token}",
+        sample_repo,
+    )
+
+    assert prepared.request_plan is not None
+    assert prepared.preview.redaction_count >= 1
+    assert token.encode() not in prepared.request_plan.body
 
 
 def test_context_escapes_source_delimiters_and_limits_citable_ranges(

--- a/tests/test_skill_adapter.py
+++ b/tests/test_skill_adapter.py
@@ -312,7 +312,7 @@ def test_runtime_probe_validates_module_origin_and_compatible_version(
         "run",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=0,
-            stdout=json.dumps({"origin": str(origin), "version": "0.1.2"}),
+            stdout=json.dumps({"origin": str(origin), "version": "0.1.4"}),
             stderr="",
         ),
     )
@@ -327,11 +327,11 @@ def test_runtime_probe_validates_module_origin_and_compatible_version(
     )
 
     assert runtime.origin == origin.resolve()
-    assert runtime.version == "0.1.2"
+    assert runtime.version == "0.1.4"
     assert runtime.prefix[-2:] == ("-m", "repolocus")
 
 
-@pytest.mark.parametrize("version", ["0.1.1", "0.2.0", "not-a-version"])
+@pytest.mark.parametrize("version", ["0.1.1", "0.1.2", "0.1.3", "0.2.0", "not-a-version"])
 def test_runtime_probe_rejects_incompatible_versions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: str
 ) -> None:
@@ -350,7 +350,7 @@ def test_runtime_probe_rejects_incompatible_versions(
         ),
     )
 
-    with pytest.raises(adapter.AdapterError, match=r"requires >=0\.1\.2,<0\.2\.0"):
+    with pytest.raises(adapter.AdapterError, match=r"requires >=0\.1\.4,<0\.2\.0"):
         adapter._probe_runtime(
             [str(tmp_path / "python"), "-I"],
             environment={},

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,16 +1,31 @@
 from __future__ import annotations
 
-from repolocus.retrieval.terms import document_terms, literal_query_terms, query_terms
+from repolocus.retrieval.terms import (
+    document_terms,
+    literal_query_term_groups,
+    literal_query_terms,
+    query_terms,
+)
 
 
 def test_cjk_terms_use_bigrams_and_trigrams() -> None:
-    indexed = document_terms("配置在哪里校验")
+    query = "\u914d\u7f6e" + "\u5728\u54ea\u91cc" + "\u6821\u9a8c"
+    indexed = document_terms(query)
 
-    assert "配置" in indexed
-    assert "校验" in indexed
-    assert "配置在" in indexed
-    assert "置在哪" in indexed
-    assert "配" not in indexed
+    assert "\u914d\u7f6e" in indexed
+    assert "\u6821\u9a8c" in indexed
+    assert "\u914d\u7f6e\u5728" in indexed
+    assert "\u7f6e\u5728\u54ea" in indexed
+    assert "\u914d" not in indexed
+
+
+def test_literal_coverage_groups_cjk_alternatives_but_not_non_cjk_terms() -> None:
+    cjk_query = "\u914d\u7f6e" + "\u5728\u54ea\u91cc" + "\u6821\u9a8c"
+    groups = literal_query_term_groups(cjk_query + " policy")
+
+    assert groups[0][0] == cjk_query
+    assert groups[0] == (cjk_query, "\u914d\u7f6e", "\u5728\u54ea", "\u6821\u9a8c")
+    assert groups[1] == ("policy",)
 
 
 def test_identifiers_paths_and_unicode_are_normalized() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,7 @@ wheels = [
 
 [[package]]
 name = "repolocus"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- invalidate legacy analysis facts and bind indexes, cache reuse, and cloud consent to repository identity
- harden traversal, repository config reads, secret redaction, provider responses, generated outputs, and destination-aware links
- fix CJK retrieval and evaluation aggregation, add repository-wide resource budgets, and prepare version 0.1.4
- document metadata-only scan results and precise timeout semantics

## Validation

- 361 passed, 1 skipped on Linux with 85.02% coverage
- Ruff format and lint passed
- Bandit medium/high scan passed
- retrieval evaluation gates passed
- 0.1.4 wheel and sdist built; clean wheel smoke test passed

## Notes

This draft PR triggers the pull_request-only CI matrix. No v0.1.4 tag is created by this PR.