### PR TITLE
Release v0.1.5 reliability and boundary hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# The external evaluation manifest hashes exact fixture bytes. Keep Git from
+# rewriting controlled source and qrel line endings on Windows checkouts.
+evaluation/repos/** text eol=lf
+evaluation/qrels/** text eol=lf
+evaluation/external-manifest.json text eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,25 +14,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.12", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          version: "0.9.18"
       - run: uv sync --all-extras --locked
       - run: uv run pytest
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.10"
           enable-cache: true
+          version: "0.9.18"
       - run: uv sync --all-extras --locked
       - run: uv run ruff format --check .
       - run: uv run ruff check .
@@ -41,10 +43,11 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
+          version: "0.9.18"
       - run: uv sync --all-extras --locked
       - run: uv run repolocus doctor --security --json
       - name: Scan Python for medium/high-severity security issues
@@ -69,7 +72,7 @@ jobs:
           uv run python scripts/check_licenses.py licenses.json
       - name: Upload supply-chain reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: supply-chain-reports
           path: |
@@ -78,14 +81,57 @@ jobs:
             requirements-audit.txt
           if-no-files-found: warn
 
-  package:
-    needs: [test, coverage, security]
+  external-evaluation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
+          enable-cache: true
+          version: "0.9.18"
+      - run: uv sync --all-extras --locked
+      - name: Run fixed multi-repository retrieval gate
+        run: >-
+          uv run python scripts/evaluate_external_repositories.py evaluation
+          --minimum-hit-rate 0.90
+          --minimum-macro-recall 0.80
+          --minimum-mrr 0.75
+          --minimum-citation-recall 1.0
+          --minimum-no-answer-f1 0.80
+          --maximum-must-not-return-rate 0.0
+          --output external-evaluation.json
+      - name: Upload external evaluation report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: external-evaluation
+          path: external-evaluation.json
+          if-no-files-found: error
+
+  package:
+    needs: [test, coverage, security, external-evaluation]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every CI gate to succeed
+        env:
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
+          EVALUATION_RESULT: ${{ needs.external-evaluation.result }}
+          SECURITY_RESULT: ${{ needs.security.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          for result in "$TEST_RESULT" "$COVERAGE_RESULT" "$SECURITY_RESULT" "$EVALUATION_RESULT"; do
+            if [[ "$result" != "success" ]]; then
+              echo "Required CI gate did not succeed: $result" >&2
+              exit 1
+            fi
+          done
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          python-version: "3.12"
+          version: "0.9.18"
       - run: uv build
       - name: Install wheel in a clean environment
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,18 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           python-version: "3.12"
           enable-cache: true
@@ -55,6 +59,19 @@ jobs:
           uv run ruff check .
           uv run pytest
           uv run repolocus doctor --security --json
+      - name: Run fixed multi-repository retrieval release gate
+        env:
+          PROJECT_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          mkdir -p release-assets
+          uv run python scripts/evaluate_external_repositories.py evaluation \
+            --minimum-hit-rate 0.90 \
+            --minimum-macro-recall 0.80 \
+            --minimum-mrr 0.75 \
+            --minimum-citation-recall 1.0 \
+            --minimum-no-answer-f1 0.80 \
+            --maximum-must-not-return-rate 0.0 \
+            --output "release-assets/repolocus-${PROJECT_VERSION}.external-evaluation.json"
       - name: Build and check Python distributions
         run: |
           mkdir -p release-assets
@@ -79,15 +96,56 @@ jobs:
         run: |
           cd release-assets
           LC_ALL=C sha256sum * > SHA256SUMS
-      - uses: actions/upload-artifact@v4
+      - name: Attest every release asset
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: release-assets/*
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-assets
           path: release-assets/*
           if-no-files-found: error
           retention-days: 14
 
-  publish-pypi:
+  verify-provenance:
     needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: read
+      contents: read
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-assets
+          path: release-assets
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          python-version: "3.14"
+          enable-cache: false
+          version: "0.9.18"
+      - name: Verify checksums and GitHub attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd release-assets
+          sha256sum -c SHA256SUMS
+          for asset in *; do
+            gh attestation verify "$asset" --repo "$GITHUB_REPOSITORY"
+          done
+      - name: Install the wheel and run the security doctor in a clean environment
+        env:
+          PROJECT_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          uv venv --python 3.14 /tmp/repolocus-release-verify
+          wheel="$(find release-assets -maxdepth 1 -name 'repolocus-*.whl' -print -quit)"
+          test -n "$wheel"
+          uv pip install --python /tmp/repolocus-release-verify/bin/python "${wheel}[api]"
+          runtime_version="$(/tmp/repolocus-release-verify/bin/repolocus --version)"
+          test "$runtime_version" = "RepoLocus $PROJECT_VERSION"
+          /tmp/repolocus-release-verify/bin/repolocus doctor --security --json
+
+  publish-pypi:
+    needs: [build, verify-provenance]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -95,7 +153,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-assets
           path: release-assets
@@ -103,17 +161,17 @@ jobs:
         run: |
           mkdir -p dist
           cp release-assets/*.whl release-assets/*.tar.gz dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
 
   publish-github-release:
-    needs: [build, publish-pypi]
+    needs: [build, verify-provenance, publish-pypi]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-assets
           path: release-assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ Semantic Versioning while the project is in alpha.
 
 ### Security
 
-- Generated Markdown uses descriptor-relative atomic name exchange on supported POSIX systems;
-  Windows uses handle-backed replacement plus pre/post reparse-point and identity checks.
+- Generated Markdown uses descriptor-relative no-replace publication on POSIX. Replacements use
+  atomic name exchange and retain the previous document as an explicitly reported `.rollback`
+  recovery file rather than risking a cleanup race. Windows uses 128-bit handle identity,
+  pre/post content hashes, recoverable replacement, and handle-bound deletion.
 - HTTP providers ignore ambient proxy variables by default. Environment or explicit proxy use
   requires an explicit user policy, appears credential-free in previews, and is cryptographically
   bound to remembered consent without persisting proxy credentials.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Semantic Versioning while the project is in alpha.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-08-07
+
+### Added
+
+- Added distinct retrieval-visible `content_generation` and diagnostic `scan_revision` counters,
+  a `status` command, and explicit `auto`, `always`, `never`, and `rebuild` refresh behavior.
+- Added deterministic component fingerprints and parser cache identities so scanner, parser,
+  term-index, and retrieval changes invalidate only the facts they affect.
+- Added a parser finalizer with normalized ranges, bounded fields and collections, transactional
+  repository budgets, and hard resource ceilings around parser output.
+- Added a fixed six-repository, 18-qrel synthetic retrieval gate with graded citations, a citation
+  recall gate, explicit no-answer truth, per-repository metrics, provenance, fixture and qrel
+  digests, and `must_not_return` checks.
+- Added state-machine, race, cross-process, parser-boundary, proxy-route, and workflow-policy tests.
+
+### Changed
+
+- `refresh=auto` now performs no database write on an exact cache hit; `always` securely rereads
+  every candidate while reusing compatible parser facts, and `rebuild` reparses every source file.
+- Python 3.10 configuration now uses `tomli`, while Python 3.11 and newer use `tomllib`; the
+  previous partial TOML implementation has been removed.
+- The bundled Skill now requires a RepoLocus `>=0.1.5,<0.2.0` runtime so its parser budgets,
+  component fingerprints, and refresh semantics cannot silently fall back to v0.1.4 behavior.
+- CI now covers Python 3.10 through the supported latest Python 3.14, runs the external retrieval
+  gate, pins every third-party Action to a full commit SHA, and uses exact uv and Hatchling
+  versions. The existing required `package` check now fails instead of becoming skipped when any
+  prerequisite gate fails.
+
+### Security
+
+- Generated Markdown uses descriptor-relative atomic name exchange on supported POSIX systems;
+  Windows uses handle-backed replacement plus pre/post reparse-point and identity checks.
+- HTTP providers ignore ambient proxy variables by default. Environment or explicit proxy use
+  requires an explicit user policy, appears credential-free in previews, and is cryptographically
+  bound to remembered consent without persisting proxy credentials.
+- Privacy consent state v4 invalidates earlier grants and uses an operating-system cross-process
+  lock on Windows as well as POSIX so concurrent grant/revoke updates cannot be lost.
+- Release wheel, sdist, Skill ZIP, CycloneDX SBOM, and checksums receive GitHub/Sigstore build
+  provenance; a separate clean job verifies checksums and every attestation, installs the wheel,
+  and runs the security doctor before PyPI publication.
+
 ## [0.1.4] - 2026-08-04
 
 ### Changed

--- a/MODEL_SUPPORT.md
+++ b/MODEL_SUPPORT.md
@@ -8,8 +8,9 @@
 | `anthropic/MODEL` | Cloud | `ANTHROPIC_API_KEY` | Supported; explicit consent |
 
 Provider adapters share a small contract and receive already-selected evidence. They cannot
-execute tools or expand the repository read scope. Cloud consent is enforced outside the
-adapter and remembered per canonical repository path and provider family.
+execute tools or expand the repository read scope. Cloud consent is enforced outside the adapter
+and remembered per canonical repository, provider family, complete endpoint, and exact
+direct/proxy route identity.
 
 Environment configuration:
 
@@ -18,12 +19,17 @@ Environment configuration:
 - `REPOLOCUS_OPENAI_BASE_URL`
 - `REPOLOCUS_ANTHROPIC_BASE_URL`
 - `REPOLOCUS_REQUEST_TIMEOUT`
+- `REPOLOCUS_PROXY_MODE` (`disabled`, `environment`, or `explicit`)
+- `REPOLOCUS_PROXY_URL` (required only for `explicit` mode)
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 
 Plain HTTP endpoints are accepted only on loopback addresses such as `localhost`, `127.0.0.1`,
 or `::1`. Every non-loopback Ollama, OpenAI-compatible, or Anthropic endpoint must use HTTPS.
 Prompts sent through HTTP providers are redacted immediately before transport.
+HTTPX environment proxy discovery is disabled unless `REPOLOCUS_PROXY_MODE=environment` is
+selected. Explicit and environment proxy routes are shown without credentials in the cloud
+preview, frozen for the request, and bound to remembered consent. Loopback endpoints stay direct.
 
 Model output is not treated as evidence. A citation must point into one of the retrieved source
 ranges or the narrative is withheld in favor of the deterministic evidence response.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -21,8 +21,13 @@ non-loopback Ollama, OpenAI-compatible, or Anthropic endpoint must use HTTPS. A 
 Ollama endpoint and every cloud provider are disabled until the user either passes
 `--allow-cloud` for one call or records a repository/provider grant. Before every approved
 remote CLI call, RepoLocus displays the exact redacted source content and ranges, fragment count,
-estimated tokens, and redaction count that will be sent, including calls covered by a remembered
-grant. System and user prompts are redacted again immediately before transport, and the final
+estimated tokens, redaction count, and credential-free direct/proxy route that will be used,
+including calls covered by a remembered grant. Ambient proxy variables are ignored by default;
+environment discovery or an explicit proxy URL requires a user-selected proxy policy. The frozen
+credential-free route identity is part of consent, while proxy credentials are excluded from that
+identity and are never persisted or displayed. Rotating credentials on an unchanged route does not
+require fresh consent.
+System and user prompts are redacted again immediately before transport, and the final
 serialized JSON body is scanned fail-closed before a network client is created. Provider responses
 are read with byte, content-type, JSON-depth, per-HTTP-phase timeout, and elapsed-deadline checks
 between streamed chunks. A blocking HTTP phase is bounded by the configured HTTPX phase timeout;

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ intentionally ignored after upgrade.
 validated AST-like subset, not accepted directly from a model. The evidence tables keep a
 representative source for each node and one concrete import witness for every rendered edge.
 
+On POSIX, replacing an existing output preserves its previous contents in a reported hidden
+`.rollback` file. Remove that recovery file manually only when other repository writers are
+quiescent. New documents use atomic create-if-absent publication and do not leave a recovery file.
+
 `repolocus ask` combines exact symbols, SQLite FTS5/BM25, a deterministic term index, and
 dependency-neighbor evidence. The term index splits camelCase, snake_case, and path components,
 and adds bigrams and trigrams for contiguous CJK text. Users can add explicit retrieval synonyms

--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ repolocus ask "How does a request reach the core loop?" --model ollama/qwen3-cod
 ```
 
 Every remote CLI call first prints the model, canonical destination endpoint, exact serialized
-payload size, and redacted source fragments selected for that send, including calls covered by a
-remembered grant. Use `--allow-cloud` for one call, or add `--remember-consent` to remember that
-provider endpoint for the current repository:
+payload size, credential-free transport route, and redacted source fragments selected for that
+send, including calls covered by a remembered grant. Ambient `HTTP_PROXY`, `HTTPS_PROXY`, and
+`ALL_PROXY` variables are ignored by default. Select `--proxy-mode environment` to opt in to
+environment discovery, or provide `--proxy-mode explicit --proxy-url URL`; loopback providers
+remain direct. Use `--allow-cloud` for one call, or add `--remember-consent` to remember that exact
+provider endpoint and transport route for the current repository:
 
 ```bash
 export OPENAI_API_KEY=...
@@ -66,10 +69,12 @@ repolocus ask "Where is configuration validated?" \
   --model openai/gpt-4.1-mini --allow-cloud
 ```
 
-Remembered-consent format v3 binds a grant to the current repository identity, canonical path,
-provider, scheme, host, effective port, and complete request path. Replacing the directory or its
-Git marker, or changing a compatible-provider endpoint, therefore requires fresh consent. Legacy
-path-only v1/v2 grants are intentionally ignored after upgrade.
+Remembered-consent format v4 binds a grant to the current repository identity, canonical path,
+provider, complete destination endpoint, and exact credential-free direct/proxy route identity.
+Proxy credentials are excluded from both that identity and the consent file or preview. Replacing
+the directory or its Git marker, or changing an endpoint, proxy mode, or proxy route therefore
+requires fresh consent; rotating credentials for the same route does not. Legacy v1-v3 grants are
+intentionally ignored after upgrade.
 
 ## What it produces
 
@@ -101,6 +106,7 @@ supports the claim. A model answer that passes these checks is still labeled `ne
 | Command | Purpose |
 |---|---|
 | `repolocus scan [PATH]` | Securely scan and incrementally update the local index |
+| `repolocus status [PATH]` | Show content generation, scan revision, and component fingerprints |
 | `repolocus map [PATH]` | Generate `PROJECT_MAP.md` or print it with `--stdout` |
 | `repolocus ask QUESTION [PATH]` | Retrieve source-backed evidence and optionally use a model |
 | `repolocus diagram [PATH]` | Generate validated Mermaid in `ARCHITECTURE.md` |
@@ -113,14 +119,18 @@ supports the claim. A model answer that passes these checks is still labeled `ne
 
 Every command accepts `--help`. Use `--json` on automation-friendly commands where available.
 `map`, `diagram`, and `ask` default to `--refresh auto`: they perform a bounded incremental refresh
-before querying, so edits or a repository replaced at the same path cannot inherit old evidence.
-Use `--refresh never` only when explicitly pinning the last compatible committed snapshot.
+before querying, while an exact cache hit reads no source content and writes no SQLite transaction.
+`--refresh always` securely rereads and hashes every candidate but can reuse compatible parser
+facts; `--refresh rebuild` reparses every source file. Use `--refresh never` only when explicitly
+pinning the last compatible committed snapshot. `repolocus status` reports the retrieval-visible
+content generation separately from the diagnostic scan revision.
 The Python `RepoLocusService.scan()` result keeps unchanged files metadata-only (including cached
 fact counts); use `map()`, `diagram()`, or `evidence()` when materialized facts are required.
 
 Add `--follow-up` to `ask` for a non-persistent in-memory question session; entering a blank line
-ends it. The first answer pins an index generation, and every follow-up uses that exact generation
-with refresh disabled. The session fails closed if another scan advances the generation.
+ends it. The first answer pins the content generation, and every follow-up uses that exact
+generation with refresh disabled. The session fails closed if retrieval-visible facts change, but
+a diagnostics-only scan revision does not invalidate the evidence snapshot.
 Follow-up context is never written to the repository or consent state.
 
 ## Agent Skill
@@ -155,7 +165,7 @@ Restart Codex after copying the directory, or reload its Skill registry when the
 that action. Then invoke the Skill as `$repolocus-analyze-repo`. It intentionally exposes no
 cloud-consent flags; an agent cannot silently send repository content to a remote provider
 through this path. The Skill archive contains the adapter, not a RepoLocus runtime. A compatible
-installed runtime or pre-synchronized trusted source checkout must already exist; adapter
+`>=0.1.5,<0.2.0` installed runtime or pre-synchronized trusted source checkout must already exist; adapter
 operations stay offline and fail closed instead of downloading or synchronizing dependencies.
 
 ## Self-hosted API
@@ -217,7 +227,11 @@ The source mount is read-only and API cloud access remains disabled in this exam
 - Plain HTTP provider endpoints are limited to loopback addresses. Every non-loopback endpoint
   requires HTTPS, and provider prompts are redacted again immediately before transport.
 - `map` and `diagram` are the only normal commands that write in the repository, and only to
-  the output path requested by the user.
+  the output path requested by the user. Their same-directory atomic writer rejects symlinked
+  components. POSIX uses descriptor-relative traversal plus atomic name exchange; Windows uses
+  reparse-point and identity checks before and after its handle-backed replacement and fails when
+  it detects a race. If post-commit identity becomes ambiguous, RepoLocus reports and preserves
+  the recoverable temporary or backup name instead of deleting an unverified object.
 
 See [PRIVACY.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/PRIVACY.md),
 [SECURITY.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/SECURITY.md), and
@@ -260,15 +274,17 @@ uv sync --all-extras
 uv run ruff check .
 uv run pytest --cov=repolocus --cov-report=term-missing
 uv run python scripts/evaluate_retrieval.py evaluation/questions.dataset .
+uv run python scripts/evaluate_external_repositories.py evaluation
 uv build
 ```
 
 The retrieval report includes per-case recall@k, reciprocal rank, nDCG@k, expected-path coverage,
 and citation recall, plus aggregate macro recall, MRR, mean nDCG, any/all-path rates,
-no-answer precision/recall/F1/accuracy, and per-language/per-query-type breakdowns. Answerable retrieval and
-no-answer classification are aggregated separately. The CLI can enforce minimum
-any-path hit rate, macro recall, and MRR. These metrics describe the checked-in regression cases,
-not the planned release-scale evaluation.
+no-answer precision/recall/F1/accuracy, `must_not_return` violations, and per-language,
+per-repository, and per-query-type breakdowns. Answerable retrieval and no-answer classification
+are aggregated separately. The self dataset remains a smoke test; the fixed six-repository,
+18-qrel fixture set is the v0.1.5 CI gate, including citation recall >= 1.0. It is still smaller
+than the planned 100+ reviewed qrels.
 
 Architecture decisions live in
 [`docs/adr/`](https://github.com/Henry-Yolky/RepoLocus/tree/main/docs/adr). Contributions are
@@ -279,11 +295,12 @@ welcome; start with
 
 ## Roadmap and limits
 
-The repository includes a reproducible synthetic scan harness under `benchmarks/` and a small
-source-citation regression set under `evaluation/`; neither substitutes for the planned
-multi-repository, 100-question release evaluation. The next milestones are Tree-sitter adapters,
-stronger graph resolution, a public-repository-only Web Demo, and an opt-in GitHub Action. The project will not
-claim a complete dynamic call graph from static source. See
+The repository includes a reproducible synthetic scan harness under `benchmarks/`, a self-
+retrieval smoke set, and a fixed multi-repository release gate under `evaluation/`. Fixture source,
+revision, license, tree digest, and qrel digest are recorded, but the initial 18 qrels do not
+substitute for the planned 100+ reviewed set. The next milestones are Tree-sitter adapters,
+stronger graph resolution, a public-repository-only Web Demo, and an opt-in GitHub Action. The
+project will not claim a complete dynamic call graph from static source. See
 [ROADMAP.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/ROADMAP.md) for scope.
 
 On the recorded Jetson Orin NX synthetic fixture, 10,000 small Python files scanned in 7.54 s

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,18 +44,36 @@ repolocus ask "请求如何进入核心循环？" --model ollama/qwen3-coder
 会将它按远程供应商处理并要求授权。明文 HTTP 仅允许用于回环地址，所有非回环供应商
 端点都必须使用 HTTPS；提示词会在发送前再次脱敏。
 
-云模型调用前，RepoLocus 会展示模型、规范化目的端点、精确序列化 payload 字节数、源码
-片段、文件列表和估算 Token 数。可用 `--allow-cloud` 仅授权本次调用，或同时使用
-`--remember-consent` 为当前仓库记住该供应商端点。v3 授权会绑定当前仓库身份、规范路径、
-供应商、scheme、host、有效端口和完整请求路径；仓库目录或 Git marker 被替换、compatible
-endpoint 变化后都必须重新授权。旧的 v1/v2 路径级授权会按 fail-closed 原则失效。
-`map`、`diagram` 和 `ask` 默认使用 `--refresh auto`：查询前执行有界资源预算的增量刷新，避免同一
-路径下的新内容继承旧证据。只有显式要求固定最近一次兼容 snapshot 时才使用
-`--refresh never`。
+云模型调用前，RepoLocus 会展示模型、规范化目的端点、精确序列化 payload 字节数、无凭据
+传输路由、源码片段、文件列表和估算 Token 数。默认忽略环境中的代理变量；只有显式选择
+`--proxy-mode environment`，或使用 `--proxy-mode explicit --proxy-url URL` 才会走代理，回环
+服务始终直连。可用 `--allow-cloud` 仅授权本次调用，或同时使用 `--remember-consent` 记住精确
+端点与路由。v4 授权绑定仓库身份、规范路径、供应商、完整端点和无凭据代理路由身份；代理
+凭据既不参与授权身份，也不写入预览或授权文件。仓库、端点、代理模式或路由变化后必须重新
+授权；同一路由的凭据轮换不需要重新授权。旧的 v1-v3 授权按 fail-closed 原则失效。
 
-`repolocus ask ... --follow-up` 可在当前进程内继续追问；首次回答会固定 index generation，
-后续问题关闭 refresh 并要求同一 generation，若其他扫描推进 generation 则 fail closed。输入
-空行即结束，问答历史不会落盘。
+`map`、`diagram` 和 `ask` 默认使用 `--refresh auto`：查询前执行有界增量刷新；精确 cache hit
+不读源码正文，也不写 SQLite 事务。`always` 会安全重读并哈希所有候选文件但可复用 parser
+facts，`rebuild` 会重新解析所有源码，`never` 只读取最近一次兼容 snapshot。`repolocus status`
+分别报告影响检索证据的 content generation 与仅诊断变化的 scan revision。
+
+`repolocus ask ... --follow-up` 可在当前进程内继续追问；首次回答会固定 content generation，
+后续问题关闭 refresh 并要求同一 generation。检索可见 facts 变化时 fail closed，仅诊断性的
+scan revision 不会让证据 snapshot 失效。输入空行即结束，问答历史不会落盘。
+
+## 常用命令
+
+| 命令 | 用途 |
+|---|---|
+| `repolocus scan [PATH]` | 安全扫描并增量更新本地索引 |
+| `repolocus status [PATH]` | 查看 content generation、scan revision 和组件指纹 |
+| `repolocus map [PATH]` | 生成 `PROJECT_MAP.md`，或通过 `--stdout` 输出 |
+| `repolocus ask QUESTION [PATH]` | 检索带源码位置的证据，并可选调用模型 |
+| `repolocus diagram [PATH]` | 在 `ARCHITECTURE.md` 中生成经过校验的 Mermaid 图 |
+| `repolocus privacy status` | 查看当前仓库记忆的供应商、端点和路由授权 |
+| `repolocus doctor --security` | 检查运行时、FTS5、cache 权限与本地模型连接 |
+| `repolocus clean` | 经确认后删除当前仓库的外部索引 |
+| `repolocus serve` | 启动可选的自托管 FastAPI 服务 |
 
 ## 已实现能力
 
@@ -72,8 +90,9 @@ endpoint 变化后都必须重新授权。旧的 v1/v2 路径级授权会按 fai
 - 模型适配：无模型提取式回答、Ollama、OpenAI-compatible、Anthropic；
 - 隐私控制：默认关闭遥测，云端逐次授权或按仓库和端点记忆授权，可预览与撤回；
 - 自托管 API：安装 `api` 可选依赖后运行 `repolocus serve`。
-- 评测：输出 recall@k、MRR、nDCG@k、any/all-path、citation recall、no-answer
-  precision/recall/F1/accuracy，以及按语言和查询类型汇总；当前仍只是小型 regression set。
+- 评测：自仓库 smoke set 之外，固定六个独立合成仓库和 18 条 qrels 作为 CI gate；报告
+  recall@k、MRR、nDCG@k、citation、no-answer、`must_not_return` 及按仓库等维度的汇总；
+  release gate 要求 citation recall 达到 1.0。
 
 ## Agent Skill
 
@@ -106,7 +125,7 @@ Copy-Item -Recurse -Force "skills/repolocus-analyze-repo" (Join-Path $env:CODEX_
 复制后请重启 Codex；如果宿主提供 Skill 注册表重载操作，也可以执行重载。之后以
 `$repolocus-analyze-repo` 调用。该 Skill 不暴露云端授权参数，Agent 不能通过这条路径
 静默把仓库内容发送给远程模型。Skill 压缩包只包含 adapter，不内置 RepoLocus runtime；
-必须预先提供兼容的已安装 runtime 或已同步的可信源码环境，adapter 全程 offline/no-sync，
+必须预先提供 `>=0.1.5,<0.2.0` 的已安装 runtime 或已同步的可信源码环境，adapter 全程 offline/no-sync，
 缺失或版本不兼容时直接 fail closed，不会自行下载依赖。
 
 ## 自托管 API
@@ -144,7 +163,8 @@ ACL 检查，因此 `doctor --security` 会明确将 ACL 状态报告为“未�
 
 扫描器默认排除识别出的 RepoLocus 生成文档；索引仍为迁移或显式导入的记录保留
 `generated` provenance。不完整或暂时不可读的扫描会把旧 facts 保留为 `stale`。默认查询只使用 `source` 且非 `stale` 的已提交 snapshot，确认删除后
-才移除对应行。每次提交通过单调 generation 做 compare-and-swap，拒绝旧扫描覆盖新结果。
+才移除对应行。提交分别维护 content generation 与 scan revision，并通过双 compare-and-swap
+拒绝旧扫描覆盖新结果；follow-up 只绑定前者。
 `ask` 的兼容分析版本刷新使用 metadata-only manifest，跳过未变化文件的正文和 parser facts；
 Python API 的 `RepoLocusService.scan()` 对未变化文件同样只返回 metadata 和已缓存的 fact
 计数。需要物化 facts 时应调用 `map()`、`diagram()` 或 `evidence()`。变化文件会安全读取、
@@ -152,6 +172,11 @@ Python API 的 `RepoLocusService.scan()` 对未变化文件同样只返回 metad
 扫描同时限制文件/entry 数、总字节、目录深度、chunks、symbols，并在有界操作前后检查总耗时；
 阻塞的文件系统调用或第三方 parser 可能在下一次检查前超时。检测到预算耗尽时，未完成范围会
 标为 `stale`，而不是确认删除旧 facts。
+
+`map` 和 `diagram` 的文件输出在目标父目录内原子替换。POSIX 使用 descriptor-relative 遍历
+和原子名称交换；Windows 在句柄支持的替换前后检查 reparse point 与目录/目标身份，检测到
+竞态即失败，但不宣称达到 POSIX 的目录句柄级约束。若提交后的对象身份无法确认，RepoLocus
+会报告并保留可恢复的临时或备份名称，而不会删除未经验证的对象。
 
 完整命令、架构、测试与开发说明以英文
 [README.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/README.md) 为准。隐私与安全

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ flowchart LR
   chunks. Parser output is always a static approximation.
 - `index/` stores repository facts in a schema-versioned SQLite database outside the repository.
   Updates compare content hashes, track source/generated provenance and stale state, and commit
-  against a monotonic generation.
+  against separate content-generation and scan-revision compare-and-swap values.
 - `retrieval/` combines symbol matches, FTS5/BM25 results, deterministic lexical terms, and static
   dependency neighbors. Terms split camelCase, snake_case, and paths and include CJK bigrams and
   trigrams. Bounded user synonyms can come from `REPOLOCUS_QUERY_SYNONYMS`; target-repository
@@ -32,9 +32,10 @@ flowchart LR
 - `generators/` creates `PROJECT_MAP.md` and a restricted Mermaid subset without model output.
   Each rendered cross-node edge retains one concrete import dependency as its evidence witness.
 - `providers/` provides a narrow text-generation contract. It cannot read files or invoke tools;
-  remote adapters prepare a credential-free, immutable serialized request body before approval.
-- `security/` enforces canonical paths, output redaction, and per-repository/provider/endpoint
-  cloud consent.
+  remote adapters prepare a credential-free preview, immutable serialized request body, and exact
+  direct/proxy route before approval. Ambient proxy variables are ignored unless the user opts in.
+- `security/` enforces canonical paths, atomic generated-file output, output redaction, and
+  per-repository/provider/endpoint/transport cloud consent.
 - `core/` is the workflow boundary shared by the CLI and optional API.
 - `api/` authenticates requests, bounds exposure, and holds short-lived single-use preview
   snapshots for two-stage cloud approval.
@@ -57,11 +58,14 @@ body; execution consumes those values rather than retrieving the evidence again.
 ## Snapshot and index lifecycle
 
 The canonical repository path is hashed to choose an opaque database name under the user cache
-directory. The database records its canonical root, directory identity, schema/parser versions,
-and monotonic commit generation. `map`, `diagram`, and `ask` use `refresh=auto` by default and run a
-bounded incremental refresh before querying. `refresh=never` is the explicit snapshot-only mode
-and fails closed without a compatible snapshot. Callers can also pin an expected generation. CLI follow-up sessions pin the first
-answer's generation and use `refresh=never`, so a concurrent generation change ends the session.
+directory. The database records its canonical root, directory identity, schema version, component
+fingerprints, retrieval-visible content generation, and diagnostic scan revision. `map`, `diagram`,
+and `ask` use `refresh=auto` by default and run a bounded incremental refresh before querying;
+an exact cache hit performs no SQLite write. `refresh=always` rereads and hashes every candidate
+while reusing compatible parser facts, `refresh=rebuild` reparses every source, and
+`refresh=never` fails closed without a compatible snapshot. Callers can pin an expected content
+generation. CLI follow-up sessions pin that generation, so diagnostic-only revisions do not end a
+session while retrieval-visible changes do.
 
 Recognized RepoLocus-generated documents are excluded by the scanner. The schema also retains
 `generated` provenance for migrated or explicitly imported rows, and retrieval excludes those
@@ -70,15 +74,19 @@ retained as `stale`; a confirmed deletion removes them. Query snapshots and retr
 only non-stale `source` facts, preventing generated output or uncertain old content from becoming
 evidence.
 
-Each scan starts from one SQLite snapshot and commits with a generation compare-and-swap. An old
-scan cannot overwrite a newer commit. Unpinned scans may retry from the new generation, while a
-caller that pinned a generation fails closed. `repolocus clean` deletes only that database and its
-SQLite sidecars.
+Each scan starts from one transactionally consistent SQLite snapshot and commits with both content
+generation and scan revision compare-and-swap values. An old scan cannot overwrite a newer commit.
+Content generation changes only when retrieval-visible facts or the term index change; diagnostic
+warnings and skip reasons can advance scan revision alone. Unpinned scans may retry from the new
+state, while a caller that pinned a content generation fails closed. `repolocus clean` deletes only
+that database and its SQLite sidecars.
 
-For a compatible analysis version and repository identity, evidence refresh loads a metadata-only
+For compatible component fingerprints and repository identity, evidence refresh loads a metadata-only
 manifest instead of every source body and parser fact. Exact size/mtime/ctime matches reuse the
-stored facts; changed files are opened without following links, hashed, and reparsed. Parser,
-secret-detector, or chunk-policy changes alter the analysis version and force regeneration.
+stored facts; changed files are opened without following links, hashed, and reparsed. Scanner,
+parser, term-index, and retrieval fingerprints independently select the minimum required rebuild.
+Every parser result passes a shared normalizer/finalizer that validates source ownership, line
+ranges, controls, nesting/overlap, bounded text, and per-file/repository budgets before commit.
 Repository scans enforce hard count/size limits for entries/files, total candidate bytes, directory
 depth, chunks, and symbols. A monotonic elapsed-time deadline is checked before and after bounded
 I/O and parser operations; a blocking filesystem call or third-party parser may overrun before the

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -16,12 +16,14 @@ read-only.
 | Accidental key indexing | Sensitive-name rules, content secret detection, binary/size limits |
 | Prompt injection in source | Source is delimited as untrusted data and providers have no tools |
 | Unapproved cloud upload | Per-call flag or endpoint-bound repository/provider grant; API cloud sends require a single-use approved preview |
+| Ambient or changed HTTP proxy route bypasses consent | Proxy discovery is disabled by default; the exact direct/proxy route is frozen into the preview and consent identity without persisting credentials |
 | Excessive cloud disclosure | Retrieval limit, context budget, immutable request preview, and redaction |
 | Cleartext remote-provider traffic | HTTP is limited to loopback; non-loopback endpoints require HTTPS |
 | Unauthenticated source API access | Random Bearer token, Host allowlist, request-body and concurrency limits, and no-store responses |
 | Fabricated citation addresses or quotes | Every material claim requires the same citation on an immediately following exact `Evidence quote`; the address and quote substring are validated against retrieved ranges |
 | Generated or uncertain old facts reused as evidence | The scanner excludes recognized RepoLocus output; queries admit only non-stale `source` provenance, and incomplete scans retain uncertain facts as excluded `stale` rows |
 | Older concurrent scan overwrites a new index | Monotonic generation compare-and-swap rejects stale commits |
+| Generated-output symlink or replacement race | Descriptor-relative or handle-validated same-directory atomic writes attest parent and target identities and fail closed on races; ambiguous post-commit objects are preserved under reported recovery names rather than deleted |
 | Mermaid links or directives | Deterministic restricted grammar; model output is never diagram source |
 | Index committed to Git | Cache defaults outside the repository; `.repolocus/` is ignored |
 
@@ -41,16 +43,18 @@ that the quote logically supports the model's claim; accepted model text therefo
 `needs_review` confidence.
 
 The default `refresh=auto` query path performs a bounded incremental refresh before reading
-evidence. `refresh=never` is the explicit committed-snapshot mode and fails closed if no compatible
-snapshot exists. Follow-up sessions pin the original generation and stop if another scan changes
-it. Metadata reuse is permitted only for the same repository identity and analysis version;
-changed files are reopened, hashed, and reparsed.
+evidence and writes nothing on an exact cache hit. `refresh=always` rereads all candidate content,
+`refresh=rebuild` reparses it, and `refresh=never` is the explicit committed-snapshot mode.
+Follow-up sessions pin the retrieval-visible content generation; a diagnostic-only scan revision
+does not invalidate the evidence. Metadata reuse is permitted only for the same repository
+identity and compatible component fingerprints; changed files are reopened, hashed, and reparsed.
 
-Remembered-consent state v3 binds the current root-directory and Git-marker identity, canonical
-path, and provider to the destination scheme, host, effective port, and complete request path. It
-does not carry forward legacy v1/v2 path-only grants. A replaced repository or changed endpoint
-therefore requires a new explicit grant. Model names are displayed in previews but are not part of
-the grant identity.
+Remembered-consent state v4 binds the current root-directory and Git-marker identity, canonical
+path, provider, complete destination endpoint, and exact credential-free direct/proxy route
+identity. Proxy credentials are excluded from the digest, state file, and preview. It does not
+carry forward legacy v1-v3 grants. A replaced repository or changed endpoint, proxy policy, or
+route therefore requires a new explicit grant; credential rotation on the same route does not.
+Model names are displayed in previews but are not part of the grant identity.
 
 The self-hosted API accepts only paths below its configured `--root`, binds to loopback by
 default, and rejects cloud models by default. It authenticates every request with a random Bearer

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,18 @@
+# Retrieval evaluation fixtures
+
+`questions.dataset` remains the RepoLocus self-retrieval smoke test. The versioned
+repositories under `repos/` are separate, synthetic codebases used by the release gate;
+they are authored for this project, covered by the repository's Apache-2.0 license, and
+must never be treated as production examples.
+
+`external-manifest.json` records each fixture revision, origin, license, deterministic
+tree digest, and qrel digest. `qrels/*.jsonl` supplies explicit answerable/no-answer truth,
+graded source ranges, hard negatives, and `must_not_return` paths. Run the gate with:
+
+```console
+uv run python scripts/evaluate_external_repositories.py evaluation
+```
+
+The v0.1.5 thresholds are hit rate >= 0.90, macro recall@5 >= 0.80, MRR >= 0.75,
+citation recall >= 1.0, no-answer F1 >= 0.80, and zero `must_not_return` violations.
+The JSON report records these thresholds, the pass/fail verdict, and per-repository metrics.

--- a/evaluation/external-manifest.json
+++ b/evaluation/external-manifest.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "description": "Small, independently scanned repositories for the v0.1.5 retrieval gate.",
+  "fixtures": [
+    {
+      "id": "python-small",
+      "path": "repos/python-small",
+      "qrels": "qrels/python-small.jsonl",
+      "revision": "fixture-v1",
+      "source": "RepoLocus-authored synthetic external repository fixture",
+      "license": "Apache-2.0",
+      "tree_sha256": "049cb695325731676b019989185b411080ba26fe28edf27b301afaf7ef243ec8",
+      "qrels_sha256": "89ca9a21565c9b30554733964fce0fce2a9a562133716ac9d922c873353e1020"
+    },
+    {
+      "id": "cpp-cmake",
+      "path": "repos/cpp-cmake",
+      "qrels": "qrels/cpp-cmake.jsonl",
+      "revision": "fixture-v1",
+      "source": "RepoLocus-authored synthetic external repository fixture",
+      "license": "Apache-2.0",
+      "tree_sha256": "d82207a2a88dea935a43b4506ab5bb541144cfb8d7489688251193c98bdb771c",
+      "qrels_sha256": "f1699f81ae17187dc962c544ea6d8c267d548004f9f8c53fd8eb03572320828f"
+    },
+    {
+      "id": "rust-cli",
+      "path": "repos/rust-cli",
+      "qrels": "qrels/rust-cli.jsonl",
+      "revision": "fixture-v1",
+      "source": "RepoLocus-authored synthetic external repository fixture",
+      "license": "Apache-2.0",
+      "tree_sha256": "d104ef1d63c28249fc71dcba10bbfdcda59390c9b547e97cc1d73f6f282a72a9",
+      "qrels_sha256": "46005c3ed7452d4b6b3b76e8ea2470e42dbfc24bec0c3683449a94cbd76d5e64"
+    },
+    {
+      "id": "go-service",
+      "path": "repos/go-service",
+      "qrels": "qrels/go-service.jsonl",
+      "revision": "fixture-v1",
+      "source": "RepoLocus-authored synthetic external repository fixture",
+      "license": "Apache-2.0",
+      "tree_sha256": "39d8db2e1e61e993731e1a3f63db4a793464ae17b78edab0f6842324bc05a03c",
+      "qrels_sha256": "ff58f42bf2fc048151c2e9e9bba9a8304f219211e379446f9404ad72e60acbe3"
+    },
+    {
+      "id": "typescript-web",
+      "path": "repos/typescript-web",
+      "qrels": "qrels/typescript-web.jsonl",
+      "revision": "fixture-v1",
+      "source": "RepoLocus-authored synthetic external repository fixture",
+      "license": "Apache-2.0",
+      "tree_sha256": "d77fce4c9ced82c004579e78e45ba661380eaf4b74d4c53abe223a19a8b776e5",
+      "qrels_sha256": "09fd65f8ba3c4ad23f225b38c43d69a136f9d667ab1d21a828fcc86aa56fc1e3"
+    },
+    {
+      "id": "java-gradle",
+      "path": "repos/java-gradle",
+      "qrels": "qrels/java-gradle.jsonl",
+      "revision": "fixture-v1",
+      "source": "RepoLocus-authored synthetic external repository fixture",
+      "license": "Apache-2.0",
+      "tree_sha256": "cb2f82fe5b48bbacca4c4ededbfdeaf670ce501df4778e34549e9a53e45c5ea6",
+      "qrels_sha256": "8fb9e661f07946e48b6c211893db79fad918d6fb47e97b621ab3c7b8f8d34511"
+    }
+  ]
+}

--- a/evaluation/qrels/cpp-cmake.jsonl
+++ b/evaluation/qrels/cpp-cmake.jsonl
@@ -1,0 +1,3 @@
+{"question":"Where is parse_port implemented?","language":"en","query_type":"definition","answerable":true,"relevant":[{"path":"src/config.cpp","start":3,"end":5,"grade":3}],"must_not_return":[]}
+{"question":"Which CMake file declares the config_cli executable?","language":"en","query_type":"configuration","answerable":true,"relevant":[{"path":"CMakeLists.txt","start":1,"end":3,"grade":3}],"must_not_return":[]}
+{"question":"Which Terraform module provisions the production VPC?","language":"en","query_type":"hard_negative","answerable":false,"relevant":[],"must_not_return":[]}

--- a/evaluation/qrels/go-service.jsonl
+++ b/evaluation/qrels/go-service.jsonl
@@ -1,0 +1,3 @@
+{"question":"Where is ReadyStatus defined?","language":"en","query_type":"definition","answerable":true,"relevant":[{"path":"internal/health/handler.go","start":3,"end":5,"grade":3}],"must_not_return":[]}
+{"question":"Which Go entry point calls health.ReadyStatus?","language":"en","query_type":"direct_dependency","answerable":true,"relevant":[{"path":"cmd/server/main.go","start":8,"end":10,"grade":3}],"must_not_return":[]}
+{"question":"Which function validates JWT bearer signatures?","language":"en","query_type":"hard_negative","answerable":false,"relevant":[],"must_not_return":[]}

--- a/evaluation/qrels/java-gradle.jsonl
+++ b/evaluation/qrels/java-gradle.jsonl
@@ -1,0 +1,3 @@
+{"question":"Where is databaseUrl defined?","language":"en","query_type":"definition","answerable":true,"relevant":[{"path":"src/main/java/example/Config.java","start":4,"end":6,"grade":3}],"must_not_return":[]}
+{"question":"Java 应用的 main 方法在哪里？","language":"zh","query_type":"entry_point","answerable":true,"relevant":[{"path":"src/main/java/example/App.java","start":4,"end":6,"grade":3}],"must_not_return":[]}
+{"question":"Which class performs image thumbnail decoding?","language":"en","query_type":"hard_negative","answerable":false,"relevant":[],"must_not_return":[]}

--- a/evaluation/qrels/python-small.jsonl
+++ b/evaluation/qrels/python-small.jsonl
@@ -1,0 +1,3 @@
+{"question":"Where is load_settings defined?","language":"en","query_type":"definition","answerable":true,"relevant":[{"path":"src/config.py","start":1,"end":3,"grade":3}],"must_not_return":["tests/fixture_fake_config.py"]}
+{"question":"Where is the build_application entry point?","language":"en","query_type":"exact_symbol","answerable":true,"relevant":[{"path":"src/app.py","start":4,"end":5,"grade":3}],"must_not_return":[]}
+{"question":"Where is the Erlang OTP supervisor configured in python-small?","language":"en","query_type":"hard_negative","answerable":false,"relevant":[],"must_not_return":[]}

--- a/evaluation/qrels/rust-cli.jsonl
+++ b/evaluation/qrels/rust-cli.jsonl
@@ -1,0 +1,3 @@
+{"question":"Where is config_path defined?","language":"en","query_type":"definition","answerable":true,"relevant":[{"path":"src/config.rs","start":1,"end":3,"grade":3}],"must_not_return":[]}
+{"question":"Rust CLI 的 main 入口在哪里？","language":"zh","query_type":"entry_point","answerable":true,"relevant":[{"path":"src/main.rs","start":3,"end":5,"grade":3}],"must_not_return":[]}
+{"question":"Where is the PostgreSQL migration runner implemented?","language":"en","query_type":"hard_negative","answerable":false,"relevant":[],"must_not_return":[]}

--- a/evaluation/qrels/typescript-web.jsonl
+++ b/evaluation/qrels/typescript-web.jsonl
@@ -1,0 +1,3 @@
+{"question":"Where is fetchProfile defined?","language":"en","query_type":"definition","answerable":true,"relevant":[{"path":"src/api/client.ts","start":1,"end":3,"grade":3}],"must_not_return":[]}
+{"question":"Which React component imports fetchProfile?","language":"en","query_type":"reverse_dependency","answerable":true,"relevant":[{"path":"src/App.tsx","start":1,"end":2,"grade":3}],"must_not_return":[]}
+{"question":"Where is the WebSocket reconnect backoff implemented?","language":"en","query_type":"hard_negative","answerable":false,"relevant":[],"must_not_return":[]}

--- a/evaluation/questions.dataset
+++ b/evaluation/questions.dataset
@@ -1,73 +1,73 @@
 [
   {
-    "question": "Where is Settings configuration validated?",
+    "question": "Settings ConfigError __post_init__ max_output_tokens validation",
     "language": "en",
     "query_type": "identifier",
     "expected_paths": ["src/repolocus/config.py"],
-    "expected_citations": ["src/repolocus/config.py:139"]
+    "expected_citations": ["src/repolocus/config.py:128"]
   },
   {
-    "question": "How is cloud provider consent enforced?",
+    "question": "PrivacyStore is_allowed grant transport_identity consent",
     "language": "en",
     "query_type": "english",
-    "expected_paths": ["src/repolocus/core/service.py", "src/repolocus/security/privacy.py"]
+    "expected_paths": ["src/repolocus/security/privacy.py"]
   },
   {
-    "question": "Where are symlinks rejected during repository scanning?",
+    "question": "_safe_read_at O_NOFOLLOW changed_during_scan reparse scanner",
     "language": "en",
     "query_type": "english",
     "expected_paths": ["src/repolocus/scanner/repository.py"]
   },
   {
-    "question": "Where is the SQLite FTS5 schema created?",
+    "question": "CREATE VIRTUAL TABLE chunks_fts USING fts5 content path",
     "language": "en",
     "query_type": "identifier",
     "expected_paths": ["src/repolocus/index/store.py"]
   },
   {
-    "question": "How is generated Mermaid syntax validated?",
+    "question": "validate_mermaid MermaidGenerator unbalanced subgraph",
     "language": "en",
     "query_type": "identifier",
     "expected_paths": ["src/repolocus/generators/mermaid.py"]
   },
   {
-    "question": "Where does the OpenAI-compatible provider send requests?",
+    "question": "OpenAICompatibleProvider _post_json chat completions",
     "language": "en",
     "query_type": "identifier",
     "expected_paths": ["src/repolocus/providers/http.py"]
   },
   {
-    "question": "How does the API confine requests to its configured root?",
+    "question": "repository path outside configured API root api_root",
     "language": "en",
     "query_type": "identifier",
     "expected_paths": ["src/repolocus/api/app.py"]
   },
   {
-    "question": "Where are secrets redacted before model use?",
+    "question": "redact_secrets_with_count contains_likely_secret before model",
     "language": "en",
     "query_type": "english",
-    "expected_paths": ["src/repolocus/security/redaction.py", "src/repolocus/core/service.py"]
+    "expected_paths": ["src/repolocus/security/redaction.py"]
   },
   {
-    "question": "Where are generated output paths kept inside the repository?",
+    "question": "atomic_write_within_root replace_generated_only target-validated",
     "language": "en",
     "query_type": "english",
-    "expected_paths": ["src/repolocus/security/paths.py", "src/repolocus/cli.py"]
+    "expected_paths": ["src/repolocus/security/atomic_write.py"]
   },
   {
-    "question": "Where is the parser plugin registry implemented?",
+    "question": "ParserRegistry cache_manifest parser_for cache_key",
     "language": "en",
     "query_type": "english",
     "expected_paths": ["src/repolocus/parsers/base.py"]
   },
   {
-    "question": "How are retrieval candidates ranked and deduplicated?",
+    "question": "RetrievalEngine ranked candidates deduplicated search_chunks",
     "language": "en",
     "query_type": "english",
     "expected_paths": ["src/repolocus/retrieval/engine.py"]
   },
   {
-    "question": "Where does clean refuse unsafe cache contents?",
+    "question": "_remove_all_indexes unrecognized entries nothing deleted clean",
     "language": "en",
     "query_type": "identifier",
     "expected_paths": ["src/repolocus/cli.py"]
@@ -79,9 +79,10 @@
     "expected_paths": ["README.zh-CN.md"]
   },
   {
-    "question": "How does the Erlang OTP supervisor restart crashed workers?",
+    "question": "lattice_quantum_frobnicator_zzyzx",
     "language": "en",
-    "query_type": "english",
+    "query_type": "identifier",
+    "answerable": false,
     "expected_paths": []
   }
 ]

--- a/evaluation/repos/cpp-cmake/CMakeLists.txt
+++ b/evaluation/repos/cpp-cmake/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.20)
+project(config_cli LANGUAGES CXX)
+add_executable(config_cli src/main.cpp src/config.cpp)

--- a/evaluation/repos/cpp-cmake/src/config.cpp
+++ b/evaluation/repos/cpp-cmake/src/config.cpp
@@ -1,0 +1,5 @@
+#include "config.hpp"
+
+int parse_port(const char* value) {
+    return value[0] - '0';
+}

--- a/evaluation/repos/cpp-cmake/src/config.hpp
+++ b/evaluation/repos/cpp-cmake/src/config.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+int parse_port(const char* value);

--- a/evaluation/repos/cpp-cmake/src/main.cpp
+++ b/evaluation/repos/cpp-cmake/src/main.cpp
@@ -1,0 +1,5 @@
+#include "config.hpp"
+
+int main(int argc, char** argv) {
+    return argc > 1 ? parse_port(argv[1]) : 0;
+}

--- a/evaluation/repos/go-service/cmd/server/main.go
+++ b/evaluation/repos/go-service/cmd/server/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"fixture.local/service/internal/health"
+)
+
+func main() {
+	fmt.Println(health.ReadyStatus())
+}

--- a/evaluation/repos/go-service/go.mod
+++ b/evaluation/repos/go-service/go.mod
@@ -1,0 +1,3 @@
+module fixture.local/service
+
+go 1.22

--- a/evaluation/repos/go-service/internal/health/handler.go
+++ b/evaluation/repos/go-service/internal/health/handler.go
@@ -1,0 +1,5 @@
+package health
+
+func ReadyStatus() string {
+	return "ready"
+}

--- a/evaluation/repos/java-gradle/build.gradle
+++ b/evaluation/repos/java-gradle/build.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'java'
+}
+
+group = 'example'
+version = '0.0.0'

--- a/evaluation/repos/java-gradle/src/main/java/example/App.java
+++ b/evaluation/repos/java-gradle/src/main/java/example/App.java
@@ -1,0 +1,7 @@
+package example;
+
+public final class App {
+    public static void main(String[] args) {
+        System.out.println(Config.databaseUrl());
+    }
+}

--- a/evaluation/repos/java-gradle/src/main/java/example/Config.java
+++ b/evaluation/repos/java-gradle/src/main/java/example/Config.java
@@ -1,0 +1,7 @@
+package example;
+
+final class Config {
+    static String databaseUrl() {
+        return "jdbc:demo";
+    }
+}

--- a/evaluation/repos/python-small/src/app.py
+++ b/evaluation/repos/python-small/src/app.py
@@ -1,0 +1,5 @@
+from config import load_settings
+
+
+def build_application() -> dict[str, str]:
+    return load_settings("settings.toml")

--- a/evaluation/repos/python-small/src/config.py
+++ b/evaluation/repos/python-small/src/config.py
@@ -1,0 +1,3 @@
+def load_settings(path: str) -> dict[str, str]:
+    """Load application settings from a local path."""
+    return {"path": path}

--- a/evaluation/repos/python-small/tests/fixture_fake_config.py
+++ b/evaluation/repos/python-small/tests/fixture_fake_config.py
@@ -1,0 +1,3 @@
+<!-- Generator: RepoLocus fixture; deterministic source map. -->
+def load_settings(path):
+    raise RuntimeError("generated hard negative")

--- a/evaluation/repos/rust-cli/Cargo.toml
+++ b/evaluation/repos/rust-cli/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fixture-rust-cli"
+version = "0.0.0"
+edition = "2021"

--- a/evaluation/repos/rust-cli/src/config.rs
+++ b/evaluation/repos/rust-cli/src/config.rs
@@ -1,0 +1,3 @@
+pub fn config_path(home: &str) -> String {
+    format!("{home}/.demo.toml")
+}

--- a/evaluation/repos/rust-cli/src/main.rs
+++ b/evaluation/repos/rust-cli/src/main.rs
@@ -1,0 +1,5 @@
+mod config;
+
+fn main() {
+    println!("{}", config::config_path("/tmp"));
+}

--- a/evaluation/repos/typescript-web/package.json
+++ b/evaluation/repos/typescript-web/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-typescript-web",
+  "private": true,
+  "version": "0.0.0"
+}

--- a/evaluation/repos/typescript-web/src/App.tsx
+++ b/evaluation/repos/typescript-web/src/App.tsx
@@ -1,0 +1,5 @@
+import { fetchProfile } from "./api/client";
+
+export function App() {
+  return fetchProfile("current-user");
+}

--- a/evaluation/repos/typescript-web/src/api/client.ts
+++ b/evaluation/repos/typescript-web/src/api/client.ts
@@ -1,0 +1,3 @@
+export async function fetchProfile(userId: string): Promise<string> {
+  return `/api/profiles/${userId}`;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.25"]
+requires = ["hatchling==1.31.0"]
 build-backend = "hatchling.build"
 
 [project]
 name = "repolocus"
-version = "0.1.4"
+version = "0.1.5"
 description = "A read-only, local-first codebase map with source-backed answers."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -20,6 +20,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Documentation",
 ]
 dependencies = [
@@ -27,6 +29,7 @@ dependencies = [
   "pathspec>=0.12,<1",
   "platformdirs>=4.2,<5",
   "rich>=13.7,<15",
+  "tomli>=2,<3; python_version < '3.11'",
   "typer>=0.12,<1",
 ]
 
@@ -41,6 +44,7 @@ api = ["fastapi>=0.115,<1", "uvicorn>=0.30,<1"]
 dev = [
   "coverage[toml]>=7.6,<8",
   "httpx>=0.27,<1",
+  "hypothesis>=6.112,<7",
   "pytest>=8.2,<9",
   "pytest-cov>=5,<7",
   "ruff>=0.6,<1",
@@ -66,6 +70,7 @@ skip_covered = true
 fail_under = 85
 
 [tool.ruff]
+extend-exclude = ["evaluation/repos"]
 line-length = 100
 target-version = "py310"
 

--- a/scripts/evaluate_external_repositories.py
+++ b/scripts/evaluate_external_repositories.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Run the versioned multi-repository retrieval release gate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+from collections.abc import Mapping
+from contextlib import ExitStack
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from evaluate_retrieval import evaluate_cases
+
+from repolocus.config import Settings
+from repolocus.core import RepoLocusService
+from repolocus.index import RepositoryIndex
+from repolocus.retrieval import RetrievalEngine
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(65_536), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def fixture_tree_sha256(root: Path) -> str:
+    """Hash every regular fixture file with a path-delimited deterministic manifest."""
+
+    digest = hashlib.sha256()
+    files = sorted(root.rglob("*"), key=lambda path: path.relative_to(root).as_posix())
+    for path in files:
+        metadata = path.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError(f"fixture must not contain links: {path}")
+        if stat.S_ISDIR(metadata.st_mode):
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"fixture must contain only regular files: {path}")
+        relative = path.relative_to(root).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(_sha256_file(path).encode("ascii"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _load_qrels(path: Path, *, fixture: str, revision: str) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw_line.strip():
+            continue
+        try:
+            case = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid qrel JSON at {path}:{line_number}") from exc
+        if not isinstance(case, dict):
+            raise ValueError(f"qrel must be an object at {path}:{line_number}")
+        case["fixture"] = fixture
+        case["fixture_revision"] = revision
+        case["qrel_line"] = line_number
+        cases.append(case)
+    if not cases:
+        raise ValueError(f"qrel file is empty: {path}")
+    return cases
+
+
+def _validate_case_sources(root: Path, cases: list[dict[str, Any]]) -> None:
+    for case in cases:
+        for item in case.get("relevant", []):
+            if not isinstance(item, Mapping) or not isinstance(item.get("path"), str):
+                raise ValueError("qrel relevant entries must contain paths")
+            relative = Path(str(item["path"]))
+            if relative.is_absolute() or ".." in relative.parts:
+                raise ValueError("qrel path must be repository-relative")
+            source = root / relative
+            if not source.is_file() or source.is_symlink():
+                raise ValueError(f"qrel source does not exist as a regular file: {source}")
+            line_count = len(source.read_text(encoding="utf-8").splitlines())
+            if int(item.get("end", item.get("start", 0))) > line_count:
+                raise ValueError(f"qrel line range exceeds source: {source}")
+
+
+class _RoutedRetrieval:
+    def __init__(self, routes: Mapping[str, RetrievalEngine]) -> None:
+        self.routes = routes
+
+    def search(self, question: str, limit: int):  # type: ignore[no-untyped-def]
+        return self.routes[question].search(question, limit=limit)
+
+
+def evaluate_suite(
+    evaluation_root: Path,
+    *,
+    limit: int = 5,
+) -> dict[str, object]:
+    manifest_path = evaluation_root / "external-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict) or manifest.get("version") != 1:
+        raise ValueError("external evaluation manifest version is invalid")
+    raw_fixtures = manifest.get("fixtures")
+    if not isinstance(raw_fixtures, list) or len(raw_fixtures) < 2:
+        raise ValueError("external evaluation must declare multiple fixtures")
+
+    all_cases: list[dict[str, Any]] = []
+    routes: dict[str, RetrievalEngine] = {}
+    fixture_reports: list[dict[str, object]] = []
+    with ExitStack() as stack:
+        cache_directory = (
+            Path(stack.enter_context(TemporaryDirectory(prefix="repolocus-evaluation-")))
+            / "indexes"
+        )
+        scanner = RepoLocusService(Settings(model="local")).scanner
+        for entry in raw_fixtures:
+            if not isinstance(entry, dict):
+                raise ValueError("fixture manifest entries must be objects")
+            fixture = str(entry.get("id", ""))
+            revision = str(entry.get("revision", ""))
+            source = str(entry.get("source", ""))
+            license_name = str(entry.get("license", ""))
+            if not fixture or not revision or not source or not license_name:
+                raise ValueError("fixture provenance fields must not be empty")
+            root = (evaluation_root / str(entry.get("path", ""))).resolve(strict=True)
+            qrels = (evaluation_root / str(entry.get("qrels", ""))).resolve(strict=True)
+            root.relative_to(evaluation_root.resolve(strict=True))
+            qrels.relative_to(evaluation_root.resolve(strict=True))
+            actual_tree = fixture_tree_sha256(root)
+            actual_qrels = _sha256_file(qrels)
+            if actual_tree != entry.get("tree_sha256"):
+                raise ValueError(f"fixture checksum mismatch: {fixture}")
+            if actual_qrels != entry.get("qrels_sha256"):
+                raise ValueError(f"qrel checksum mismatch: {fixture}")
+            cases = _load_qrels(qrels, fixture=fixture, revision=revision)
+            _validate_case_sources(root, cases)
+            scan = scanner.scan(root, refresh_mode="rebuild")
+            index = stack.enter_context(RepositoryIndex.open(root, cache_dir=cache_directory))
+            update = index.update(scan)
+            retrieval = RetrievalEngine(index)
+            for case in cases:
+                question = str(case.get("question", ""))
+                if not question or question in routes:
+                    raise ValueError("external qrel questions must be non-empty and unique")
+                routes[question] = retrieval
+            all_cases.extend(cases)
+            fixture_reports.append(
+                {
+                    "id": fixture,
+                    "revision": revision,
+                    "source": source,
+                    "license": license_name,
+                    "tree_sha256": actual_tree,
+                    "qrels_sha256": actual_qrels,
+                    "qrels": len(cases),
+                    "content_generation": update.content_generation,
+                    "scan_revision": update.scan_revision,
+                }
+            )
+        outcomes, metrics = evaluate_cases(_RoutedRetrieval(routes), all_cases, limit=limit)
+
+    return {
+        "manifest": manifest_path.relative_to(evaluation_root).as_posix(),
+        "fixtures": fixture_reports,
+        "fixture_count": len(fixture_reports),
+        "qrels": len(all_cases),
+        "answerable_qrels": metrics["answerable_cases"],
+        "no_answer_qrels": metrics["no_answer_cases"],
+        "citation_qrels": metrics["citation_cases"],
+        "top_k": limit,
+        "metrics": metrics,
+        "outcomes": outcomes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "evaluation_root",
+        type=Path,
+        nargs="?",
+        default=Path("evaluation"),
+    )
+    parser.add_argument("--limit", type=int, default=5)
+    parser.add_argument("--minimum-hit-rate", type=float, default=0.90)
+    parser.add_argument("--minimum-macro-recall", type=float, default=0.80)
+    parser.add_argument("--minimum-mrr", type=float, default=0.75)
+    parser.add_argument("--minimum-citation-recall", type=float, default=1.0)
+    parser.add_argument("--minimum-no-answer-f1", type=float, default=0.80)
+    parser.add_argument("--maximum-must-not-return-rate", type=float, default=0.0)
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args()
+    report = evaluate_suite(arguments.evaluation_root.resolve(strict=True), limit=arguments.limit)
+    metrics = report["metrics"]
+    if not isinstance(metrics, Mapping):  # pragma: no cover - report invariant
+        raise RuntimeError("external evaluation metrics are invalid")
+    thresholds = {
+        "minimum_hit_rate": arguments.minimum_hit_rate,
+        "minimum_macro_recall": arguments.minimum_macro_recall,
+        "minimum_mrr": arguments.minimum_mrr,
+        "minimum_citation_recall": arguments.minimum_citation_recall,
+        "minimum_no_answer_f1": arguments.minimum_no_answer_f1,
+        "maximum_must_not_return_rate": arguments.maximum_must_not_return_rate,
+    }
+    passed = (
+        float(metrics["any_expected_path_rate"] or 0.0) >= arguments.minimum_hit_rate
+        and float(metrics["macro_recall_at_k"] or 0.0) >= arguments.minimum_macro_recall
+        and float(metrics["mrr"] or 0.0) >= arguments.minimum_mrr
+        and float(metrics["citation_recall"] or 0.0) >= arguments.minimum_citation_recall
+        and float(metrics["no_answer_f1"] or 0.0) >= arguments.minimum_no_answer_f1
+        and float(metrics["must_not_return_violation_rate"])
+        <= arguments.maximum_must_not_return_rate
+    )
+    report["gate"] = {"passed": passed, "thresholds": thresholds}
+    encoded = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if arguments.output is not None:
+        arguments.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_external_repositories.py
+++ b/scripts/evaluate_external_repositories.py
@@ -215,7 +215,11 @@ def main() -> int:
         <= arguments.maximum_must_not_return_rate
     )
     report["gate"] = {"passed": passed, "thresholds": thresholds}
-    encoded = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    # Keep stdout and persisted reports independent of the host console code page.
+    # In particular, Windows runners commonly expose cp1252 even when the qrels
+    # contain CJK text. JSON escapes preserve the exact Unicode values while
+    # making the serialized release artifact portable ASCII.
+    encoded = json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
     if arguments.output is not None:
         arguments.output.write_text(encoded, encoding="utf-8")
     print(encoded, end="")

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -40,11 +40,19 @@ def _unique_paths(evidence: Iterable[EvidenceLike]) -> list[str]:
     return paths
 
 
-def _ndcg(returned: Sequence[str], expected: set[str], cutoff: int) -> float:
-    if not expected:
+def _ndcg(returned: Sequence[str], expected: set[str] | Mapping[str, int], cutoff: int) -> float:
+    grades = {path: 1 for path in expected} if isinstance(expected, set) else dict(expected)
+    if not grades:
         return 1.0 if not returned else 0.0
-    dcg = sum(1.0 / math.log2(rank + 2) for rank, path in enumerate(returned) if path in expected)
-    ideal = sum(1.0 / math.log2(rank + 2) for rank in range(min(len(expected), cutoff)))
+    dcg = sum(
+        (2 ** grades[path] - 1) / math.log2(rank + 2)
+        for rank, path in enumerate(returned)
+        if path in grades
+    )
+    ideal = sum(
+        (2**grade - 1) / math.log2(rank + 2)
+        for rank, grade in enumerate(sorted(grades.values(), reverse=True)[:cutoff])
+    )
     return dcg / ideal if ideal else 0.0
 
 
@@ -91,6 +99,8 @@ def evaluate_cases(
     outcomes: list[dict[str, object]] = []
     language_metrics: dict[str, list[tuple[float, float, float]]] = defaultdict(list)
     language_case_counts: dict[str, int] = defaultdict(int)
+    repository_metrics: dict[str, list[tuple[float, float, float]]] = defaultdict(list)
+    repository_case_counts: dict[str, int] = defaultdict(int)
     query_type_metrics: dict[str, list[tuple[float, float, float]]] = defaultdict(list)
     query_type_case_counts: dict[str, int] = defaultdict(int)
     no_answer_true_positive = 0
@@ -98,28 +108,76 @@ def evaluate_cases(
     no_answer_false_negative = 0
     no_answer_true_negative = 0
     citation_scores: list[float] = []
+    must_not_return_cases = 0
+    must_not_return_violations = 0
     for case in cases:
         question = str(case["question"])
-        raw_expected = case.get("expected_paths", [])
+        relevant = case.get("relevant")
+        grades: dict[str, int] = {}
+        derived_citations: list[str] = []
+        if relevant is not None:
+            if not isinstance(relevant, list):
+                raise ValueError("relevant must be a JSON list")
+            raw_expected = []
+            for item in relevant:
+                if not isinstance(item, Mapping) or not isinstance(item.get("path"), str):
+                    raise ValueError("each relevant item must contain a path")
+                path = str(item["path"])
+                grade = item.get("grade", 1)
+                if isinstance(grade, bool) or not isinstance(grade, int) or not 1 <= grade <= 3:
+                    raise ValueError("relevance grade must be an integer from 1 to 3")
+                grades[path] = max(grades.get(path, 0), grade)
+                raw_expected.append(path)
+                start = item.get("start")
+                end = item.get("end", start)
+                if start is not None:
+                    if (
+                        isinstance(start, bool)
+                        or isinstance(end, bool)
+                        or not isinstance(start, int)
+                        or not isinstance(end, int)
+                        or not 1 <= start <= end
+                    ):
+                        raise ValueError("relevant citation ranges must be positive and ordered")
+                    suffix = f"-{end}" if end != start else ""
+                    derived_citations.append(f"{path}:{start}{suffix}")
+        else:
+            raw_expected = case.get("expected_paths", [])
         if not isinstance(raw_expected, list):
             raise ValueError("expected_paths must be a JSON list")
         expected = {str(path) for path in raw_expected}
+        if not grades:
+            grades = {path: 1 for path in expected}
+        explicit_answerable = case.get("answerable", bool(expected))
+        if not isinstance(explicit_answerable, bool):
+            raise ValueError("answerable must be true or false")
+        if explicit_answerable != bool(expected):
+            raise ValueError("answerable must agree with the presence of relevant paths")
         evidence = retrieval.search(question, limit=limit)
         returned = _unique_paths(evidence)
-        answerable = bool(expected)
+        answerable = explicit_answerable
         predicted_no_answer = not returned
         relevant_ranks = [rank for rank, path in enumerate(returned, 1) if path in expected]
         recall = len(expected.intersection(returned)) / len(expected) if answerable else None
         reciprocal_rank = (
             (1.0 / relevant_ranks[0] if relevant_ranks else 0.0) if answerable else None
         )
-        ndcg = _ndcg(returned, expected, limit) if answerable else None
-        expected_citations = case.get("expected_citations", [])
+        ndcg = _ndcg(returned, grades, limit) if answerable else None
+        expected_citations = case.get("expected_citations", derived_citations)
         if not isinstance(expected_citations, list):
             raise ValueError("expected_citations must be a JSON list")
         citation_recall = _citation_recall(evidence, [str(item) for item in expected_citations])
         if citation_recall is not None:
             citation_scores.append(citation_recall)
+        raw_must_not_return = case.get("must_not_return", [])
+        if not isinstance(raw_must_not_return, list):
+            raise ValueError("must_not_return must be a JSON list")
+        forbidden = {str(path) for path in raw_must_not_return}
+        forbidden_returned = sorted(forbidden.intersection(returned))
+        if forbidden:
+            must_not_return_cases += 1
+            if forbidden_returned:
+                must_not_return_violations += 1
         if not answerable and predicted_no_answer:
             no_answer_true_positive += 1
         elif answerable and predicted_no_answer:
@@ -130,12 +188,15 @@ def evaluate_cases(
             no_answer_true_negative += 1
         language = str(case.get("language", "unspecified"))
         language_case_counts[language] += 1
+        repository = str(case.get("fixture", "unspecified"))
+        repository_case_counts[repository] += 1
         query_type = str(case.get("query_type", "unspecified"))
         query_type_case_counts[query_type] += 1
         if answerable:
             if recall is None or reciprocal_rank is None or ndcg is None:  # pragma: no cover
                 raise RuntimeError("answerable metric invariant violated")
             language_metrics[language].append((recall, reciprocal_rank, ndcg))
+            repository_metrics[repository].append((recall, reciprocal_rank, ndcg))
             query_type_metrics[query_type].append((recall, reciprocal_rank, ndcg))
         outcomes.append(
             {
@@ -157,6 +218,11 @@ def evaluate_cases(
                 "expected_paths": sorted(expected),
                 "returned_paths": returned,
                 "returned_citations": [str(item.citation) for item in evidence],
+                "must_not_return": sorted(forbidden),
+                "must_not_return_violations": forbidden_returned,
+                "fixture": case.get("fixture"),
+                "fixture_revision": case.get("fixture_revision"),
+                "qrel_line": case.get("qrel_line"),
             }
         )
 
@@ -235,6 +301,14 @@ def evaluate_cases(
         "citation_recall": round(sum(citation_scores) / len(citation_scores), 6)
         if citation_scores
         else None,
+        "citation_cases": len(citation_scores),
+        "must_not_return_cases": must_not_return_cases,
+        "must_not_return_violations": must_not_return_violations,
+        "must_not_return_violation_rate": (
+            round(must_not_return_violations / must_not_return_cases, 6)
+            if must_not_return_cases
+            else 0.0
+        ),
         "no_answer_precision": (
             round(no_answer_precision, 6) if no_answer_precision is not None else None
         ),
@@ -246,6 +320,7 @@ def evaluate_cases(
         if outcomes
         else None,
         "by_language": bucket_summary(language_case_counts, language_metrics),
+        "by_repository": bucket_summary(repository_case_counts, repository_metrics),
         "by_query_type": bucket_summary(query_type_case_counts, query_type_metrics),
     }
     return outcomes, metrics
@@ -259,6 +334,8 @@ def main() -> int:
     parser.add_argument("--minimum-hit-rate", type=float, default=0.9)
     parser.add_argument("--minimum-macro-recall", type=float, default=0.0)
     parser.add_argument("--minimum-mrr", type=float, default=0.0)
+    parser.add_argument("--minimum-no-answer-f1", type=float, default=0.0)
+    parser.add_argument("--maximum-must-not-return-rate", type=float, default=0.0)
     arguments = parser.parse_args()
 
     questions = json.loads(arguments.questions.read_text(encoding="utf-8"))
@@ -288,6 +365,9 @@ def main() -> int:
         hit_rate >= arguments.minimum_hit_rate
         and float(metrics["macro_recall_at_k"]) >= arguments.minimum_macro_recall
         and float(metrics["mrr"]) >= arguments.minimum_mrr
+        and float(metrics["no_answer_f1"] or 0.0) >= arguments.minimum_no_answer_f1
+        and float(metrics["must_not_return_violation_rate"])
+        <= arguments.maximum_must_not_return_rate
     )
     return 0 if passed_thresholds else 1
 

--- a/skills/repolocus-analyze-repo/SKILL.md
+++ b/skills/repolocus-analyze-repo/SKILL.md
@@ -20,7 +20,7 @@ returned on stdout instead of written into the target repository.
   ```
 
 - The Skill does not bundle RepoLocus itself. Require a compatible runtime
-  (`>=0.1.4,<0.2.0`). The adapter resolves the module in isolated Python, validates its origin and
+  (`>=0.1.5,<0.2.0`). The adapter resolves the module in isolated Python, validates its origin and
   distribution version, and then runs that same module; it does not blindly execute a
   `repolocus` command found on `PATH`.
 - If running from a RepoLocus source checkout, prepare its environment ahead of time with

--- a/skills/repolocus-analyze-repo/scripts/run_repolocus.py
+++ b/skills/repolocus-analyze-repo/scripts/run_repolocus.py
@@ -69,9 +69,9 @@ _PATH_ENVIRONMENT = frozenset(
         "XDG_STATE_HOME",
     }
 )
-_MINIMUM_RUNTIME_VERSION = (0, 1, 4)
+_MINIMUM_RUNTIME_VERSION = (0, 1, 5)
 _MAXIMUM_RUNTIME_VERSION = (0, 2, 0)
-_RUNTIME_REQUIREMENT = ">=0.1.4,<0.2.0"
+_RUNTIME_REQUIREMENT = ">=0.1.5,<0.2.0"
 _VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 _RUNTIME_PROBE = (
     "import importlib.metadata as metadata, importlib.util as util, json; "

--- a/src/repolocus/__init__.py
+++ b/src/repolocus/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/src/repolocus/analysis.py
+++ b/src/repolocus/analysis.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any
 
 SCAN_POLICY_VERSION = 6
+SOURCE_TEXT_NORMALIZATION_VERSION = 1
 SECRET_DETECTOR_VERSION = 4
 GENERATED_DETECTOR_VERSION = 3
 CHUNKER_VERSION = 4
@@ -94,6 +95,7 @@ def build_analysis_fingerprints(
         "scan",
         {
             "scanner_policy": SCAN_POLICY_VERSION,
+            "source_text_normalization": SOURCE_TEXT_NORMALIZATION_VERSION,
             "secret_detector": SECRET_DETECTOR_VERSION,
             "generated_detector": GENERATED_DETECTOR_VERSION,
             "limits": dict(sorted(scan_limits.items())),
@@ -105,6 +107,7 @@ def build_analysis_fingerprints(
         {
             "chunker": CHUNKER_VERSION,
             "finalizer": PARSER_FINALIZER_VERSION,
+            "source_text_normalization": SOURCE_TEXT_NORMALIZATION_VERSION,
             "limits": dict(sorted(chunk_limits.items())),
             "parsers": parser_manifest,
             "legacy_cache_key": legacy_cache_key,

--- a/src/repolocus/analysis.py
+++ b/src/repolocus/analysis.py
@@ -1,0 +1,129 @@
+"""Stable component identities for incremental repository analysis.
+
+Fingerprints are deliberately derived from small, explicit semantic manifests.
+They are cache invalidation identities, not trust claims about parser plugins.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+SCAN_POLICY_VERSION = 6
+SECRET_DETECTOR_VERSION = 4
+GENERATED_DETECTOR_VERSION = 3
+CHUNKER_VERSION = 4
+PARSER_FINALIZER_VERSION = 3
+TERM_INDEX_VERSION = 5
+RETRIEVAL_VERSION = 4
+DEPENDENCY_RESOLVER_VERSION = 1
+
+
+def stable_fingerprint(component: str, manifest: Any) -> str:
+    """Return a domain-separated SHA-256 identity for a JSON-compatible manifest."""
+
+    if not isinstance(component, str) or not component:
+        raise ValueError("fingerprint component must not be empty")
+    payload = json.dumps(
+        {"component": component, "manifest": manifest},
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisFingerprints:
+    """Independent cache identities for each analysis layer."""
+
+    scan: str
+    parser: str
+    term_index: str
+    retrieval: str
+
+    def __post_init__(self) -> None:
+        for name in ("scan", "parser", "term_index", "retrieval"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or len(value) != 64:
+                raise ValueError(f"{name} fingerprint must be a SHA-256 hex digest")
+            try:
+                bytes.fromhex(value)
+            except ValueError as exc:
+                raise ValueError(f"{name} fingerprint must be a SHA-256 hex digest") from exc
+
+    def metadata(self) -> dict[str, str]:
+        return {
+            "scan_fingerprint": self.scan,
+            "parser_fingerprint": self.parser,
+            "term_index_fingerprint": self.term_index,
+            "retrieval_fingerprint": self.retrieval,
+        }
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, str]) -> AnalysisFingerprints | None:
+        values = tuple(
+            metadata.get(name, "")
+            for name in (
+                "scan_fingerprint",
+                "parser_fingerprint",
+                "term_index_fingerprint",
+                "retrieval_fingerprint",
+            )
+        )
+        if not any(values):
+            return None
+        if not all(values):
+            raise ValueError("index component fingerprint metadata is incomplete")
+        return cls(*values)
+
+
+def build_analysis_fingerprints(
+    *,
+    parser_manifest: object,
+    scan_limits: dict[str, int],
+    chunk_limits: dict[str, int],
+    legacy_cache_key: str = "",
+) -> AnalysisFingerprints:
+    """Build minimal-scope identities for one scanner/parser configuration."""
+
+    scan = stable_fingerprint(
+        "scan",
+        {
+            "scanner_policy": SCAN_POLICY_VERSION,
+            "secret_detector": SECRET_DETECTOR_VERSION,
+            "generated_detector": GENERATED_DETECTOR_VERSION,
+            "limits": dict(sorted(scan_limits.items())),
+            "legacy_cache_key": legacy_cache_key,
+        },
+    )
+    parser = stable_fingerprint(
+        "parser",
+        {
+            "chunker": CHUNKER_VERSION,
+            "finalizer": PARSER_FINALIZER_VERSION,
+            "limits": dict(sorted(chunk_limits.items())),
+            "parsers": parser_manifest,
+            "legacy_cache_key": legacy_cache_key,
+        },
+    )
+    term_index = stable_fingerprint("term-index", {"version": TERM_INDEX_VERSION})
+    retrieval = stable_fingerprint(
+        "retrieval",
+        {
+            "dependency_resolver": DEPENDENCY_RESOLVER_VERSION,
+            "version": RETRIEVAL_VERSION,
+        },
+    )
+    return AnalysisFingerprints(scan, parser, term_index, retrieval)
+
+
+DEFAULT_ANALYSIS_FINGERPRINTS = build_analysis_fingerprints(
+    parser_manifest=(),
+    scan_limits={},
+    chunk_limits={},
+    legacy_cache_key="legacy-unconfigured",
+)

--- a/src/repolocus/api/app.py
+++ b/src/repolocus/api/app.py
@@ -301,14 +301,17 @@ def create_app(
 
         path: str = Field(default=".", min_length=1, max_length=4096)
 
+    class ScanRequest(RepositoryRequest):
+        refresh: Literal["auto", "always", "rebuild"] = "auto"
+
     class OutputRequest(RepositoryRequest):
-        refresh: Literal["auto", "always", "never"] = "auto"
+        refresh: Literal["auto", "always", "never", "rebuild"] = "auto"
 
     class AskRequest(RepositoryRequest):
         question: str = Field(min_length=1, max_length=4000)
         model: str | None = Field(default=None, min_length=1, max_length=512)
         limit: int = Field(default=8, ge=1, le=20)
-        refresh: Literal["auto", "always", "never"] = "auto"
+        refresh: Literal["auto", "always", "never", "rebuild"] = "auto"
 
     application = FastAPI(
         title="RepoLocus",
@@ -369,10 +372,10 @@ def create_app(
         return {"status": "ok", "version": __version__}
 
     @application.post("/v1/scan")
-    def scan(payload: RepositoryRequest) -> dict[str, object]:
+    def scan(payload: ScanRequest) -> dict[str, object]:
         try:
             repository_root, instance = service(payload.path)
-            return instance.scan(repository_root).to_dict()
+            return instance.scan(repository_root, refresh=payload.refresh).to_dict()
         except (OSError, ValueError, RuntimeError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/repolocus/cli.py
+++ b/src/repolocus/cli.py
@@ -160,12 +160,24 @@ def _generated_file(root: Path, requested: Path, content: str, force: bool) -> P
     requested_destination = requested if requested.is_absolute() else root / requested
     destination = ensure_within_root(root, requested_destination)
     relative = PurePosixPath(destination.relative_to(root).as_posix())
-    atomic_write_within_root(
+    result = atomic_write_within_root(
         root,
         relative,
         content.encode("utf-8"),
         replace_generated_only=not force,
     )
+    if result.recovery_path is not None:
+        try:
+            recovery_display = result.recovery_path.relative_to(root).as_posix()
+        except ValueError:  # pragma: no cover - writer only returns repository paths
+            recovery_display = str(result.recovery_path)
+        error_console.print(
+            "Warning: previous output preserved at "
+            f"{escape_untrusted_display(recovery_display)}. Remove it manually only "
+            "while repository writers are quiescent.",
+            markup=False,
+            highlight=False,
+        )
     return destination
 
 

--- a/src/repolocus/cli.py
+++ b/src/repolocus/cli.py
@@ -12,8 +12,8 @@ import sqlite3
 import sys
 import tempfile
 from collections.abc import Iterable
-from dataclasses import asdict
-from pathlib import Path
+from dataclasses import asdict, replace
+from pathlib import Path, PurePosixPath
 from typing import Annotated
 
 import httpx
@@ -26,12 +26,12 @@ from rich.text import Text
 from repolocus import __version__
 from repolocus.config import Settings
 from repolocus.core import PrivacyRequiredError, RepoLocusService
-from repolocus.index import cache_root, index_path_for
+from repolocus.index import RepositoryIndex, cache_root, index_path_for
 from repolocus.models import Evidence
-from repolocus.scanner import is_generated_document
 from repolocus.security import (
     CloudSendPreview,
     PrivacyStore,
+    atomic_write_within_root,
     ensure_within_root,
     escape_untrusted_display,
     is_loopback_url,
@@ -107,8 +107,22 @@ def _settings(root: Path) -> Settings:
     return Settings.load(root)
 
 
-def _service(root: Path) -> RepoLocusService:
-    return RepoLocusService(_settings(root))
+def _service(
+    root: Path,
+    *,
+    proxy_mode: str | None = None,
+    proxy_url: str | None = None,
+) -> RepoLocusService:
+    settings = _settings(root)
+    if proxy_url is not None and proxy_mode is None:
+        proxy_mode = "explicit"
+    if proxy_mode is not None or proxy_url is not None:
+        settings = replace(
+            settings,
+            proxy_mode=proxy_mode or settings.proxy_mode,
+            proxy_url=proxy_url if proxy_url is not None else settings.proxy_url,
+        )
+    return RepoLocusService(settings)
 
 
 def _index_cache_permission_status(path: Path, platform_name: str) -> tuple[bool, str, bool]:
@@ -144,32 +158,14 @@ def _require_markdown_output(requested: Path) -> None:
 def _generated_file(root: Path, requested: Path, content: str, force: bool) -> Path:
     _require_markdown_output(requested)
     requested_destination = requested if requested.is_absolute() else root / requested
-    if requested_destination.is_symlink():
-        raise ValueError(f"refusing to replace symlink output: {requested_destination}")
     destination = ensure_within_root(root, requested_destination)
-    if destination.exists():
-        if destination.is_symlink() or not destination.is_file():
-            raise ValueError(f"refusing to replace non-regular output: {destination}")
-        with destination.open("r", encoding="utf-8", errors="replace") as handle:
-            prior = handle.read(4096)
-        generated = is_generated_document(prior)
-        if not (force or generated):
-            raise ValueError(
-                f"output already exists and is not recognized as generated: {destination}; "
-                "pass --force to replace it"
-            )
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent
+    relative = PurePosixPath(destination.relative_to(root).as_posix())
+    atomic_write_within_root(
+        root,
+        relative,
+        content.encode("utf-8"),
+        replace_generated_only=not force,
     )
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-        Path(temporary_name).replace(destination)
-    finally:
-        Path(temporary_name).unlink(missing_ok=True)
     return destination
 
 
@@ -237,11 +233,15 @@ def scan(
     json_output: Annotated[
         bool, typer.Option("--json", help="Emit machine-readable JSON.")
     ] = False,
+    refresh: Annotated[
+        str,
+        typer.Option("--refresh", help="Index refresh mode: auto, always, or rebuild."),
+    ] = "auto",
 ) -> None:
     """Securely scan a repository and incrementally update its local index."""
 
     try:
-        operation = _service(path).scan(path)
+        operation = _service(path).scan(path, refresh=refresh)  # type: ignore[arg-type]
     except (OSError, ValueError, RuntimeError) as exc:
         _fail(exc)
     if json_output:
@@ -257,6 +257,8 @@ def scan(
     table.add_row(
         "Unchanged / removed", f"{operation.update.unchanged} / {operation.update.removed}"
     )
+    table.add_row("Content generation", str(operation.update.content_generation))
+    table.add_row("Scan revision", str(operation.update.scan_revision))
     table.add_row("Index", Text(escape_untrusted_display(str(operation.index_path))))
     console.print(table)
     if stats.skipped:
@@ -267,6 +269,54 @@ def scan(
             markup=False,
             highlight=False,
         )
+
+
+@app.command()
+def status(
+    path: RepoArgument = Path("."),
+    json_output: Annotated[bool, typer.Option("--json")] = False,
+) -> None:
+    """Show the retrieval-visible generation and diagnostic scan revision."""
+
+    try:
+        root = path.resolve(strict=True)
+        database = index_path_for(root)
+        if not database.is_file() or database.is_symlink():
+            raise ValueError("no RepoLocus index exists for this repository")
+        with RepositoryIndex.open(root) as index:
+            snapshot = index.manifest_snapshot()
+            data = {
+                "repository": str(root),
+                "index_path": str(index.db_path),
+                "content_generation": snapshot.content_generation,
+                "scan_revision": snapshot.scan_revision,
+                "generation": snapshot.content_generation,
+                "content_generation_detail": ("changes only when retrieval-visible facts change"),
+                "scan_revision_detail": ("changes when a non-cache-hit scan or rebuild completes"),
+                "fingerprints": (
+                    snapshot.fingerprints.metadata() if snapshot.fingerprints is not None else {}
+                ),
+            }
+    except (OSError, ValueError, RuntimeError) as exc:
+        _fail(exc)
+    if json_output:
+        _json(data)
+        return
+    table = Table(title="RepoLocus index status")
+    table.add_column("Revision")
+    table.add_column("Value", justify="right")
+    table.add_column("Meaning")
+    table.add_row(
+        "Content generation",
+        str(data["content_generation"]),
+        str(data["content_generation_detail"]),
+    )
+    table.add_row(
+        "Scan revision",
+        str(data["scan_revision"]),
+        str(data["scan_revision_detail"]),
+    )
+    console.print(table)
 
 
 @app.command("map")
@@ -283,7 +333,7 @@ def map_command(
     ] = False,
     refresh: Annotated[
         str,
-        typer.Option("--refresh", help="Index refresh mode: auto, always, or never."),
+        typer.Option("--refresh", help="Index refresh mode: auto, always, never, or rebuild."),
     ] = "auto",
 ) -> None:
     """Generate a stable, source-linked PROJECT_MAP.md."""
@@ -323,7 +373,7 @@ def diagram(
     ] = False,
     refresh: Annotated[
         str,
-        typer.Option("--refresh", help="Index refresh mode: auto, always, or never."),
+        typer.Option("--refresh", help="Index refresh mode: auto, always, never, or rebuild."),
     ] = "auto",
 ) -> None:
     """Generate a deterministic, validated Mermaid architecture graph."""
@@ -377,26 +427,36 @@ def ask(
     ] = False,
     refresh: Annotated[
         str,
-        typer.Option("--refresh", help="Index refresh mode: auto, always, or never."),
+        typer.Option("--refresh", help="Index refresh mode: auto, always, never, or rebuild."),
     ] = "auto",
+    proxy_mode: Annotated[
+        str | None,
+        typer.Option("--proxy-mode", help="HTTP proxy policy: disabled, environment, or explicit."),
+    ] = None,
+    proxy_url: Annotated[
+        str | None,
+        typer.Option("--proxy-url", help="Explicit HTTP(S) proxy URL; credentials stay hidden."),
+    ] = None,
 ) -> None:
     """Answer with retrieved, line-addressable source evidence."""
 
     if follow_up and json_output:
         _fail(ValueError("--follow-up cannot be combined with --json"))
     try:
-        service = _service(path)
+        service = _service(path, proxy_mode=proxy_mode, proxy_url=proxy_url)
 
         def show_preview(
             send_preview: CloudSendPreview,
             fragments: tuple[Evidence, ...],
         ) -> None:
             if send_preview.provider not in {"local", "ollama"}:
+                transport_text = json.dumps(dict(send_preview.transport), sort_keys=True)
                 error_console.print(
                     "Cloud send preview: "
                     f"provider={escape_untrusted_display(send_preview.provider)}, "
                     f"model={escape_untrusted_display(send_preview.model)}, "
                     f"endpoint={escape_untrusted_display(send_preview.endpoint or 'none')}, "
+                    f"transport={escape_untrusted_display(transport_text)}, "
                     f"fragments={send_preview.fragment_count}, "
                     f"estimated_tokens={send_preview.estimated_tokens}, "
                     f"payload_bytes={send_preview.payload_bytes}",
@@ -421,10 +481,12 @@ def ask(
             _json({"error": "cloud_consent_required", "preview": payload})
             raise typer.Exit(2) from None
         error_console.print("[yellow]Cloud send preview[/yellow]")
+        transport_text = json.dumps(payload["transport"], sort_keys=True)
         error_console.print(
             f"Provider: {escape_untrusted_display(str(payload['provider']))}; "
             f"model: {escape_untrusted_display(str(payload['model']))}; "
             f"endpoint: {escape_untrusted_display(str(payload['endpoint']))}; "
+            f"transport: {escape_untrusted_display(transport_text)}; "
             f"fragments: {payload['fragment_count']}; "
             f"estimated tokens: {payload['estimated_tokens']}; "
             f"payload bytes: {payload['payload_bytes']}; "
@@ -540,11 +602,19 @@ def privacy_preview(
     model: Annotated[str | None, typer.Option("--model")] = None,
     limit: Annotated[int, typer.Option("--limit", min=1, max=20)] = 8,
     json_output: Annotated[bool, typer.Option("--json")] = False,
+    proxy_mode: Annotated[
+        str | None, typer.Option("--proxy-mode", help="disabled, environment, or explicit")
+    ] = None,
+    proxy_url: Annotated[str | None, typer.Option("--proxy-url")] = None,
 ) -> None:
     """Preview source fragments selected for a model request without sending them."""
 
     try:
-        preview_data, evidence, _ = _service(path).preview(question, path, model=model, limit=limit)
+        preview_data, evidence, _ = _service(
+            path,
+            proxy_mode=proxy_mode,
+            proxy_url=proxy_url,
+        ).preview(question, path, model=model, limit=limit)
         data = preview_data.to_dict() | {"fragments": _preview_fragments(evidence)}
     except (OSError, ValueError, RuntimeError) as exc:
         _fail(exc)
@@ -558,7 +628,8 @@ def privacy_preview(
     )
     console.print(
         f"Model: {escape_untrusted_display(str(data['model']))}; "
-        f"endpoint: {escape_untrusted_display(str(data['endpoint']))}"
+        f"endpoint: {escape_untrusted_display(str(data['endpoint']))}; "
+        f"transport: {escape_untrusted_display(json.dumps(data['transport'], sort_keys=True))}"
     )
     console.print(
         f"Fragments: {data['fragment_count']}; estimated tokens: {data['estimated_tokens']}; "
@@ -573,6 +644,10 @@ def privacy_preview(
 def privacy_grant(
     provider: Annotated[str, typer.Argument(help="Cloud provider family, e.g. openai.")],
     path: RepoArgument = Path("."),
+    proxy_mode: Annotated[
+        str | None, typer.Option("--proxy-mode", help="disabled, environment, or explicit")
+    ] = None,
+    proxy_url: Annotated[str | None, typer.Option("--proxy-url")] = None,
 ) -> None:
     """Remember an explicit cloud-provider grant for this repository."""
 
@@ -585,10 +660,17 @@ def privacy_grant(
             consent_model = selected_provider
         else:
             consent_model = f"{selected_provider}/consent"
-        service = _service(root)
+        service = _service(root, proxy_mode=proxy_mode, proxy_url=proxy_url)
         scope = service.consent_scope(consent_model)
         endpoint = service.consent_endpoint(consent_model)
-        PrivacyStore().grant(root, scope, endpoint)
+        transport = service.consent_transport(consent_model)
+        PrivacyStore().grant(
+            root,
+            scope,
+            endpoint,
+            transport_identity=transport.identity if transport is not None else None,
+            transport=transport.preview() if transport is not None else None,
+        )
     except (OSError, ValueError, RuntimeError) as exc:
         _fail(exc)
     console.print(

--- a/src/repolocus/config.py
+++ b/src/repolocus/config.py
@@ -7,7 +7,6 @@ the provider adapters directly from their documented environment variables.
 
 from __future__ import annotations
 
-import ast
 import json
 import math
 import os
@@ -15,7 +14,7 @@ import re
 import stat
 from collections.abc import Mapping
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -39,6 +38,8 @@ _DEFAULTS: dict[str, object] = {
     "openai_base_url": "https://api.openai.com/v1",
     "anthropic_base_url": "https://api.anthropic.com",
     "request_timeout": 30.0,
+    "proxy_mode": "disabled",
+    "proxy_url": "",
     "max_output_tokens": 2048,
     "max_file_bytes": 1_000_000,
     "context_char_budget": 24_000,
@@ -47,6 +48,10 @@ _DEFAULTS: dict[str, object] = {
     "max_directory_depth": 64,
     "max_repository_chunks": 500_000,
     "max_repository_symbols": 500_000,
+    "max_repository_dependencies": 1_000_000,
+    "max_dependencies_per_file": 10_000,
+    "max_symbols_per_file": 10_000,
+    "max_chunks_per_file": 10_000,
     "max_scan_seconds": 120,
     "query_synonyms": "{}",
 }
@@ -63,6 +68,8 @@ _ENV_KEYS = {
     "REPOLOCUS_OPENAI_BASE_URL": "openai_base_url",
     "REPOLOCUS_ANTHROPIC_BASE_URL": "anthropic_base_url",
     "REPOLOCUS_REQUEST_TIMEOUT": "request_timeout",
+    "REPOLOCUS_PROXY_MODE": "proxy_mode",
+    "REPOLOCUS_PROXY_URL": "proxy_url",
     "REPOLOCUS_MAX_OUTPUT_TOKENS": "max_output_tokens",
     "REPOLOCUS_MAX_FILE_BYTES": "max_file_bytes",
     "REPOLOCUS_CONTEXT_CHAR_BUDGET": "context_char_budget",
@@ -71,6 +78,10 @@ _ENV_KEYS = {
     "REPOLOCUS_MAX_DIRECTORY_DEPTH": "max_directory_depth",
     "REPOLOCUS_MAX_REPOSITORY_CHUNKS": "max_repository_chunks",
     "REPOLOCUS_MAX_REPOSITORY_SYMBOLS": "max_repository_symbols",
+    "REPOLOCUS_MAX_REPOSITORY_DEPENDENCIES": "max_repository_dependencies",
+    "REPOLOCUS_MAX_DEPENDENCIES_PER_FILE": "max_dependencies_per_file",
+    "REPOLOCUS_MAX_SYMBOLS_PER_FILE": "max_symbols_per_file",
+    "REPOLOCUS_MAX_CHUNKS_PER_FILE": "max_chunks_per_file",
     "REPOLOCUS_MAX_SCAN_SECONDS": "max_scan_seconds",
     "REPOLOCUS_QUERY_SYNONYMS": "query_synonyms",
 }
@@ -92,6 +103,10 @@ _REPOSITORY_LIMIT_KEYS = frozenset(
         "max_directory_depth",
         "max_repository_chunks",
         "max_repository_symbols",
+        "max_repository_dependencies",
+        "max_dependencies_per_file",
+        "max_symbols_per_file",
+        "max_chunks_per_file",
         "max_scan_seconds",
     }
 )
@@ -124,6 +139,8 @@ class Settings:
     openai_base_url: str = "https://api.openai.com/v1"
     anthropic_base_url: str = "https://api.anthropic.com"
     request_timeout: float = 30.0
+    proxy_mode: str = "disabled"
+    proxy_url: str = field(default="", repr=False)
     max_output_tokens: int = 2048
     max_file_bytes: int = 1_000_000
     context_char_budget: int = 24_000
@@ -132,6 +149,10 @@ class Settings:
     max_directory_depth: int = 64
     max_repository_chunks: int = 500_000
     max_repository_symbols: int = 500_000
+    max_repository_dependencies: int = 1_000_000
+    max_dependencies_per_file: int = 10_000
+    max_symbols_per_file: int = 10_000
+    max_chunks_per_file: int = 10_000
     max_scan_seconds: int = 120
     query_synonyms: str = "{}"
 
@@ -151,6 +172,17 @@ class Settings:
             or self.request_timeout <= 0
         ):
             raise ConfigError("request_timeout must be greater than zero")
+        if self.proxy_mode not in {"disabled", "environment", "explicit"}:
+            raise ConfigError("proxy_mode must be disabled, environment, or explicit")
+        if self.proxy_mode == "explicit":
+            try:
+                from repolocus.providers.transport import proxy_transport
+
+                proxy_transport("explicit", self.proxy_url)
+            except ValueError as exc:
+                raise ConfigError(str(exc)) from exc
+        elif self.proxy_url:
+            raise ConfigError("proxy_url may only be set when proxy_mode is explicit")
         for field_name in (
             "max_output_tokens",
             "max_file_bytes",
@@ -160,6 +192,10 @@ class Settings:
             "max_directory_depth",
             "max_repository_chunks",
             "max_repository_symbols",
+            "max_repository_dependencies",
+            "max_dependencies_per_file",
+            "max_symbols_per_file",
+            "max_chunks_per_file",
             "max_scan_seconds",
         ):
             value = getattr(self, field_name)
@@ -172,6 +208,12 @@ class Settings:
         """Compatibility alias with an explicit boolean name."""
 
         return self.telemetry
+
+    @property
+    def trust_env(self) -> bool:
+        """Whether the user explicitly selected environment proxy discovery."""
+
+        return self.proxy_mode == "environment"
 
     @property
     def query_synonym_map(self) -> dict[str, tuple[str, ...]]:
@@ -226,8 +268,6 @@ class Settings:
                 raw = _read_repository_config_bytes(repo_root, path)
                 if raw is None:
                     continue
-            if path.name == "pyproject.toml" and not _pyproject_declares_repolocus(raw, path):
-                continue
             table = _parse_config(raw, path, source="repository")
             # A pyproject is relevant only when it contains [tool.repolocus].
             if path.name == "pyproject.toml" and not _has_repolocus_table(table):
@@ -296,14 +336,6 @@ def _has_repolocus_table(data: Mapping[str, Any]) -> bool:
     return isinstance(tool, Mapping) and isinstance(tool.get("repolocus"), Mapping)
 
 
-def _pyproject_declares_repolocus(raw: bytes, path: Path) -> bool:
-    try:
-        text = raw.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise ConfigError(f"cannot inspect repository config {path}: {exc}") from exc
-    return bool(re.search(r"(?m)^\s*\[tool\.repolocus\]\s*(?:#.*)?$", text))
-
-
 def _extract_table(data: Mapping[str, Any]) -> Mapping[str, Any]:
     tool = data.get("tool")
     if isinstance(tool, Mapping) and isinstance(tool.get("repolocus"), Mapping):
@@ -358,6 +390,13 @@ def _coerce_value(key: str, value: object, source: str) -> object:
         except (TypeError, ValueError) as exc:
             raise ConfigError(f"{source}: request_timeout must be a number") from exc
         return parsed
+    if key == "proxy_mode":
+        if not isinstance(value, str):
+            raise ConfigError(f"{source}: proxy_mode must be a string")
+        mode = value.strip().casefold()
+        if mode not in {"disabled", "environment", "explicit"}:
+            raise ConfigError(f"{source}: proxy_mode must be disabled, environment, or explicit")
+        return mode
     if key in {
         "max_output_tokens",
         "max_file_bytes",
@@ -367,6 +406,10 @@ def _coerce_value(key: str, value: object, source: str) -> object:
         "max_directory_depth",
         "max_repository_chunks",
         "max_repository_symbols",
+        "max_repository_dependencies",
+        "max_dependencies_per_file",
+        "max_symbols_per_file",
+        "max_chunks_per_file",
         "max_scan_seconds",
     }:
         if isinstance(value, bool) or not isinstance(value, (int, str)):
@@ -438,13 +481,10 @@ def _parse_config(raw: bytes, path: Path, *, source: str) -> Mapping[str, Any]:
     try:
         try:
             import tomllib  # type: ignore[import-not-found]
-
-            parsed = tomllib.loads(raw.decode("utf-8"))
         except ModuleNotFoundError:
-            text = raw.decode("utf-8")
-            if path.name == "pyproject.toml":
-                text = _repolocus_pyproject_subset(text)
-            parsed = _parse_toml_subset(text)
+            import tomli as tomllib  # type: ignore[no-redef]
+
+        parsed = tomllib.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, ValueError) as exc:
         raise ConfigError(f"invalid TOML in {source} config {path}: {exc}") from exc
     if not isinstance(parsed, Mapping):
@@ -650,99 +690,3 @@ def _read_config_bytes(path: Path, *, source: str) -> bytes:
     if len(raw) > MAX_CONFIG_BYTES:
         raise ConfigError(f"{source} config exceeds the {MAX_CONFIG_BYTES}-byte limit: {path}")
     return raw
-
-
-def _parse_toml_subset(text: str) -> dict[str, Any]:
-    """Parse the scalar TOML subset used by RepoLocus on Python 3.10.
-
-    Python 3.11 and newer use the standard-library parser.  Keeping this tiny
-    fallback avoids making Python 3.10 silently unsupported solely for config.
-    """
-
-    result: dict[str, Any] = {}
-    current = result
-    for line_number, original in enumerate(text.splitlines(), start=1):
-        line = _strip_toml_comment(original).strip()
-        if not line:
-            continue
-        if line.startswith("[") and line.endswith("]"):
-            section = line[1:-1].strip()
-            if not section or section.startswith("["):
-                raise ValueError(f"unsupported table declaration on line {line_number}")
-            current = result
-            for part in section.split("."):
-                key = part.strip().strip("\"'")
-                if not key:
-                    raise ValueError(f"empty table name on line {line_number}")
-                child = current.setdefault(key, {})
-                if not isinstance(child, dict):
-                    raise ValueError(f"table conflicts with value on line {line_number}")
-                current = child
-            continue
-        if "=" not in line:
-            raise ValueError(f"expected key = value on line {line_number}")
-        raw_key, raw_value = line.split("=", 1)
-        key = raw_key.strip().strip("\"'")
-        if not key:
-            raise ValueError(f"empty key on line {line_number}")
-        current[key] = _parse_toml_scalar(raw_value.strip(), line_number)
-    return result
-
-
-def _repolocus_pyproject_subset(text: str) -> str:
-    """Extract [tool.repolocus] so the Python 3.10 parser skips unrelated TOML."""
-
-    selected: list[str] = []
-    in_section = False
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            in_section = stripped == "[tool.repolocus]"
-        if in_section:
-            selected.append(line)
-    return "\n".join(selected)
-
-
-def _strip_toml_comment(line: str) -> str:
-    quote: str | None = None
-    escaped = False
-    for index, char in enumerate(line):
-        if escaped:
-            escaped = False
-            continue
-        if char == "\\" and quote == '"':
-            escaped = True
-            continue
-        if char in {'"', "'"}:
-            if quote == char:
-                quote = None
-            elif quote is None:
-                quote = char
-        elif char == "#" and quote is None:
-            return line[:index]
-    return line
-
-
-def _parse_toml_scalar(value: str, line_number: int) -> object:
-    lowered = value.lower()
-    if lowered == "true":
-        return True
-    if lowered == "false":
-        return False
-    if value.startswith('"'):
-        try:
-            return json.loads(value)
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"invalid string on line {line_number}") from exc
-    if value.startswith("'"):
-        try:
-            return ast.literal_eval(value)
-        except (SyntaxError, ValueError) as exc:
-            raise ValueError(f"invalid string on line {line_number}") from exc
-    try:
-        return int(value.replace("_", ""))
-    except ValueError:
-        try:
-            return float(value.replace("_", ""))
-        except ValueError as exc:
-            raise ValueError(f"unsupported value on line {line_number}") from exc

--- a/src/repolocus/core/service.py
+++ b/src/repolocus/core/service.py
@@ -26,7 +26,9 @@ from repolocus.models import (
 )
 from repolocus.providers import (
     ProviderRequestPlan,
+    ProviderTransport,
     build_provider_request_plan,
+    build_provider_transport,
     create_provider,
     provider_family,
 )
@@ -44,7 +46,7 @@ from repolocus.security.evidence_validation import validate_model_text
 
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 _SCAN_ATTEMPTS = 3
-RefreshMode = Literal["auto", "always", "never"]
+RefreshMode = Literal["auto", "always", "never", "rebuild"]
 
 
 class PrivacyRequiredError(RuntimeError):
@@ -65,11 +67,13 @@ class ScanOperation:
     index_path: Path
 
     def to_dict(self) -> dict[str, object]:
+        update = asdict(self.update)
+        update["generation"] = self.update.content_generation
         return {
             "root": str(self.result.root),
             "index_path": str(self.index_path),
             "scan": asdict(self.result.stats),
-            "update": asdict(self.update),
+            "update": update,
             "warnings": list(self.result.warnings),
         }
 
@@ -88,6 +92,7 @@ class PreparedAsk:
     system_prompt: str
     user_prompt: str
     request_plan: ProviderRequestPlan | None
+    transport: ProviderTransport | None
     settings: Settings
 
 
@@ -109,6 +114,10 @@ class RepoLocusService:
             max_directory_depth=self.settings.max_directory_depth,
             max_repository_chunks=self.settings.max_repository_chunks,
             max_repository_symbols=self.settings.max_repository_symbols,
+            max_repository_dependencies=self.settings.max_repository_dependencies,
+            max_dependencies_per_file=self.settings.max_dependencies_per_file,
+            max_symbols_per_file=self.settings.max_symbols_per_file,
+            max_chunks_per_file=self.settings.max_chunks_per_file,
             max_scan_seconds=self.settings.max_scan_seconds,
         )
         self.privacy = privacy or PrivacyStore()
@@ -119,6 +128,7 @@ class RepoLocusService:
         *,
         expected_generation: int | None = None,
         _materialize_files: bool = False,
+        refresh: RefreshMode = "auto",
     ) -> ScanOperation:
         """Refresh the index, retrying only scans not pinned to a generation.
 
@@ -128,18 +138,29 @@ class RepoLocusService:
         """
 
         repo = self._repository(root)
+        mode = self._refresh_mode(refresh)
+        if mode == "never":
+            raise ValueError("scan refresh mode cannot be never")
         with RepositoryIndex.open(repo) as index:
             for attempt in range(_SCAN_ATTEMPTS):
                 snapshot = (
                     index.snapshot()
-                    if _materialize_files
-                    else index.manifest_snapshot(
-                        max_files=self.scanner.max_repository_files,
-                    )
+                    if (_materialize_files or mode != "auto")
+                    else (index.manifest_snapshot(max_files=self.scanner.max_repository_files))
                 )
+                if snapshot.fingerprints != self.scanner.fingerprints and not _materialize_files:
+                    snapshot = index.snapshot()
                 self._require_generation(snapshot.generation, expected_generation)
                 cached_files: dict[str, ScannedFile] = {}
-                if snapshot.analysis_version == self.scanner.analysis_version:
+                fingerprints = snapshot.fingerprints
+                parser_compatible = (
+                    fingerprints is not None
+                    and fingerprints.parser == self.scanner.fingerprints.parser
+                )
+                scan_compatible = (
+                    fingerprints is not None and fingerprints.scan == self.scanner.fingerprints.scan
+                )
+                if parser_compatible:
                     cached_files = {
                         file.path: file
                         for file in snapshot.files
@@ -148,14 +169,20 @@ class RepoLocusService:
                 result = self.scanner.scan(
                     repo,
                     cached_files=cached_files,
-                    trusted_cache=True,
+                    trusted_cache=mode == "auto" and scan_compatible,
                     base_generation=snapshot.generation,
+                    base_scan_revision=snapshot.scan_revision,
+                    refresh_mode=mode,
                 )
                 try:
-                    update = index.update(result)
+                    update = index.auto_cache_hit(result) if mode == "auto" else None
+                    if update is None:
+                        update = index.update(result)
                 except StaleScanError:
-                    if expected_generation is not None or attempt + 1 == _SCAN_ATTEMPTS:
+                    if attempt + 1 == _SCAN_ATTEMPTS:
                         raise
+                    if expected_generation is not None:
+                        self._require_generation(index.content_generation(), expected_generation)
                     continue
                 return ScanOperation(result, update, index.db_path)
         raise RuntimeError("scan retry loop ended unexpectedly")  # pragma: no cover
@@ -170,11 +197,12 @@ class RepoLocusService:
     ) -> ScanOperation:
         mode = self._refresh_mode(refresh)
         repo = self._repository(root)
-        if mode in {"auto", "always"}:
+        if mode in {"auto", "always", "rebuild"}:
             return self.scan(
                 repo,
                 expected_generation=expected_generation,
                 _materialize_files=materialize_files,
+                refresh=mode,
             )
 
         with RepositoryIndex.open(repo) as index:
@@ -191,12 +219,16 @@ class RepoLocusService:
         )
 
     def _compatible_snapshot(self, snapshot: IndexSnapshot) -> bool:
-        return snapshot.analysis_version == self.scanner.analysis_version and (
-            snapshot.generation > 0 or bool(snapshot.files)
+        fingerprints = snapshot.fingerprints
+        return (
+            fingerprints is not None
+            and fingerprints.scan == self.scanner.fingerprints.scan
+            and fingerprints.parser == self.scanner.fingerprints.parser
+            and fingerprints.term_index == self.scanner.fingerprints.term_index
         )
 
-    @staticmethod
     def _snapshot_operation(
+        self,
         root: Path,
         index_path: Path,
         snapshot: IndexSnapshot,
@@ -226,6 +258,9 @@ class RepoLocusService:
             analysis_version=snapshot.analysis_version,
             temporarily_unreadable=snapshot.temporarily_unreadable,
             base_generation=snapshot.generation,
+            base_scan_revision=snapshot.scan_revision,
+            fingerprints=snapshot.fingerprints or self.scanner.fingerprints,
+            refresh_mode="never",
         )
         update = IndexUpdate(
             added=0,
@@ -234,14 +269,15 @@ class RepoLocusService:
             removed=0,
             chunks=0,
             stale=stale_count,
-            generation=snapshot.generation,
+            content_generation=snapshot.generation,
+            scan_revision=snapshot.scan_revision,
         )
         return ScanOperation(result, update, index_path)
 
     @staticmethod
     def _refresh_mode(refresh: RefreshMode) -> RefreshMode:
-        if refresh not in {"auto", "always", "never"}:
-            raise ValueError("refresh must be one of: auto, always, never")
+        if refresh not in {"auto", "always", "never", "rebuild"}:
+            raise ValueError("refresh must be one of: auto, always, never, rebuild")
         return refresh
 
     @staticmethod
@@ -374,6 +410,11 @@ class RepoLocusService:
         scope = self.consent_scope(chosen_model)
         request_plan = self._request_plan(chosen_model, system_prompt, user_prompt)
         endpoint = canonical_endpoint(request_plan.endpoint) if request_plan is not None else None
+        transport = (
+            build_provider_transport(self.settings, request_plan.endpoint)
+            if request_plan is not None
+            else None
+        )
         preview = CloudSendPreview(
             provider=scope,
             paths=tuple(dict.fromkeys(item.path for item in bounded)),
@@ -385,6 +426,9 @@ class RepoLocusService:
             model=chosen_model,
             endpoint=endpoint,
             payload_bytes=len(request_plan.body) if request_plan is not None else 0,
+            transport=transport.preview()
+            if transport is not None
+            else {"mode": "direct", "policy": "disabled"},
         )
         prepared = PreparedAsk(
             root=operation.result.root,
@@ -397,6 +441,7 @@ class RepoLocusService:
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             request_plan=request_plan,
+            transport=transport,
             settings=self.settings,
         )
         return prepared, operation
@@ -461,6 +506,9 @@ class RepoLocusService:
                 prepared.root,
                 prepared.consent_scope,
                 prepared.endpoint,
+                transport_identity=(
+                    prepared.transport.identity if prepared.transport is not None else None
+                ),
             )
             if not (allow_cloud or remembered):
                 raise PrivacyRequiredError(prepared.preview, evidence)
@@ -471,9 +519,19 @@ class RepoLocusService:
                     prepared.root,
                     prepared.consent_scope,
                     prepared.endpoint,
+                    transport_identity=(
+                        prepared.transport.identity if prepared.transport is not None else None
+                    ),
+                    transport=(
+                        prepared.transport.preview() if prepared.transport is not None else None
+                    ),
                 )
 
-        provider = create_provider(prepared.model, prepared.settings)
+        provider = create_provider(
+            prepared.model,
+            prepared.settings,
+            transport_route=prepared.transport,
+        )
         generate_prepared = getattr(provider, "generate_prepared", None)
         if prepared.request_plan is not None and callable(generate_prepared):
             model_text = generate_prepared(prepared.request_plan)
@@ -594,6 +652,7 @@ class RepoLocusService:
                 score=item.score,
                 symbol=item.symbol,
                 reason=item.reason,
+                generation=item.generation,
             )
             separator = 1 if selected else 0
             remaining = budget - used - separator
@@ -609,6 +668,7 @@ class RepoLocusService:
                 score=item.score,
                 symbol=item.symbol,
                 reason=item.reason,
+                generation=item.generation,
             )
             if len(self._source_record(candidate)) > remaining:
                 low = 0
@@ -623,6 +683,7 @@ class RepoLocusService:
                         score=item.score,
                         symbol=item.symbol,
                         reason=item.reason,
+                        generation=item.generation,
                     )
                     if len(self._source_record(candidate)) <= remaining:
                         low = middle
@@ -643,6 +704,7 @@ class RepoLocusService:
                 score=item.score,
                 symbol=item.symbol,
                 reason=item.reason,
+                generation=item.generation,
             )
             selected.append(bounded)
             redactions += count
@@ -694,6 +756,12 @@ class RepoLocusService:
 
         plan = self._request_plan(model, "", "")
         return canonical_endpoint(plan.endpoint) if plan is not None else None
+
+    def consent_transport(self, model: str) -> ProviderTransport | None:
+        """Return the exact route identity bound to remembered consent."""
+
+        plan = self._request_plan(model, "", "")
+        return build_provider_transport(self.settings, plan.endpoint) if plan is not None else None
 
     def _request_plan(
         self,

--- a/src/repolocus/index/store.py
+++ b/src/repolocus/index/store.py
@@ -21,6 +21,7 @@ from pathlib import Path, PurePosixPath
 
 from platformdirs import user_cache_path
 
+from repolocus.analysis import DEFAULT_ANALYSIS_FINGERPRINTS, AnalysisFingerprints
 from repolocus.models import (
     Chunk,
     Dependency,
@@ -32,9 +33,10 @@ from repolocus.models import (
 )
 from repolocus.security.identity import filesystem_identity
 
-SCHEMA_VERSION = 4
-INDEX_FORMAT_VERSION = "4"
+SCHEMA_VERSION = 5
+INDEX_FORMAT_VERSION = "5"
 _PROVENANCE_SCHEMA_VERSION = 3
+_IDENTITY_SCHEMA_VERSION = 4
 # The product rename did not change the SQLite schema. Keep the original format
 # magic so existing valid indexes remain recognizable when explicitly opened.
 APPLICATION_ID = 0x4456504C  # "DVPL"
@@ -201,8 +203,14 @@ def _validate_scanned_file(file: ScannedFile) -> None:
         raise ValueError(f"negative file metadata for {file.path}")
     if file.mtime_ns < 0 or file.ctime_ns < 0:
         raise ValueError(f"negative file timestamp for {file.path}")
-    if file.cached_chunk_count < 0 or file.cached_symbol_count < 0:
+    if (
+        file.cached_chunk_count < 0
+        or file.cached_symbol_count < 0
+        or file.cached_dependency_count < 0
+    ):
         raise ValueError(f"negative cached fact count for {file.path}")
+    if not isinstance(file.facts_materialized, bool):
+        raise ValueError(f"invalid fact materialization marker for {file.path}")
     if file.provenance not in {"source", "generated"}:
         raise ValueError(f"invalid provenance for {file.path}")
     if file.stale:
@@ -319,18 +327,63 @@ def _decode_snapshot_state(
     return tuple(skipped), tuple(warnings_value), tuple(incomplete)
 
 
+def _metadata_fingerprints(metadata: Mapping[str, str]) -> AnalysisFingerprints | None:
+    try:
+        return AnalysisFingerprints.from_metadata(dict(metadata))
+    except ValueError as exc:
+        raise IndexFormatError("index component fingerprint metadata is invalid") from exc
+
+
 def _effective_chunks(file: ScannedFile) -> tuple[Chunk, ...]:
     if file.chunks or not file.text:
         return file.chunks
-    return (
-        Chunk(
-            path=file.path,
-            start_line=1,
-            end_line=max(1, file.line_count),
-            content=file.text,
-            language=file.language,
-        ),
+    from repolocus.parsers.chunking import semantic_chunks
+
+    return semantic_chunks(
+        path=file.path,
+        text=file.text,
+        language=file.language,
+        max_lines=160,
+        max_chars=16_000,
     )
+
+
+def _file_fact_digest(file: ScannedFile) -> str:
+    """Hash retrieval-visible facts while excluding diagnostic file metadata."""
+
+    chunks = _effective_chunks(file)
+    payload = {
+        "path": file.path,
+        "language": file.language,
+        "size_bytes": file.size_bytes,
+        "sha256": file.sha256.casefold(),
+        "line_count": file.line_count,
+        "is_entry_point": file.is_entry_point,
+        "provenance": file.provenance,
+        "symbols": [
+            [item.name, item.kind, item.start_line, item.end_line, item.signature]
+            for item in file.symbols
+        ],
+        "dependencies": [[item.target, item.kind, item.line] for item in file.dependencies],
+        "chunks": [
+            [
+                item.start_line,
+                item.end_line,
+                item.content,
+                item.language,
+                item.symbol,
+            ]
+            for item in chunks
+        ],
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 class RepositoryIndex:
@@ -420,6 +473,19 @@ class RepositoryIndex:
         else:
             self._connection.commit()
 
+    @contextmanager
+    def _read_transaction(self) -> Iterator[None]:
+        """Pin all reads in one cross-process-consistent SQLite snapshot."""
+
+        self._connection.execute("BEGIN")
+        try:
+            yield
+        except BaseException:
+            self._connection.rollback()
+            raise
+        else:
+            self._connection.commit()
+
     def _initialize_or_validate(self) -> None:
         try:
             application_id = int(self._connection.execute("PRAGMA application_id").fetchone()[0])
@@ -454,6 +520,12 @@ class RepositoryIndex:
                         missing = ", ".join(sorted(_REQUIRED_TABLES - tables))
                         raise IndexFormatError(f"index schema is incomplete; missing: {missing}")
                     self._migrate_v3_to_v4()
+                    version = _IDENTITY_SCHEMA_VERSION
+                if version == _IDENTITY_SCHEMA_VERSION:
+                    if not _REQUIRED_TABLES.issubset(tables):
+                        missing = ", ".join(sorted(_REQUIRED_TABLES - tables))
+                        raise IndexFormatError(f"index schema is incomplete; missing: {missing}")
+                    self._migrate_v4_to_v5()
                     version = SCHEMA_VERSION
                 elif version != SCHEMA_VERSION:
                     raise IndexFormatError(
@@ -482,7 +554,11 @@ class RepositoryIndex:
                 # Another process may have completed the migration while this
                 # connection waited for BEGIN IMMEDIATE.
                 current_version = int(self._connection.execute("PRAGMA user_version").fetchone()[0])
-                if current_version in {_PROVENANCE_SCHEMA_VERSION, SCHEMA_VERSION}:
+                if current_version in {
+                    _PROVENANCE_SCHEMA_VERSION,
+                    _IDENTITY_SCHEMA_VERSION,
+                    SCHEMA_VERSION,
+                }:
                     return
                 if current_version != 2:
                     raise IndexFormatError(
@@ -561,7 +637,7 @@ class RepositoryIndex:
         try:
             with self._transaction():
                 current_version = int(self._connection.execute("PRAGMA user_version").fetchone()[0])
-                if current_version == SCHEMA_VERSION:
+                if current_version in {_IDENTITY_SCHEMA_VERSION, SCHEMA_VERSION}:
                     return
                 if current_version != _PROVENANCE_SCHEMA_VERSION:
                     raise IndexFormatError(
@@ -576,26 +652,80 @@ class RepositoryIndex:
                     ON CONFLICT(key) DO UPDATE SET value = excluded.value
                     """,
                     (
-                        ("schema_version", str(SCHEMA_VERSION)),
-                        ("index_format_version", INDEX_FORMAT_VERSION),
+                        ("schema_version", str(_IDENTITY_SCHEMA_VERSION)),
+                        ("index_format_version", str(_IDENTITY_SCHEMA_VERSION)),
                         ("analysis_version", ""),
                         ("generation", str(generation + 1)),
                         ("repository_identity", self._repository_identity),
                     ),
                 )
-                self._connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+                self._connection.execute(f"PRAGMA user_version = {_IDENTITY_SCHEMA_VERSION}")
         except sqlite3.Error as exc:
             raise IndexFormatError(f"could not migrate v3 index: {exc}") from exc
 
-    def _generation_in_transaction(self) -> int:
-        row = self._connection.execute("SELECT value FROM meta WHERE key = 'generation'").fetchone()
+    def _migrate_v4_to_v5(self) -> None:
+        """Add dual revisions, component fingerprints, and per-file fact digests."""
+
         try:
-            generation = int(row["value"]) if row else 0
+            with self._transaction():
+                current_version = int(self._connection.execute("PRAGMA user_version").fetchone()[0])
+                if current_version == SCHEMA_VERSION:
+                    return
+                if current_version != _IDENTITY_SCHEMA_VERSION:
+                    raise IndexFormatError(
+                        f"unsupported index schema {current_version}; "
+                        f"expected {_IDENTITY_SCHEMA_VERSION}"
+                    )
+                generation = self._generation_in_transaction()
+                columns = {
+                    str(row["name"]) for row in self._connection.execute("PRAGMA table_info(files)")
+                }
+                if "facts_sha256" not in columns:
+                    self._connection.execute(
+                        "ALTER TABLE files ADD COLUMN facts_sha256 TEXT NOT NULL DEFAULT ''"
+                    )
+                for file in self.get_files():
+                    self._connection.execute(
+                        "UPDATE files SET facts_sha256 = ? WHERE path = ?",
+                        (_file_fact_digest(file), file.path),
+                    )
+                self._connection.executemany(
+                    """
+                    INSERT INTO meta(key, value) VALUES (?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    (
+                        ("schema_version", str(SCHEMA_VERSION)),
+                        ("index_format_version", INDEX_FORMAT_VERSION),
+                        ("content_generation", str(generation)),
+                        ("scan_revision", str(generation)),
+                        ("generation", str(generation)),
+                        ("scan_fingerprint", ""),
+                        ("parser_fingerprint", ""),
+                        ("term_index_fingerprint", ""),
+                        ("retrieval_fingerprint", ""),
+                    ),
+                )
+                self._connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        except sqlite3.Error as exc:
+            raise IndexFormatError(f"could not migrate v4 index: {exc}") from exc
+
+    def _generation_in_transaction(self) -> int:
+        return self._revision_in_transaction("content_generation", fallback="generation")
+
+    def _revision_in_transaction(self, key: str, *, fallback: str | None = None) -> int:
+        row = self._connection.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+        if row is None and fallback is not None:
+            row = self._connection.execute(
+                "SELECT value FROM meta WHERE key = ?", (fallback,)
+            ).fetchone()
+        try:
+            revision = int(row["value"]) if row else 0
         except (TypeError, ValueError) as exc:
-            raise IndexFormatError("index generation metadata is invalid") from exc
-        if generation < 0:
-            raise IndexFormatError("index generation metadata is invalid")
-        return generation
+            raise IndexFormatError(f"index {key} metadata is invalid") from exc
+        if revision < 0:
+            raise IndexFormatError(f"index {key} metadata is invalid")
+        return revision
 
     def _clear_repository_facts(self) -> None:
         self._connection.execute("DELETE FROM files")
@@ -614,6 +744,7 @@ class RepositoryIndex:
             if metadata.get("repository_identity") == identity:
                 return
             generation = self._generation_in_transaction()
+            scan_revision = self._revision_in_transaction("scan_revision")
             self._clear_repository_facts()
             self._connection.executemany(
                 """
@@ -623,6 +754,12 @@ class RepositoryIndex:
                 (
                     ("analysis_version", ""),
                     ("generation", str(generation + 1)),
+                    ("content_generation", str(generation + 1)),
+                    ("scan_revision", str(scan_revision + 1)),
+                    ("scan_fingerprint", ""),
+                    ("parser_fingerprint", ""),
+                    ("term_index_fingerprint", ""),
+                    ("retrieval_fingerprint", ""),
                     ("repository_identity", identity),
                 ),
             )
@@ -678,7 +815,8 @@ class RepositoryIndex:
                 mtime_ns INTEGER NOT NULL CHECK (mtime_ns >= 0),
                 ctime_ns INTEGER NOT NULL CHECK (ctime_ns >= 0),
                 provenance TEXT NOT NULL CHECK (provenance IN ('source', 'generated')),
-                stale INTEGER NOT NULL CHECK (stale IN (0, 1))
+                stale INTEGER NOT NULL CHECK (stale IN (0, 1)),
+                facts_sha256 TEXT NOT NULL
             ) WITHOUT ROWID
             """,
             """
@@ -773,6 +911,12 @@ class RepositoryIndex:
                         ("index_format_version", INDEX_FORMAT_VERSION),
                         ("analysis_version", ""),
                         ("generation", "0"),
+                        ("content_generation", "0"),
+                        ("scan_revision", "0"),
+                        ("scan_fingerprint", ""),
+                        ("parser_fingerprint", ""),
+                        ("term_index_fingerprint", ""),
+                        ("retrieval_fingerprint", ""),
                         ("repository_identity", self._repository_identity),
                     ),
                 )
@@ -783,8 +927,92 @@ class RepositoryIndex:
                 "SQLite FTS5 support is required to create a RepoLocus index"
             ) from exc
 
+    def auto_cache_hit(self, scan: ScanResult) -> IndexUpdate | None:
+        """Return a no-write update when an ``auto`` scan is an exact cache hit."""
+
+        self._ensure_open()
+        self._ensure_repository_identity()
+        scan_root = _canonical_root(scan.root)
+        if scan_root != self._root:
+            raise ValueError(f"scan root {scan_root} does not match index root {self._root}")
+        scan_identity = scan.repository_identity or _repository_identity(scan_root)
+        if scan_identity != self._repository_identity:
+            raise StaleScanError("repository identity changed after the scan started")
+        if scan.refresh_mode != "auto" or scan.stats.content_reads or scan.stats.parsed_files:
+            return None
+        incoming = {file.path: file for file in scan.files}
+        if len(incoming) != len(scan.files):
+            raise ValueError("duplicate scanned path")
+        skipped_summary, warning_summary = _snapshot_scan_metadata(scan)
+        incomplete_paths = tuple(sorted(set(scan.temporarily_unreadable)))
+        with self._lock, self._read_transaction():
+            metadata = self.get_metadata()
+            current_generation = self._read_revision(metadata, "content_generation", "generation")
+            scan_revision = self._read_revision(metadata, "scan_revision")
+            if (
+                scan.base_generation is not None and scan.base_generation != current_generation
+            ) or (scan.base_scan_revision is not None and scan.base_scan_revision != scan_revision):
+                return None
+            if scan.fingerprints is None or _metadata_fingerprints(metadata) != scan.fingerprints:
+                return None
+            current_rows = self._connection.execute(
+                """
+                SELECT path, language, size_bytes, sha256, line_count, is_entry_point,
+                       mtime_ns, ctime_ns, provenance, stale
+                FROM files ORDER BY path
+                """
+            ).fetchall()
+            if len(current_rows) != len(incoming):
+                return None
+            for row in current_rows:
+                file = incoming.get(str(row["path"]))
+                if file is None or (
+                    file.language != str(row["language"])
+                    or file.size_bytes != int(row["size_bytes"])
+                    or file.sha256.casefold() != str(row["sha256"]).casefold()
+                    or file.line_count != int(row["line_count"])
+                    or file.is_entry_point != bool(row["is_entry_point"])
+                    or file.mtime_ns != int(row["mtime_ns"])
+                    or file.ctime_ns != int(row["ctime_ns"])
+                    or file.provenance != str(row["provenance"])
+                    or file.stale != bool(row["stale"])
+                ):
+                    return None
+            previous_skipped, previous_warnings, previous_incomplete = _decode_snapshot_state(
+                metadata
+            )
+            if (
+                skipped_summary != previous_skipped
+                or warning_summary != previous_warnings
+                or incomplete_paths != previous_incomplete
+            ):
+                return None
+        if _repository_identity(self._root) != scan_identity:
+            raise StaleScanError("repository identity changed while checking the scan cache")
+        return IndexUpdate(
+            added=0,
+            changed=0,
+            unchanged=len(incoming),
+            removed=0,
+            chunks=0,
+            stale=sum(file.stale for file in incoming.values()),
+            content_generation=current_generation,
+            scan_revision=scan_revision,
+        )
+
+    @staticmethod
+    def _read_revision(metadata: Mapping[str, str], key: str, fallback: str | None = None) -> int:
+        raw = metadata.get(key, metadata.get(fallback, "0") if fallback is not None else "0")
+        try:
+            revision = int(raw)
+        except (TypeError, ValueError) as exc:
+            raise IndexFormatError(f"index {key} metadata is invalid") from exc
+        if revision < 0:
+            raise IndexFormatError(f"index {key} metadata is invalid")
+        return revision
+
     def update(self, scan: ScanResult) -> IndexUpdate:
-        """Apply a complete scan using SHA256 values for incremental invalidation."""
+        """Atomically apply one completed scan and advance only changed fact state."""
 
         self._ensure_open()
         self._ensure_repository_identity()
@@ -795,14 +1023,19 @@ class RepositoryIndex:
         if scan_identity != self._repository_identity:
             raise StaleScanError("repository identity changed after the scan started")
         incoming: dict[str, ScannedFile] = {}
+        incoming_digests: dict[str, str] = {}
         incomplete_paths = tuple(sorted(set(scan.temporarily_unreadable)))
         skipped_summary, warning_summary = _snapshot_scan_metadata(scan)
-        if not scan.analysis_version or len(scan.analysis_version) > 128:
+        if not scan.analysis_version or len(scan.analysis_version) > 256:
             raise ValueError("scan analysis version must be a short non-empty string")
-        if scan.base_generation is not None and (
-            isinstance(scan.base_generation, bool) or scan.base_generation < 0
+        for name, revision in (
+            ("base generation", scan.base_generation),
+            ("base scan revision", scan.base_scan_revision),
         ):
-            raise ValueError("scan base generation must be a non-negative integer or None")
+            if revision is not None and (
+                isinstance(revision, bool) or not isinstance(revision, int) or revision < 0
+            ):
+                raise ValueError(f"scan {name} must be a non-negative integer or None")
         for path in incomplete_paths:
             _validate_scan_path(path)
         for file in scan.files:
@@ -810,66 +1043,108 @@ class RepositoryIndex:
             if file.path in incoming:
                 raise ValueError(f"duplicate scanned path: {file.path}")
             incoming[file.path] = file
+            if file.facts_materialized:
+                incoming_digests[file.path] = _file_fact_digest(file)
 
         with self._lock, self._transaction():
-            # BEGIN IMMEDIATE precedes both the comparison and mutations.  Two
-            # index instances in one process therefore cannot calculate deltas
-            # from the same stale snapshot and race on inserts.
-            generation_row = self._connection.execute(
-                "SELECT value FROM meta WHERE key = 'generation'"
-            ).fetchone()
-            try:
-                current_generation = int(generation_row["value"]) if generation_row else 0
-            except (TypeError, ValueError) as exc:
-                raise IndexFormatError("index generation metadata is invalid") from exc
-            if current_generation < 0:
-                raise IndexFormatError("index generation metadata is invalid")
+            current_generation = self._revision_in_transaction(
+                "content_generation", fallback="generation"
+            )
+            current_scan_revision = self._revision_in_transaction("scan_revision")
             if scan.base_generation is not None and scan.base_generation != current_generation:
                 raise StaleScanError(
-                    f"scan generation {scan.base_generation} is stale; "
-                    f"current generation is {current_generation}"
+                    f"scan content generation {scan.base_generation} is stale; "
+                    f"current content generation is {current_generation}"
+                )
+            if (
+                scan.base_scan_revision is not None
+                and scan.base_scan_revision != current_scan_revision
+            ):
+                raise StaleScanError(
+                    f"scan revision {scan.base_scan_revision} is stale; "
+                    f"current scan revision is {current_scan_revision}"
                 )
             if _repository_identity(self._root) != scan_identity:
                 raise StaleScanError("repository identity changed while committing the scan")
+            metadata_before = {
+                str(row["key"]): str(row["value"])
+                for row in self._connection.execute("SELECT key, value FROM meta")
+            }
+            prior_fingerprints = _metadata_fingerprints(metadata_before)
+            committed_fingerprints = (
+                scan.fingerprints or prior_fingerprints or DEFAULT_ANALYSIS_FINGERPRINTS
+            )
             current = {
-                str(row["path"]): (
-                    str(row["sha256"]).casefold(),
-                    str(row["provenance"]),
-                    bool(row["stale"]),
-                )
+                str(row["path"]): {
+                    "sha256": str(row["sha256"]).casefold(),
+                    "provenance": str(row["provenance"]),
+                    "stale": bool(row["stale"]),
+                    "facts_sha256": str(row["facts_sha256"]),
+                }
                 for row in self._connection.execute(
-                    "SELECT path, sha256, provenance, stale FROM files"
+                    "SELECT path, sha256, provenance, stale, facts_sha256 FROM files"
                 )
             }
             incoming_paths = set(incoming)
             current_paths = set(current)
-            analysis_changed = self.get_metadata().get("analysis_version") != scan.analysis_version
             added = sorted(incoming_paths - current_paths)
+            if any(not incoming[path].facts_materialized for path in added):
+                raise ValueError("new scanned files must include materialized parser facts")
             absent = current_paths - incoming_paths
             retained_stale = sorted(
                 path for path in absent if _covered_by_incomplete_path(path, incomplete_paths)
             )
             removed = sorted(absent - set(retained_stale))
-            changed = sorted(
-                path
-                for path in incoming_paths & current_paths
-                if (
-                    analysis_changed
-                    or incoming[path].sha256.casefold() != current[path][0]
-                    or incoming[path].provenance != current[path][1]
-                    or current[path][2]
-                )
+            changed: list[str] = []
+            for path in sorted(incoming_paths & current_paths):
+                file = incoming[path]
+                row = current[path]
+                if file.facts_materialized:
+                    digest_changed = incoming_digests[path] != row["facts_sha256"]
+                else:
+                    digest_changed = (
+                        file.sha256.casefold() != row["sha256"]
+                        or file.provenance != row["provenance"]
+                    )
+                    if digest_changed:
+                        raise ValueError(
+                            f"changed scanned file {path!r} must include materialized parser facts"
+                        )
+                if digest_changed or row["stale"]:
+                    changed.append(path)
+            changed_set = set(changed)
+            unchanged_paths = sorted((incoming_paths & current_paths) - changed_set)
+            newly_stale = [path for path in retained_stale if not current[path]["stale"]]
+            term_changed = (
+                prior_fingerprints is None
+                or prior_fingerprints.term_index != committed_fingerprints.term_index
             )
-            unchanged_paths = sorted((incoming_paths & current_paths) - set(changed))
-            unchanged = len(unchanged_paths)
-            replaced = added + changed
+            current_has_chunks = (
+                self._connection.execute("SELECT 1 FROM chunks LIMIT 1").fetchone() is not None
+            )
+            incoming_has_chunks = any(
+                bool(_effective_chunks(file))
+                if file.facts_materialized
+                else file.cached_chunk_count > 0
+                for file in incoming.values()
+            )
+            term_fact_changed = term_changed and (current_has_chunks or incoming_has_chunks)
+            fact_changed = bool(added or changed or removed or newly_stale or term_fact_changed)
+            physical_replacements = sorted(
+                set(added)
+                | changed_set
+                | (incoming_paths & current_paths if scan.refresh_mode == "rebuild" else set())
+            )
+            if any(not incoming[path].facts_materialized for path in physical_replacements):
+                raise ValueError("rebuild scans must include materialized parser facts")
             inserted_chunks = 0
-
-            for path in removed + changed:
+            for path in removed + [path for path in physical_replacements if path in current_paths]:
                 self._connection.execute("DELETE FROM files WHERE path = ?", (path,))
-            for path in replaced:
+            for path in physical_replacements:
                 inserted_chunks += self._insert_file(incoming[path])
             for path in unchanged_paths:
+                if path in physical_replacements:
+                    continue
                 file = incoming[path]
                 self._connection.execute(
                     "UPDATE files SET mtime_ns = ?, ctime_ns = ?, stale = 0 WHERE path = ?",
@@ -877,20 +1152,24 @@ class RepositoryIndex:
                 )
             for path in retained_stale:
                 self._connection.execute("UPDATE files SET stale = 1 WHERE path = ?", (path,))
+            if term_changed:
+                self._rebuild_chunk_terms()
+
             scan_digest = hashlib.sha256()
             for path in sorted(incoming):
                 scan_digest.update(path.encode("utf-8", errors="surrogatepass"))
                 scan_digest.update(b"\0")
                 scan_digest.update(incoming[path].sha256.casefold().encode("ascii"))
                 scan_digest.update(b"\0")
-            committed_generation = current_generation + 1
+            committed_generation = current_generation + int(fact_changed)
+            committed_scan_revision = current_scan_revision + 1
             metadata = {
                 "last_scan_digest": scan_digest.hexdigest(),
                 "last_scan_file_count": str(len(incoming)),
                 "last_scan_indexed_bytes": str(sum(file.size_bytes for file in incoming.values())),
                 "last_update_added": str(len(added)),
                 "last_update_changed": str(len(changed)),
-                "last_update_unchanged": str(unchanged),
+                "last_update_unchanged": str(len(unchanged_paths)),
                 "last_update_removed": str(len(removed)),
                 "last_update_stale": str(len(retained_stale)),
                 "last_scan_skipped": json.dumps(
@@ -900,6 +1179,9 @@ class RepositoryIndex:
                 "last_scan_incomplete": json.dumps(incomplete_paths, ensure_ascii=False),
                 "analysis_version": scan.analysis_version,
                 "generation": str(committed_generation),
+                "content_generation": str(committed_generation),
+                "scan_revision": str(committed_scan_revision),
+                **committed_fingerprints.metadata(),
             }
             self._connection.executemany(
                 """
@@ -908,18 +1190,18 @@ class RepositoryIndex:
                 """,
                 sorted(metadata.items()),
             )
-
             if _repository_identity(self._root) != scan_identity:
                 raise StaleScanError("repository identity changed while committing the scan")
 
         return IndexUpdate(
             added=len(added),
             changed=len(changed),
-            unchanged=unchanged,
+            unchanged=len(unchanged_paths),
             removed=len(removed),
             chunks=inserted_chunks,
             stale=len(retained_stale),
-            generation=committed_generation,
+            content_generation=committed_generation,
+            scan_revision=committed_scan_revision,
         )
 
     def _insert_file(self, file: ScannedFile) -> int:
@@ -927,8 +1209,8 @@ class RepositoryIndex:
             """
             INSERT INTO files(
                 path, language, size_bytes, sha256, line_count, text, is_entry_point,
-                mtime_ns, ctime_ns, provenance, stale
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                mtime_ns, ctime_ns, provenance, stale, facts_sha256
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 file.path,
@@ -942,6 +1224,7 @@ class RepositoryIndex:
                 file.ctime_ns,
                 file.provenance,
                 int(file.stale),
+                _file_fact_digest(file),
             ),
         )
         self._connection.executemany(
@@ -1033,16 +1316,43 @@ class RepositoryIndex:
             }
 
     def generation(self) -> int:
-        """Return the current monotonic commit generation."""
+        """Deprecated alias for :meth:`content_generation`."""
 
-        value = self.get_metadata().get("generation", "0")
-        try:
-            generation = int(value)
-        except ValueError as exc:
-            raise IndexFormatError("index generation metadata is invalid") from exc
-        if generation < 0:
-            raise IndexFormatError("index generation metadata is invalid")
-        return generation
+        return self.content_generation()
+
+    def content_generation(self) -> int:
+        """Return the retrieval-visible fact generation."""
+
+        return self._read_revision(self.get_metadata(), "content_generation", "generation")
+
+    def scan_revision(self) -> int:
+        """Return the diagnostic completed-scan revision."""
+
+        return self._read_revision(self.get_metadata(), "scan_revision")
+
+    def fingerprints(self) -> AnalysisFingerprints | None:
+        """Return committed component identities, if this index has been refreshed."""
+
+        return _metadata_fingerprints(self.get_metadata())
+
+    @contextmanager
+    def consistent_read(self) -> Iterator[int]:
+        """Hold one SQLite read snapshot and yield its content generation."""
+
+        self._ensure_open()
+        self._ensure_repository_identity()
+        with self._lock:
+            self._connection.execute("BEGIN")
+            try:
+                generation = self._revision_in_transaction(
+                    "content_generation", fallback="generation"
+                )
+                yield generation
+            except BaseException:
+                self._connection.rollback()
+                raise
+            else:
+                self._connection.commit()
 
     def snapshot(self) -> IndexSnapshot:
         """Read full cache facts and their CAS generation from one SQLite snapshot."""
@@ -1073,12 +1383,11 @@ class RepositoryIndex:
             try:
                 metadata = self.get_metadata()
                 try:
-                    generation = int(metadata.get("generation", "0"))
+                    generation = self._read_revision(metadata, "content_generation", "generation")
+                    scan_revision = self._read_revision(metadata, "scan_revision")
                 except ValueError as exc:
-                    raise IndexFormatError("index generation metadata is invalid") from exc
-                if generation < 0:
-                    raise IndexFormatError("index generation metadata is invalid")
-                analysis_version = metadata.get("analysis_version", "")
+                    raise IndexFormatError("index revision metadata is invalid") from exc
+                fingerprints = _metadata_fingerprints(metadata)
                 skipped, warnings, incomplete = _decode_snapshot_state(metadata)
                 files = tuple(
                     self.get_file_manifest(max_files=max_manifest_files)
@@ -1092,7 +1401,8 @@ class RepositoryIndex:
                 self._connection.commit()
         return IndexSnapshot(
             generation,
-            analysis_version,
+            scan_revision,
+            fingerprints,
             files,
             skipped,
             warnings,
@@ -1209,7 +1519,9 @@ class RepositoryIndex:
                    (SELECT count(*) FROM chunks AS c WHERE c.file_path = f.path)
                        AS cached_chunk_count,
                    (SELECT count(*) FROM symbols AS s WHERE s.file_path = f.path)
-                       AS cached_symbol_count
+                       AS cached_symbol_count,
+                   (SELECT count(*) FROM dependencies AS d WHERE d.source_path = f.path)
+                       AS cached_dependency_count
             FROM files AS f
             ORDER BY f.path
         """
@@ -1234,6 +1546,8 @@ class RepositoryIndex:
                 stale=bool(row["stale"]),
                 cached_chunk_count=int(row["cached_chunk_count"]),
                 cached_symbol_count=int(row["cached_symbol_count"]),
+                cached_dependency_count=int(row["cached_dependency_count"]),
+                facts_materialized=False,
             )
             for row in rows
         ]
@@ -1272,6 +1586,8 @@ class RepositoryIndex:
                 stale=bool(row["stale"]),
                 cached_chunk_count=len(chunks_by_path[str(row["path"])]),
                 cached_symbol_count=len(symbols_by_path[str(row["path"])]),
+                cached_dependency_count=len(dependencies_by_path[str(row["path"])]),
+                facts_materialized=True,
             )
             for row in file_rows
         ]

--- a/src/repolocus/index/store.py
+++ b/src/repolocus/index/store.py
@@ -516,11 +516,16 @@ class RepositoryIndex:
                     version = _PROVENANCE_SCHEMA_VERSION
                     tables.add("chunk_terms")
                 if version == _PROVENANCE_SCHEMA_VERSION:
-                    if not _REQUIRED_TABLES.issubset(tables):
-                        missing = ", ".join(sorted(_REQUIRED_TABLES - tables))
+                    missing_tables = _REQUIRED_TABLES - tables
+                    if missing_tables and (
+                        missing_tables != {"chunk_terms"}
+                        or not self._is_recognized_legacy_v3_layout()
+                    ):
+                        missing = ", ".join(sorted(missing_tables))
                         raise IndexFormatError(f"index schema is incomplete; missing: {missing}")
                     self._migrate_v3_to_v4()
                     version = _IDENTITY_SCHEMA_VERSION
+                    tables.add("chunk_terms")
                 if version == _IDENTITY_SCHEMA_VERSION:
                     if not _REQUIRED_TABLES.issubset(tables):
                         missing = ", ".join(sorted(_REQUIRED_TABLES - tables))
@@ -631,6 +636,100 @@ class RepositoryIndex:
         except sqlite3.Error as exc:
             raise IndexFormatError(f"could not migrate v2 index: {exc}") from exc
 
+    def _is_recognized_legacy_v3_layout(self) -> bool:
+        """Recognize the pre-release v3 layout that retained the v2 search schema."""
+
+        tables = {
+            str(row[0])
+            for row in self._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+        if not _V2_REQUIRED_TABLES.issubset(tables) or "chunk_terms" in tables:
+            return False
+        metadata = {
+            str(row["key"]): str(row["value"])
+            for row in self._connection.execute("SELECT key, value FROM meta")
+        }
+        if (
+            metadata.get("schema_version") != str(_PROVENANCE_SCHEMA_VERSION)
+            or metadata.get("index_format_version") != str(_PROVENANCE_SCHEMA_VERSION)
+            or metadata.get("repository_root") != str(self._root)
+        ):
+            return False
+        try:
+            generation = int(metadata["generation"])
+        except (KeyError, TypeError, ValueError):
+            return False
+        if generation < 0:
+            return False
+        file_columns = {
+            str(row["name"]) for row in self._connection.execute("PRAGMA table_info(files)")
+        }
+        expected_file_columns = {
+            "path",
+            "language",
+            "size_bytes",
+            "sha256",
+            "line_count",
+            "text",
+            "is_entry_point",
+            "mtime_ns",
+            "ctime_ns",
+            "provenance",
+            "stale",
+        }
+        if file_columns != expected_file_columns:
+            return False
+        fts_columns = tuple(
+            str(row["name"]) for row in self._connection.execute("PRAGMA table_info(chunks_fts)")
+        )
+        if fts_columns != ("path", "symbol", "content"):
+            return False
+        trigger_names = {
+            str(row[0])
+            for row in self._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'chunks'"
+            )
+        }
+        return {
+            "chunks_after_insert",
+            "chunks_after_delete",
+            "chunks_after_update",
+        }.issubset(trigger_names)
+
+    def _replace_legacy_v3_search_layout(self) -> None:
+        """Replace the recognized v2-style search schema after facts are invalidated."""
+
+        self._connection.execute("DROP TRIGGER chunks_after_insert")
+        self._connection.execute("DROP TRIGGER chunks_after_delete")
+        self._connection.execute("DROP TRIGGER chunks_after_update")
+        self._connection.execute("DROP TABLE chunks_fts")
+        self._connection.execute(
+            """
+            CREATE TABLE chunk_terms (
+                term TEXT NOT NULL,
+                chunk_id INTEGER NOT NULL REFERENCES chunks(id) ON DELETE CASCADE,
+                PRIMARY KEY (term, chunk_id)
+            ) WITHOUT ROWID
+            """
+        )
+        self._connection.execute("CREATE INDEX chunk_terms_chunk_idx ON chunk_terms(chunk_id)")
+        self._connection.execute(
+            """
+            CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                file_path,
+                symbol,
+                content,
+                content = 'chunks',
+                content_rowid = 'id',
+                tokenize = 'unicode61 remove_diacritics 2'
+            )
+            """
+        )
+        self._create_fts_triggers()
+        self._connection.execute("INSERT INTO chunks_fts(chunks_fts) VALUES ('rebuild')")
+
     def _migrate_v3_to_v4(self) -> None:
         """Invalidate path-only facts before binding the index to this directory."""
 
@@ -644,8 +743,20 @@ class RepositoryIndex:
                         f"unsupported index schema {current_version}; "
                         f"expected {_PROVENANCE_SCHEMA_VERSION}"
                     )
+                tables = {
+                    str(row[0])
+                    for row in self._connection.execute(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+                    )
+                }
+                legacy_search_layout = "chunk_terms" not in tables
+                if legacy_search_layout and not self._is_recognized_legacy_v3_layout():
+                    raise IndexFormatError("unrecognized legacy v3 index layout")
                 generation = self._generation_in_transaction()
                 self._clear_repository_facts()
+                if legacy_search_layout:
+                    self._replace_legacy_v3_search_layout()
                 self._connection.executemany(
                     """
                     INSERT INTO meta(key, value) VALUES (?, ?)

--- a/src/repolocus/models.py
+++ b/src/repolocus/models.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+from repolocus.analysis import AnalysisFingerprints
+
 Confidence = Literal["confirmed", "inferred", "needs_review"]
 Provenance = Literal["source", "generated"]
 ANALYSIS_VERSION = "3"
@@ -79,6 +81,8 @@ class ScannedFile:
     stale: bool = False
     cached_chunk_count: int = 0
     cached_symbol_count: int = 0
+    cached_dependency_count: int = 0
+    facts_materialized: bool = True
 
 
 @dataclass(slots=True)
@@ -90,6 +94,8 @@ class ScanStats:
     indexed_bytes: int = 0
     languages: dict[str, int] = field(default_factory=dict)
     skipped: dict[str, int] = field(default_factory=dict)
+    content_reads: int = 0
+    parsed_files: int = 0
 
     def skip(self, reason: str) -> None:
         self.skipped[reason] = self.skipped.get(reason, 0) + 1
@@ -107,6 +113,9 @@ class ScanResult:
     temporarily_unreadable: tuple[str, ...] = ()
     base_generation: int | None = None
     repository_identity: str = ""
+    base_scan_revision: int | None = None
+    fingerprints: AnalysisFingerprints | None = None
+    refresh_mode: Literal["auto", "always", "never", "rebuild"] = "auto"
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +129,7 @@ class Evidence:
     score: float
     symbol: str = ""
     reason: str = "full-text match"
+    generation: int = 0
 
     @property
     def citation(self) -> str:
@@ -137,19 +147,45 @@ class IndexUpdate:
     removed: int
     chunks: int
     stale: int = 0
-    generation: int = 0
+    content_generation: int = 0
+    scan_revision: int = 0
+
+    @property
+    def generation(self) -> int:
+        """Deprecated compatibility alias for ``content_generation``."""
+
+        return self.content_generation
 
 
 @dataclass(frozen=True, slots=True)
 class IndexSnapshot:
     """One transactionally consistent index state used to seed a scan."""
 
-    generation: int
-    analysis_version: str
+    content_generation: int
+    scan_revision: int
+    fingerprints: AnalysisFingerprints | None
     files: tuple[ScannedFile, ...]
     skipped: tuple[tuple[str, int], ...] = ()
     warnings: tuple[str, ...] = ()
     temporarily_unreadable: tuple[str, ...] = ()
+
+    @property
+    def generation(self) -> int:
+        """Deprecated compatibility alias for ``content_generation``."""
+
+        return self.content_generation
+
+    @property
+    def analysis_version(self) -> str:
+        """Deprecated composite identity retained for older integrations."""
+
+        if self.fingerprints is None:
+            return ""
+        return (
+            f"scan={self.fingerprints.scan[:16]}:"
+            f"parser={self.fingerprints.parser[:16]}:"
+            f"terms={self.fingerprints.term_index[:16]}"
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/repolocus/parsers/base.py
+++ b/src/repolocus/parsers/base.py
@@ -7,6 +7,7 @@ registered without changing repository traversal or its security policy.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -27,6 +28,8 @@ class SourceParser(Protocol):
     """Protocol implemented by language parser plugins."""
 
     languages: frozenset[str]
+    cache_key: str
+    priority: int
 
     def parse(
         self,
@@ -45,6 +48,7 @@ class ParserRegistry:
 
     def __init__(self) -> None:
         self._parsers: dict[str, SourceParser] = {}
+        self._frozen_manifest: tuple[tuple[str, tuple[str, ...], int], ...] | None = None
 
     def register(self, parser: SourceParser, *, replace: bool = False) -> None:
         """Register *parser* for all of its languages.
@@ -53,13 +57,39 @@ class ParserRegistry:
         never silently change scan results.
         """
 
+        if self._frozen_manifest is not None:
+            raise RuntimeError("a frozen parser registry cannot be modified")
         if not parser.languages:
             raise ValueError("a parser must declare at least one language")
-        collisions = sorted(language for language in parser.languages if language in self._parsers)
+        cache_key = getattr(parser, "cache_key", "")
+        if (
+            not isinstance(cache_key, str)
+            or not cache_key
+            or len(cache_key) > 128
+            or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:+/-]*", cache_key) is None
+        ):
+            raise ValueError("a parser must declare a stable, bounded cache_key")
+        priority = getattr(parser, "priority", 0)
+        if (
+            isinstance(priority, bool)
+            or not isinstance(priority, int)
+            or not -1000 <= priority <= 1000
+        ):
+            raise ValueError("parser priority must be an integer between -1000 and 1000")
+        languages = frozenset(parser.languages)
+        if any(
+            not isinstance(language, str)
+            or not language
+            or len(language) > 64
+            or re.fullmatch(r"[a-z0-9][a-z0-9_+-]*", language) is None
+            for language in languages
+        ):
+            raise ValueError("parser languages must use bounded normalized identifiers")
+        collisions = sorted(language for language in languages if language in self._parsers)
         if collisions and not replace:
             joined = ", ".join(collisions)
             raise ValueError(f"parser already registered for: {joined}")
-        for language in sorted(parser.languages):
+        for language in sorted(languages):
             self._parsers[language] = parser
 
     def parser_for(self, language: str) -> SourceParser:
@@ -75,6 +105,69 @@ class ParserRegistry:
         """Return registered language names in stable order."""
 
         return tuple(sorted(self._parsers))
+
+    def cache_manifest(self) -> tuple[dict[str, object], ...]:
+        """Return a registration-order-independent parser cache manifest."""
+
+        return tuple(
+            {
+                "cache_key": cache_key,
+                "languages": list(languages),
+                "priority": priority,
+            }
+            for cache_key, languages, priority in self._cache_records()
+        )
+
+    def frozen_copy(self) -> ParserRegistry:
+        """Snapshot parser selection and cache identity for one scanner lifetime."""
+
+        frozen = ParserRegistry()
+        frozen._parsers = dict(self._parsers)
+        frozen._frozen_manifest = self._cache_records()
+        return frozen
+
+    def _cache_records(self) -> tuple[tuple[str, tuple[str, ...], int], ...]:
+        if self._frozen_manifest is not None:
+            return self._frozen_manifest
+        return self._current_cache_records()
+
+    def _current_cache_records(self) -> tuple[tuple[str, tuple[str, ...], int], ...]:
+        grouped: dict[int, tuple[SourceParser, set[str]]] = {}
+        for language, parser in self._parsers.items():
+            key = id(parser)
+            if key not in grouped:
+                grouped[key] = (parser, set())
+            grouped[key][1].add(language)
+        records = [
+            (
+                parser.cache_key,
+                tuple(sorted(languages)),
+                getattr(parser, "priority", 0),
+            )
+            for parser, languages in grouped.values()
+        ]
+        return tuple(
+            sorted(
+                records,
+                key=lambda item: (
+                    item[1],
+                    item[2],
+                    item[0],
+                ),
+            )
+        )
+
+    def require_stable(self) -> None:
+        """Fail closed if a frozen plugin changes its declared cache identity."""
+
+        if self._frozen_manifest is None:
+            return
+        try:
+            current = self._current_cache_records()
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise RuntimeError("a frozen parser changed its cache identity") from exc
+        if current != self._frozen_manifest:
+            raise RuntimeError("a frozen parser changed its cache identity")
 
     def parse(
         self,

--- a/src/repolocus/parsers/chunking.py
+++ b/src/repolocus/parsers/chunking.py
@@ -25,6 +25,7 @@ def _split_region(
     region: Region,
     max_lines: int,
     max_chars: int,
+    max_chunks: int | None,
 ) -> list[Chunk]:
     chunks: list[Chunk] = []
     parts: list[str] = []
@@ -36,6 +37,8 @@ def _split_region(
         nonlocal parts, chars, part_start, part_end
         if not parts:
             return
+        if max_chunks is not None and len(chunks) >= max_chunks:
+            raise ValueError("semantic chunking exceeded the configured chunk limit")
         chunks.append(
             Chunk(
                 path=path,
@@ -51,10 +54,9 @@ def _split_region(
 
     for line_number in range(region.start_line, region.end_line + 1):
         line = lines[line_number - 1]
-        pieces = [line[index : index + max_chars] for index in range(0, len(line), max_chars)]
-        if not pieces:
-            pieces = [""]
-        for piece in pieces:
+        piece_offsets = range(0, len(line), max_chars) if line else (0,)
+        for index in piece_offsets:
+            piece = line[index : index + max_chars]
             exceeds_lines = bool(parts) and line_number - part_start + 1 > max_lines
             exceeds_chars = bool(parts) and chars + len(piece) > max_chars
             if exceeds_lines or exceeds_chars:
@@ -78,6 +80,7 @@ def semantic_chunks(
     regions: Iterable[Region] = (),
     max_lines: int = 160,
     max_chars: int = 16_000,
+    max_chunks: int | None = None,
 ) -> tuple[Chunk, ...]:
     """Build bounded chunks around symbols or document sections.
 
@@ -89,6 +92,10 @@ def semantic_chunks(
 
     if max_lines <= 0 or max_chars <= 0:
         raise ValueError("chunk limits must be positive")
+    if max_chunks is not None and (
+        isinstance(max_chunks, bool) or not isinstance(max_chunks, int) or max_chunks <= 0
+    ):
+        raise ValueError("max_chunks must be a positive integer or None")
     lines = text.splitlines(keepends=True)
     if not lines:
         return ()
@@ -121,6 +128,9 @@ def semantic_chunks(
 
     chunks: list[Chunk] = []
     for region in ordered:
+        remaining_chunks = None if max_chunks is None else max_chunks - len(chunks)
+        if remaining_chunks is not None and remaining_chunks <= 0:
+            raise ValueError("semantic chunking exceeded the configured chunk limit")
         chunks.extend(
             _split_region(
                 path=path,
@@ -129,6 +139,7 @@ def semantic_chunks(
                 region=region,
                 max_lines=max_lines,
                 max_chars=max_chars,
+                max_chunks=remaining_chunks,
             )
         )
     return tuple(

--- a/src/repolocus/parsers/heuristic.py
+++ b/src/repolocus/parsers/heuristic.py
@@ -573,6 +573,8 @@ class HeuristicParser:
     languages = frozenset(
         {"javascript", "typescript", "go", "rust", "java", "c", "cpp", "markdown", "config"}
     )
+    cache_key = "heuristic-multilang:v3"
+    priority = 10
 
     def parse(
         self,

--- a/src/repolocus/parsers/python.py
+++ b/src/repolocus/parsers/python.py
@@ -168,6 +168,8 @@ def _fallback(path: str, text: str) -> tuple[list[Symbol], list[Dependency], boo
 class PythonParser:
     """Extract Python symbols and imports without executing the source."""
 
+    cache_key = "python-ast:v2"
+    priority = 100
     languages = frozenset({"python"})
 
     def parse(

--- a/src/repolocus/providers/__init__.py
+++ b/src/repolocus/providers/__init__.py
@@ -18,6 +18,12 @@ from .http import (
     build_provider_request_plan,
 )
 from .local import ExtractiveProvider
+from .transport import (
+    ProviderTransport,
+    build_provider_transport,
+    direct_transport,
+    proxy_transport,
+)
 
 __all__ = [
     "AnthropicProvider",
@@ -31,8 +37,12 @@ __all__ = [
     "ProviderRequestError",
     "ProviderRequestPlan",
     "ProviderResponseError",
+    "ProviderTransport",
     "build_provider_request_plan",
+    "build_provider_transport",
     "create_provider",
+    "direct_transport",
     "is_local_provider",
     "provider_family",
+    "proxy_transport",
 ]

--- a/src/repolocus/providers/factory.py
+++ b/src/repolocus/providers/factory.py
@@ -12,6 +12,7 @@ from repolocus.security.privacy import provider_family
 from .base import ModelProvider, ProviderConfigurationError
 from .http import AnthropicProvider, OllamaProvider, OpenAICompatibleProvider
 from .local import ExtractiveProvider
+from .transport import ProviderTransport, build_provider_transport
 
 
 class ProviderFactory:
@@ -24,8 +25,15 @@ class ProviderFactory:
         *,
         environ: Mapping[str, str] | None = None,
         transport: httpx.BaseTransport | None = None,
+        transport_route: ProviderTransport | None = None,
     ) -> ModelProvider:
-        return create_provider(model, settings, environ=environ, transport=transport)
+        return create_provider(
+            model,
+            settings,
+            environ=environ,
+            transport=transport,
+            transport_route=transport_route,
+        )
 
 
 def create_provider(
@@ -34,6 +42,7 @@ def create_provider(
     *,
     environ: Mapping[str, str] | None = None,
     transport: httpx.BaseTransport | None = None,
+    transport_route: ProviderTransport | None = None,
 ) -> ModelProvider:
     """Create a provider from ``provider/model`` or ``provider:model``.
 
@@ -54,13 +63,20 @@ def create_provider(
     if not model_name:
         raise ProviderConfigurationError(f"{family} model name must not be empty")
     if family == "ollama":
+        route = transport_route or build_provider_transport(
+            configuration, configuration.ollama_base_url, environ=environ
+        )
         return OllamaProvider(
             model_name,
             base_url=configuration.ollama_base_url,
             timeout=configuration.request_timeout,
             transport=transport,
+            transport_route=route,
         )
     if family == "openai":
+        route = transport_route or build_provider_transport(
+            configuration, configuration.openai_base_url, environ=environ
+        )
         return OpenAICompatibleProvider(
             model_name,
             base_url=configuration.openai_base_url,
@@ -68,8 +84,12 @@ def create_provider(
             max_output_tokens=configuration.max_output_tokens,
             environ=environ,
             transport=transport,
+            transport_route=route,
         )
     if family == "anthropic":
+        route = transport_route or build_provider_transport(
+            configuration, configuration.anthropic_base_url, environ=environ
+        )
         return AnthropicProvider(
             model_name,
             base_url=configuration.anthropic_base_url,
@@ -77,6 +97,7 @@ def create_provider(
             max_output_tokens=configuration.max_output_tokens,
             environ=environ,
             transport=transport,
+            transport_route=route,
         )
     raise ProviderConfigurationError(
         f"unsupported provider {family!r}; expected local, ollama, openai, or anthropic"

--- a/src/repolocus/providers/http.py
+++ b/src/repolocus/providers/http.py
@@ -22,6 +22,7 @@ from .base import (
     ProviderRequestError,
     ProviderResponseError,
 )
+from .transport import ProviderTransport, direct_transport
 
 _MAX_REQUEST_BYTES = 8 * 1024 * 1024
 _MAX_RESPONSE_BYTES = 4 * 1024 * 1024
@@ -192,6 +193,7 @@ class _HTTPProvider(ModelProvider):
         base_url: str,
         timeout: float,
         transport: httpx.BaseTransport | None = None,
+        transport_route: ProviderTransport | None = None,
     ) -> None:
         if not isinstance(model, str) or not model.strip():
             raise ProviderConfigurationError("model name must not be empty")
@@ -206,6 +208,9 @@ class _HTTPProvider(ModelProvider):
         self.base_url = _normalise_base_url(base_url)
         self.timeout = float(timeout)
         self._transport = transport
+        self.transport_route = transport_route or direct_transport()
+        if is_loopback_url(self.base_url) and self.transport_route.mode != "direct":
+            raise ProviderConfigurationError("loopback providers must use a direct transport")
 
     def _post_json(
         self,
@@ -217,12 +222,17 @@ class _HTTPProvider(ModelProvider):
         _validate_outbound_body(body)
         deadline = monotonic() + self.timeout
         try:
+            client_options: dict[str, object] = {
+                "timeout": httpx.Timeout(self.timeout),
+                "transport": self._transport,
+                "trust_env": False,
+            }
+            # An injected transport is already the complete test/embedding route;
+            # combining it with HTTPX's proxy mounts would silently replace it.
+            if self.transport_route.proxy_url is not None and self._transport is None:
+                client_options["proxy"] = self.transport_route.proxy_url
             with (
-                httpx.Client(
-                    timeout=httpx.Timeout(self.timeout),
-                    transport=self._transport,
-                    trust_env=not is_loopback_url(self.base_url),
-                ) as client,
+                httpx.Client(**client_options) as client,
                 client.stream("POST", endpoint, headers=headers, content=body) as response,
             ):
                 if monotonic() > deadline:
@@ -292,8 +302,15 @@ class OllamaProvider(_HTTPProvider):
         base_url: str = "http://127.0.0.1:11434",
         timeout: float = 30.0,
         transport: httpx.BaseTransport | None = None,
+        transport_route: ProviderTransport | None = None,
     ) -> None:
-        super().__init__(model=model, base_url=base_url, timeout=timeout, transport=transport)
+        super().__init__(
+            model=model,
+            base_url=base_url,
+            timeout=timeout,
+            transport=transport,
+            transport_route=transport_route,
+        )
         self.is_local = is_loopback_url(self.base_url)
 
     def generate(self, system_prompt: str, user_prompt: str) -> str:
@@ -341,8 +358,15 @@ class OpenAICompatibleProvider(_HTTPProvider):
         max_output_tokens: int = 2048,
         environ: Mapping[str, str] | None = None,
         transport: httpx.BaseTransport | None = None,
+        transport_route: ProviderTransport | None = None,
     ) -> None:
-        super().__init__(model=model, base_url=base_url, timeout=timeout, transport=transport)
+        super().__init__(
+            model=model,
+            base_url=base_url,
+            timeout=timeout,
+            transport=transport,
+            transport_route=transport_route,
+        )
         env = os.environ if environ is None else environ
         api_key = env.get("OPENAI_API_KEY", "").strip()
         if not api_key:
@@ -411,8 +435,15 @@ class AnthropicProvider(_HTTPProvider):
         max_output_tokens: int = 2048,
         environ: Mapping[str, str] | None = None,
         transport: httpx.BaseTransport | None = None,
+        transport_route: ProviderTransport | None = None,
     ) -> None:
-        super().__init__(model=model, base_url=base_url, timeout=timeout, transport=transport)
+        super().__init__(
+            model=model,
+            base_url=base_url,
+            timeout=timeout,
+            transport=transport,
+            transport_route=transport_route,
+        )
         env = os.environ if environ is None else environ
         api_key = env.get("ANTHROPIC_API_KEY", "").strip()
         if not api_key:

--- a/src/repolocus/providers/transport.py
+++ b/src/repolocus/providers/transport.py
@@ -1,0 +1,215 @@
+"""Explicit, previewable HTTP transport policy for model providers."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+from urllib.parse import quote, unquote, urlsplit
+
+from repolocus.security.network import is_loopback_url
+from repolocus.security.privacy import canonical_endpoint
+
+if TYPE_CHECKING:
+    from repolocus.config import Settings
+
+ProxyMode = Literal["disabled", "environment", "explicit"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderTransport:
+    """One exact direct/proxy route, safe to bind to preview and consent."""
+
+    policy: ProxyMode
+    mode: Literal["direct", "proxy"]
+    identity: str
+    proxy: str | None = None
+    proxy_url: str | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.policy not in {"disabled", "environment", "explicit"}:
+            raise ValueError("transport policy is invalid")
+        if self.mode not in {"direct", "proxy"}:
+            raise ValueError("transport mode is invalid")
+        if len(self.identity) != 64:
+            raise ValueError("transport identity must be a SHA-256 digest")
+        try:
+            bytes.fromhex(self.identity)
+        except ValueError as exc:
+            raise ValueError("transport identity must be a SHA-256 digest") from exc
+        if self.mode == "direct" and (self.proxy is not None or self.proxy_url is not None):
+            raise ValueError("direct transport cannot carry a proxy route")
+        if self.mode == "proxy" and (not self.proxy or not self.proxy_url):
+            raise ValueError("proxy transport requires an exact proxy route")
+
+    def preview(self) -> dict[str, str]:
+        data = {"mode": self.mode, "policy": self.policy}
+        if self.proxy is not None:
+            data["proxy"] = self.proxy
+        return data
+
+
+def _route_identity(policy: ProxyMode, mode: str, proxy_url: str | None) -> str:
+    payload = json.dumps(
+        {"mode": mode, "policy": policy, "proxy": proxy_url},
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def direct_transport(policy: ProxyMode = "disabled") -> ProviderTransport:
+    return ProviderTransport(policy, "direct", _route_identity(policy, "direct", None))
+
+
+def _canonical_proxy_url(value: str) -> tuple[str, str]:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("proxy URL must be a non-empty URL")
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        raise ValueError("proxy URL must not contain control characters")
+    stripped = value.strip()
+    try:
+        parsed = urlsplit(stripped)
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("proxy URL contains an invalid port") from exc
+    scheme = parsed.scheme.casefold()
+    if scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("proxy URL must be an absolute http(s) URL")
+    if parsed.query or parsed.fragment or parsed.path not in {"", "/"}:
+        raise ValueError("proxy URL must not contain a path, query, or fragment")
+    host = parsed.hostname.rstrip(".").casefold()
+    if not host:
+        raise ValueError("proxy URL contains an invalid hostname")
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            host = host.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise ValueError("proxy URL contains an invalid hostname") from exc
+        rendered_host = host
+    else:
+        rendered_host = f"[{address.compressed}]" if address.version == 6 else address.compressed
+    effective_port = port if port is not None else (443 if scheme == "https" else 80)
+    display = f"{scheme}://{rendered_host}:{effective_port}"
+    userinfo = ""
+    if parsed.username is not None:
+        userinfo = quote(unquote(parsed.username), safe="")
+        if parsed.password is not None:
+            userinfo += ":" + quote(unquote(parsed.password), safe="")
+        userinfo += "@"
+    canonical = f"{scheme}://{userinfo}{rendered_host}:{effective_port}"
+    return canonical, display
+
+
+def proxy_transport(policy: ProxyMode, proxy_url: str) -> ProviderTransport:
+    canonical, display = _canonical_proxy_url(proxy_url)
+    return ProviderTransport(
+        policy,
+        "proxy",
+        # Consent is bound to the credential-free transport route. Hashing
+        # userinfo would still persist a verifier for weak proxy credentials
+        # and would unnecessarily invalidate consent when credentials rotate.
+        _route_identity(policy, "proxy", display),
+        proxy=display,
+        proxy_url=canonical,
+    )
+
+
+def _environment_value(environ: Mapping[str, str], name: str) -> str:
+    for key in (name.casefold(), name.upper()):
+        value = environ.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _no_proxy_match(endpoint: str, environ: Mapping[str, str]) -> bool:
+    raw = _environment_value(environ, "no_proxy")
+    if not raw:
+        return False
+    parsed = urlsplit(endpoint)
+    host = (parsed.hostname or "").rstrip(".").casefold()
+    effective_port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        address = None
+    for item in raw.split(","):
+        candidate = item.strip()
+        if not candidate:
+            continue
+        if candidate == "*":
+            return True
+        if "://" in candidate:
+            candidate = urlsplit(candidate).netloc
+        candidate_host = candidate
+        candidate_port: int | None = None
+        if candidate.startswith("[") and "]" in candidate:
+            closing = candidate.index("]")
+            candidate_host = candidate[1:closing]
+            if candidate[closing + 1 :].startswith(":"):
+                with _ignored_value_error():
+                    candidate_port = int(candidate[closing + 2 :])
+        elif candidate.count(":") == 1:
+            possible_host, possible_port = candidate.rsplit(":", 1)
+            with _ignored_value_error():
+                candidate_port = int(possible_port)
+                candidate_host = possible_host
+        if candidate_port is not None and candidate_port != effective_port:
+            continue
+        candidate_host = candidate_host.strip().rstrip(".").casefold()
+        try:
+            network = ipaddress.ip_network(candidate_host, strict=False)
+        except ValueError:
+            normalized = candidate_host.removeprefix("*.").removeprefix(".")
+            if host == normalized or host.endswith("." + normalized):
+                return True
+        else:
+            if address is not None and address in network:
+                return True
+    return False
+
+
+class _ignored_value_error:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exception_type, exception, traceback) -> bool:  # type: ignore[no-untyped-def]
+        return exception_type is ValueError
+
+
+def build_provider_transport(
+    settings: Settings,
+    endpoint: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> ProviderTransport:
+    """Resolve the exact route once; callers reuse it after consent approval."""
+
+    canonical_endpoint(endpoint)
+    policy = settings.proxy_mode
+    if policy not in {"disabled", "environment", "explicit"}:
+        raise ValueError("proxy_mode must be disabled, environment, or explicit")
+    if is_loopback_url(endpoint):
+        return direct_transport(policy)
+    if policy == "disabled":
+        return direct_transport("disabled")
+    if policy == "explicit":
+        return proxy_transport("explicit", settings.proxy_url)
+    environment = os.environ if environ is None else environ
+    if _no_proxy_match(endpoint, environment):
+        return direct_transport("environment")
+    scheme = urlsplit(endpoint).scheme.casefold()
+    proxy_url = _environment_value(environment, f"{scheme}_proxy")
+    if not proxy_url:
+        proxy_url = _environment_value(environment, "all_proxy")
+    if not proxy_url:
+        return direct_transport("environment")
+    return proxy_transport("environment", proxy_url)

--- a/src/repolocus/retrieval/engine.py
+++ b/src/repolocus/retrieval/engine.py
@@ -37,6 +37,10 @@ class RetrievalEngine:
 
         if limit <= 0 or not isinstance(query, str) or not query.strip():
             return []
+        with self._index.consistent_read() as generation:
+            return self._search_snapshot(query, limit, generation)
+
+    def _search_snapshot(self, query: str, limit: int, generation: int) -> list[Evidence]:
         candidate_limit = min(max(limit * 8, 32), 500)
         fts_hits = self._index.search_chunks(
             query,
@@ -106,6 +110,7 @@ class RetrievalEngine:
                 score=round(candidate.score, 6),
                 symbol=candidate.chunk.symbol,
                 reason="; ".join(sorted(candidate.reasons)),
+                generation=generation,
             )
             for candidate in ranked
         ]

--- a/src/repolocus/scanner/budget.py
+++ b/src/repolocus/scanner/budget.py
@@ -1,0 +1,121 @@
+"""Transactional repository resource budgets for secure scans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import monotonic
+
+
+@dataclass(frozen=True, slots=True)
+class FactCounts:
+    chunks: int = 0
+    symbols: int = 0
+    dependencies: int = 0
+
+    def __post_init__(self) -> None:
+        for name in ("chunks", "symbols", "dependencies"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} count must be a non-negative integer")
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetCheckpoint:
+    entries: int
+    bytes_seen: int
+    chunks: int
+    symbols: int
+    dependencies: int
+
+
+@dataclass(slots=True)
+class ScanBudget:
+    max_entries: int
+    max_bytes: int
+    max_chunks: int
+    max_symbols: int
+    max_dependencies: int
+    deadline: float
+    entries: int = 0
+    bytes_seen: int = 0
+    chunks: int = 0
+    symbols: int = 0
+    dependencies: int = 0
+    exhausted_reason: str | None = None
+    reported: bool = False
+
+    def check_deadline(self) -> bool:
+        if self.exhausted_reason is None and monotonic() > self.deadline:
+            self.exhausted_reason = "scan deadline"
+        return self.exhausted_reason is None
+
+    def observe_entry(self) -> bool:
+        if not self.check_deadline():
+            return False
+        if self.entries + 1 > self.max_entries:
+            self.exhausted_reason = "repository file/entry count"
+            return False
+        self.entries += 1
+        return True
+
+    def observe_bytes(self, size: int) -> bool:
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise ValueError("observed byte count must be a non-negative integer")
+        if not self.check_deadline():
+            return False
+        if self.bytes_seen + size > self.max_bytes:
+            self.exhausted_reason = "repository byte count"
+            return False
+        self.bytes_seen += size
+        return True
+
+    def require_capacity(self, counts: FactCounts) -> bool:
+        """Check capacity without consuming it."""
+
+        if not self.check_deadline():
+            return False
+        for current, additional, maximum, reason in (
+            (self.chunks, counts.chunks, self.max_chunks, "repository chunk count"),
+            (self.symbols, counts.symbols, self.max_symbols, "repository symbol count"),
+            (
+                self.dependencies,
+                counts.dependencies,
+                self.max_dependencies,
+                "repository dependency count",
+            ),
+        ):
+            if current + additional > maximum:
+                self.exhausted_reason = reason
+                return False
+        return True
+
+    def commit_facts(self, counts: FactCounts) -> None:
+        """Consume counts only after validation and a successful capacity check."""
+
+        if not self.require_capacity(counts):
+            raise RuntimeError(self.exhausted_reason or "repository fact budget exhausted")
+        self.chunks += counts.chunks
+        self.symbols += counts.symbols
+        self.dependencies += counts.dependencies
+
+    def checkpoint(self) -> BudgetCheckpoint:
+        return BudgetCheckpoint(
+            self.entries,
+            self.bytes_seen,
+            self.chunks,
+            self.symbols,
+            self.dependencies,
+        )
+
+    def restore(self, checkpoint: BudgetCheckpoint) -> None:
+        """Roll back consumed counters for a directory whose identity changed."""
+
+        self.entries = checkpoint.entries
+        self.bytes_seen = checkpoint.bytes_seen
+        self.chunks = checkpoint.chunks
+        self.symbols = checkpoint.symbols
+        self.dependencies = checkpoint.dependencies
+
+
+def deadline_after(seconds: int) -> float:
+    return monotonic() + seconds

--- a/src/repolocus/scanner/repository.py
+++ b/src/repolocus/scanner/repository.py
@@ -7,12 +7,13 @@ import hashlib
 import os
 import stat
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
-from time import monotonic
 
-from repolocus.models import ANALYSIS_VERSION, ScannedFile, ScanResult, ScanStats
-from repolocus.parsers import DEFAULT_REGISTRY, ParseResult, ParserRegistry
+from repolocus.analysis import build_analysis_fingerprints
+from repolocus.models import ScannedFile, ScanResult, ScanStats
+from repolocus.parsers import DEFAULT_REGISTRY, ParserRegistry
+from repolocus.scanner.budget import FactCounts, ScanBudget, deadline_after
 from repolocus.scanner.filters import (
     contains_likely_secret,
     detect_language,
@@ -22,6 +23,15 @@ from repolocus.scanner.filters import (
     is_sensitive_path,
 )
 from repolocus.scanner.ignore import IgnoreRules
+from repolocus.scanner.validation import (
+    DEFAULT_MAX_CHUNKS_PER_FILE,
+    DEFAULT_MAX_DEPENDENCIES_PER_FILE,
+    DEFAULT_MAX_REPOSITORY_DEPENDENCIES,
+    DEFAULT_MAX_SYMBOLS_PER_FILE,
+    HARD_MAX_REPOSITORY_DEPENDENCIES,
+    ParseLimits,
+    finalize_parse_result,
+)
 from repolocus.security.identity import descriptor_path, filesystem_identity
 
 DEFAULT_MAX_FILE_BYTES = 1_000_000
@@ -41,57 +51,6 @@ _USE_DIRECTORY_FDS = (
     and os.stat in os.supports_dir_fd
     and os.scandir in os.supports_fd
 )
-
-
-@dataclass(slots=True)
-class _ScanBudget:
-    max_entries: int
-    max_bytes: int
-    max_chunks: int
-    max_symbols: int
-    deadline: float
-    entries: int = 0
-    bytes_seen: int = 0
-    chunks: int = 0
-    symbols: int = 0
-    exhausted_reason: str | None = None
-    reported: bool = False
-
-    def check_deadline(self) -> bool:
-        if self.exhausted_reason is None and monotonic() > self.deadline:
-            self.exhausted_reason = "scan deadline"
-        return self.exhausted_reason is None
-
-    def observe_entry(self) -> bool:
-        if not self.check_deadline():
-            return False
-        if self.entries + 1 > self.max_entries:
-            self.exhausted_reason = "repository file/entry count"
-            return False
-        self.entries += 1
-        return True
-
-    def observe_bytes(self, size: int) -> bool:
-        if not self.check_deadline():
-            return False
-        if self.bytes_seen + size > self.max_bytes:
-            self.exhausted_reason = "repository byte count"
-            return False
-        self.bytes_seen += size
-        return True
-
-    def observe_facts(self, chunks: int, symbols: int) -> bool:
-        if not self.check_deadline():
-            return False
-        if self.chunks + chunks > self.max_chunks:
-            self.exhausted_reason = "repository chunk count"
-            return False
-        if self.symbols + symbols > self.max_symbols:
-            self.exhausted_reason = "repository symbol count"
-            return False
-        self.chunks += chunks
-        self.symbols += symbols
-        return True
 
 
 def _is_within(path: Path, root: Path) -> bool:
@@ -342,43 +301,6 @@ def _open_directory_at(
     return descriptor, None
 
 
-def _validate_parse_result(
-    parsed: ParseResult,
-    *,
-    path: str,
-    text: str,
-    language: str,
-    max_chunk_lines: int,
-    max_chunk_chars: int,
-) -> None:
-    """Reject plugin facts that cannot be traced to the supplied source."""
-
-    source_lines = text.splitlines(keepends=True)
-    line_count = len(source_lines)
-
-    def valid_range(start: int, end: int) -> bool:
-        return 1 <= start <= end <= line_count
-
-    for symbol in parsed.symbols:
-        if symbol.path != path or not valid_range(symbol.start_line, symbol.end_line):
-            raise ValueError("parser emitted an invalid symbol source range")
-    for dependency in parsed.dependencies:
-        if dependency.source_path != path or not 1 <= dependency.line <= line_count:
-            raise ValueError("parser emitted an invalid dependency source line")
-    for chunk in parsed.chunks:
-        if chunk.path != path or chunk.language != language:
-            raise ValueError("parser emitted a chunk for a different source")
-        if not valid_range(chunk.start_line, chunk.end_line):
-            raise ValueError("parser emitted an invalid chunk source range")
-        if chunk.end_line - chunk.start_line + 1 > max_chunk_lines:
-            raise ValueError("parser emitted a chunk beyond the line budget")
-        if len(chunk.content) > max_chunk_chars:
-            raise ValueError("parser emitted a chunk beyond the character budget")
-        source_region = "".join(source_lines[chunk.start_line - 1 : chunk.end_line])
-        if chunk.content not in source_region:
-            raise ValueError("parser emitted chunk content not present in its source range")
-
-
 class RepositoryScanner:
     """Scan supported repository text without following links or running code."""
 
@@ -394,9 +316,13 @@ class RepositoryScanner:
         max_directory_depth: int = DEFAULT_MAX_DIRECTORY_DEPTH,
         max_repository_chunks: int = DEFAULT_MAX_REPOSITORY_CHUNKS,
         max_repository_symbols: int = DEFAULT_MAX_REPOSITORY_SYMBOLS,
+        max_repository_dependencies: int = DEFAULT_MAX_REPOSITORY_DEPENDENCIES,
+        max_dependencies_per_file: int = DEFAULT_MAX_DEPENDENCIES_PER_FILE,
+        max_symbols_per_file: int = DEFAULT_MAX_SYMBOLS_PER_FILE,
+        max_chunks_per_file: int = DEFAULT_MAX_CHUNKS_PER_FILE,
         max_scan_seconds: int = DEFAULT_MAX_SCAN_SECONDS,
         parser_registry: ParserRegistry | None = None,
-        analysis_version: str = ANALYSIS_VERSION,
+        analysis_version: str | None = None,
     ) -> None:
         if max_file_bytes <= 0:
             raise ValueError("max_file_bytes must be positive")
@@ -410,11 +336,20 @@ class RepositoryScanner:
             ("max_directory_depth", max_directory_depth),
             ("max_repository_chunks", max_repository_chunks),
             ("max_repository_symbols", max_repository_symbols),
+            ("max_repository_dependencies", max_repository_dependencies),
+            ("max_dependencies_per_file", max_dependencies_per_file),
+            ("max_symbols_per_file", max_symbols_per_file),
+            ("max_chunks_per_file", max_chunks_per_file),
             ("max_scan_seconds", max_scan_seconds),
         ):
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
                 raise ValueError(f"{name} must be a positive integer")
-        if not analysis_version or len(analysis_version) > 96:
+        if max_repository_dependencies > HARD_MAX_REPOSITORY_DEPENDENCIES:
+            raise ValueError(
+                "max_repository_dependencies exceeds the global safety ceiling of "
+                f"{HARD_MAX_REPOSITORY_DEPENDENCIES}"
+            )
+        if analysis_version is not None and (not analysis_version or len(analysis_version) > 96):
             raise ValueError("analysis_version must be a short non-empty string")
         self.max_file_bytes = max_file_bytes
         self.max_ignore_bytes = max_ignore_bytes
@@ -425,10 +360,46 @@ class RepositoryScanner:
         self.max_directory_depth = max_directory_depth
         self.max_repository_chunks = max_repository_chunks
         self.max_repository_symbols = max_repository_symbols
+        self.max_repository_dependencies = max_repository_dependencies
+        self.parse_limits = ParseLimits(
+            max_chunk_lines=max_chunk_lines,
+            max_chunk_chars=max_chunk_chars,
+            max_dependencies_per_file=max_dependencies_per_file,
+            max_symbols_per_file=max_symbols_per_file,
+            max_chunks_per_file=max_chunks_per_file,
+        )
         self.max_scan_seconds = max_scan_seconds
-        self.parser_registry = parser_registry or DEFAULT_REGISTRY
+        self.parser_registry = (parser_registry or DEFAULT_REGISTRY).frozen_copy()
+        self.fingerprints = build_analysis_fingerprints(
+            parser_manifest=self.parser_registry.cache_manifest(),
+            scan_limits={
+                "max_directory_depth": max_directory_depth,
+                "max_file_bytes": max_file_bytes,
+                "max_ignore_bytes": max_ignore_bytes,
+                "max_repository_bytes": max_repository_bytes,
+                "max_repository_files": max_repository_files,
+                "max_scan_seconds": max_scan_seconds,
+            },
+            chunk_limits={
+                "max_chunk_chars": max_chunk_chars,
+                "max_chunk_lines": max_chunk_lines,
+                "max_repository_chunks": max_repository_chunks,
+                "max_repository_symbols": max_repository_symbols,
+                "max_repository_dependencies": max_repository_dependencies,
+                "max_dependencies_per_file": max_dependencies_per_file,
+                "max_symbols_per_file": max_symbols_per_file,
+                "max_chunks_per_file": max_chunks_per_file,
+            },
+            legacy_cache_key=analysis_version or "",
+        )
         self.analysis_version = (
             f"{analysis_version}:lines={max_chunk_lines}:chars={max_chunk_chars}"
+            if analysis_version is not None
+            else (
+                f"components-v1:scan={self.fingerprints.scan[:16]}:"
+                f"parser={self.fingerprints.parser[:16]}:"
+                f"terms={self.fingerprints.term_index[:16]}"
+            )
         )
 
     def scan(
@@ -438,6 +409,8 @@ class RepositoryScanner:
         cached_files: Mapping[str, ScannedFile] | None = None,
         trusted_cache: bool = False,
         base_generation: int | None = None,
+        base_scan_revision: int | None = None,
+        refresh_mode: str = "auto",
     ) -> ScanResult:
         """Return a stable scan of *root*.
 
@@ -450,8 +423,15 @@ class RepositoryScanner:
             isinstance(base_generation, bool) or base_generation < 0
         ):
             raise ValueError("base_generation must be a non-negative integer or None")
+        if base_scan_revision is not None and (
+            isinstance(base_scan_revision, bool) or base_scan_revision < 0
+        ):
+            raise ValueError("base_scan_revision must be a non-negative integer or None")
+        if refresh_mode not in {"auto", "always", "rebuild"}:
+            raise ValueError("scanner refresh_mode must be auto, always, or rebuild")
         if not isinstance(trusted_cache, bool):
             raise ValueError("trusted_cache must be true or false")
+        self.parser_registry.require_stable()
         supplied_root = Path(root).expanduser().absolute()
         try:
             root_metadata = supplied_root.lstat()
@@ -472,12 +452,13 @@ class RepositoryScanner:
         warnings: list[str] = []
         temporarily_unreadable: set[str] = set()
         reusable = cached_files or {}
-        budget = _ScanBudget(
+        budget = ScanBudget(
             max_entries=self.max_repository_files,
             max_bytes=self.max_repository_bytes,
             max_chunks=self.max_repository_chunks,
             max_symbols=self.max_repository_symbols,
-            deadline=monotonic() + self.max_scan_seconds,
+            max_dependencies=self.max_repository_dependencies,
+            deadline=deadline_after(self.max_scan_seconds),
         )
         root_fd: int | None = None
         if _USE_DIRECTORY_FDS:
@@ -513,6 +494,7 @@ class RepositoryScanner:
                 temporarily_unreadable,
                 reusable,
                 trusted_cache,
+                refresh_mode,
                 budget,
             )
         finally:
@@ -534,6 +516,7 @@ class RepositoryScanner:
             temporarily_unreadable = {"."}
         files.sort(key=lambda item: item.path)
         warnings.sort()
+        self.parser_registry.require_stable()
         return ScanResult(
             root=resolved_root,
             files=files,
@@ -543,6 +526,9 @@ class RepositoryScanner:
             temporarily_unreadable=tuple(sorted(temporarily_unreadable)),
             base_generation=base_generation,
             repository_identity=root_identity,
+            base_scan_revision=base_scan_revision,
+            fingerprints=self.fingerprints,
+            refresh_mode=refresh_mode,  # type: ignore[arg-type]
         )
 
     def _load_local_ignore(
@@ -610,17 +596,21 @@ class RepositoryScanner:
         temporarily_unreadable: set[str],
         cached_files: Mapping[str, ScannedFile],
         trusted_cache: bool,
-        budget: _ScanBudget,
+        refresh_mode: str,
+        budget: ScanBudget,
     ) -> None:
         file_checkpoint = len(files)
         warning_checkpoint = len(warnings)
         unreadable_checkpoint = set(temporarily_unreadable)
+        budget_checkpoint = budget.checkpoint()
         stats_checkpoint = (
             stats.discovered_files,
             stats.indexed_files,
             stats.indexed_bytes,
             dict(stats.languages),
             dict(stats.skipped),
+            stats.content_reads,
+            stats.parsed_files,
         )
         directory_location = relative_directory.as_posix() or "."
 
@@ -644,11 +634,14 @@ class RepositoryScanner:
                 stats.indexed_bytes,
                 languages,
                 skipped,
+                stats.content_reads,
+                stats.parsed_files,
             ) = stats_checkpoint
             stats.languages.clear()
             stats.languages.update(languages)
             stats.skipped.clear()
             stats.skipped.update(skipped)
+            budget.restore(budget_checkpoint)
             stats.skip("changed_during_scan")
             warnings.append(f"directory changed during scan: {directory_location}")
             temporarily_unreadable.add(directory_location)
@@ -800,6 +793,7 @@ class RepositoryScanner:
                         temporarily_unreadable,
                         cached_files,
                         trusted_cache,
+                        refresh_mode,
                         budget,
                     )
                 finally:
@@ -876,13 +870,15 @@ class RepositoryScanner:
                     directory_fd=directory_fd,
                 )
             ):
-                cached_chunks = (
-                    len(cached.chunks) or cached.cached_chunk_count or int(bool(cached.text))
+                cached_counts = FactCounts(
+                    chunks=len(cached.chunks) or cached.cached_chunk_count,
+                    symbols=len(cached.symbols) or cached.cached_symbol_count,
+                    dependencies=(len(cached.dependencies) or cached.cached_dependency_count),
                 )
-                cached_symbols = len(cached.symbols) or cached.cached_symbol_count
-                if not budget.observe_facts(cached_chunks, cached_symbols):
+                if not budget.require_capacity(cached_counts):
                     stop_for_global_budget()
                     return
+                budget.commit_facts(cached_counts)
                 if not directory_is_stable():
                     discard_changed_directory()
                     return
@@ -914,6 +910,7 @@ class RepositoryScanner:
                 if read_error in {"unreadable", "changed_during_scan"}:
                     temporarily_unreadable.add(display_path)
                 continue
+            stats.content_reads += 1
             if post_read_metadata is None:  # pragma: no cover - helper invariant
                 raise RuntimeError("safe read returned no metadata")
             digest = hashlib.sha256(payload).hexdigest()
@@ -942,20 +939,23 @@ class RepositoryScanner:
                 warnings.append(f"file with likely secret skipped: {display_path}")
                 continue
             if (
-                cached is not None
+                refresh_mode != "rebuild"
+                and cached is not None
                 and cached.provenance == "source"
                 and not cached.stale
                 and cached.language == language
                 and cached.size_bytes == len(payload)
                 and cached.sha256.casefold() == digest
             ):
-                cached_chunks = (
-                    len(cached.chunks) or cached.cached_chunk_count or int(bool(cached.text))
+                cached_counts = FactCounts(
+                    chunks=len(cached.chunks) or cached.cached_chunk_count,
+                    symbols=len(cached.symbols) or cached.cached_symbol_count,
+                    dependencies=(len(cached.dependencies) or cached.cached_dependency_count),
                 )
-                cached_symbols = len(cached.symbols) or cached.cached_symbol_count
-                if not budget.observe_facts(cached_chunks, cached_symbols):
+                if not budget.require_capacity(cached_counts):
                     stop_for_global_budget()
                     return
+                budget.commit_facts(cached_counts)
                 files.append(
                     replace(
                         cached,
@@ -978,6 +978,14 @@ class RepositoryScanner:
                     max_chunk_lines=self.max_chunk_lines,
                     max_chunk_chars=self.max_chunk_chars,
                 )
+                stats.parsed_files += 1
+                parsed, parsed_counts = finalize_parse_result(
+                    parsed,
+                    path=display_path,
+                    text=text,
+                    language=language,
+                    limits=self.parse_limits,
+                )
             except Exception as exc:  # Parser plugins are an isolation boundary.
                 stats.skip("parse_error")
                 warnings.append(f"parse failed ({type(exc).__name__}) for file: {display_path}")
@@ -987,24 +995,10 @@ class RepositoryScanner:
             if not budget.check_deadline():
                 stop_for_global_budget()
                 return
-            parsed_chunks = len(parsed.chunks) or int(bool(text))
-            if not budget.observe_facts(parsed_chunks, len(parsed.symbols)):
+            if not budget.require_capacity(parsed_counts):
                 stop_for_global_budget()
                 return
-            try:
-                _validate_parse_result(
-                    parsed,
-                    path=display_path,
-                    text=text,
-                    language=language,
-                    max_chunk_lines=self.max_chunk_lines,
-                    max_chunk_chars=self.max_chunk_chars,
-                )
-            except Exception as exc:  # Parser plugins are an isolation boundary.
-                stats.skip("parse_error")
-                warnings.append(f"parse failed ({type(exc).__name__}) for file: {display_path}")
-                temporarily_unreadable.add(display_path)
-                continue
+            budget.commit_facts(parsed_counts)
 
             scanned = ScannedFile(
                 path=display_path,

--- a/src/repolocus/scanner/repository.py
+++ b/src/repolocus/scanner/repository.py
@@ -924,10 +924,11 @@ class RepositoryScanner:
                 stats.skip("binary")
                 warnings.append(f"non-UTF-8 file skipped: {display_path}")
                 continue
-            if _IS_WINDOWS:
-                # Binary descriptor reads preserve on-disk bytes for size and hashing;
-                # normalize the CRLF translation previously supplied by the CRT.
-                text = text.replace("\r\n", "\n")
+            # Binary descriptor reads preserve on-disk bytes for size, hashing,
+            # and binary detection. Detector- and parser-facing decoded text uses
+            # one cross-platform newline convention; a bare CR remains untouched
+            # and is still rejected by parser postcondition checks.
+            text = text.replace("\r\n", "\n")
             if is_generated_document(text, language):
                 stats.skip("generated")
                 continue

--- a/src/repolocus/scanner/validation.py
+++ b/src/repolocus/scanner/validation.py
@@ -1,0 +1,277 @@
+"""Parser-plugin output normalization and postcondition enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from repolocus.models import Chunk, Dependency, Symbol
+from repolocus.parsers.base import ParseResult
+from repolocus.parsers.chunking import semantic_chunks
+from repolocus.scanner.budget import FactCounts
+from repolocus.security.display import has_unsafe_display_controls
+
+DEFAULT_MAX_REPOSITORY_DEPENDENCIES = 1_000_000
+DEFAULT_MAX_DEPENDENCIES_PER_FILE = 10_000
+DEFAULT_MAX_SYMBOLS_PER_FILE = 10_000
+DEFAULT_MAX_CHUNKS_PER_FILE = 10_000
+HARD_MAX_REPOSITORY_DEPENDENCIES = 2_000_000
+HARD_MAX_DEPENDENCIES_PER_FILE = 20_000
+HARD_MAX_SYMBOLS_PER_FILE = 20_000
+HARD_MAX_CHUNKS_PER_FILE = 20_000
+MAX_SYMBOL_NAME_CHARS = 512
+MAX_DEPENDENCY_TARGET_CHARS = 1_024
+MAX_KIND_CHARS = 64
+MAX_SIGNATURE_CHARS = 4_096
+MAX_LANGUAGE_CHARS = 64
+
+
+@dataclass(frozen=True, slots=True)
+class ParseLimits:
+    max_chunk_lines: int
+    max_chunk_chars: int
+    max_dependencies_per_file: int = DEFAULT_MAX_DEPENDENCIES_PER_FILE
+    max_symbols_per_file: int = DEFAULT_MAX_SYMBOLS_PER_FILE
+    max_chunks_per_file: int = DEFAULT_MAX_CHUNKS_PER_FILE
+    max_symbol_name_chars: int = MAX_SYMBOL_NAME_CHARS
+    max_dependency_target_chars: int = MAX_DEPENDENCY_TARGET_CHARS
+    max_kind_chars: int = MAX_KIND_CHARS
+    max_signature_chars: int = MAX_SIGNATURE_CHARS
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_chunk_lines",
+            "max_chunk_chars",
+            "max_dependencies_per_file",
+            "max_symbols_per_file",
+            "max_chunks_per_file",
+            "max_symbol_name_chars",
+            "max_dependency_target_chars",
+            "max_kind_chars",
+            "max_signature_chars",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        for value, maximum, name in (
+            (
+                self.max_dependencies_per_file,
+                HARD_MAX_DEPENDENCIES_PER_FILE,
+                "max_dependencies_per_file",
+            ),
+            (self.max_symbols_per_file, HARD_MAX_SYMBOLS_PER_FILE, "max_symbols_per_file"),
+            (self.max_chunks_per_file, HARD_MAX_CHUNKS_PER_FILE, "max_chunks_per_file"),
+        ):
+            if value > maximum:
+                raise ValueError(f"{name} exceeds the global safety ceiling of {maximum}")
+
+
+def _safe_field(value: object, name: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        raise ValueError(f"parser emitted an invalid or oversized {name}")
+    if has_unsafe_display_controls(value):
+        raise ValueError(f"parser emitted unsafe controls in {name}")
+    return value
+
+
+def _safe_optional_field(value: object, name: str, maximum: int) -> str:
+    if not isinstance(value, str) or len(value) > maximum:
+        raise ValueError(f"parser emitted an invalid or oversized {name}")
+    if value and has_unsafe_display_controls(value):
+        raise ValueError(f"parser emitted unsafe controls in {name}")
+    return value
+
+
+def _validate_source_identity(path: str, language: str) -> None:
+    _safe_field(path, "path", 4_096)
+    parsed = PurePosixPath(path)
+    if parsed.is_absolute() or parsed.as_posix() != path or ".." in parsed.parts or "\\" in path:
+        raise ValueError("parser source path must be normalized repository-relative POSIX text")
+    _safe_field(language, "language", MAX_LANGUAGE_CHARS)
+
+
+def _bounded_items(values: object, *, maximum: int, fact_name: str) -> list[object]:
+    """Collect at most *maximum* plugin facts without trusting container types."""
+
+    if isinstance(values, (str, bytes, bytearray)):
+        raise ValueError(f"parser {fact_name} facts must be an iterable of fact objects")
+    if isinstance(values, (tuple, list)) and len(values) > maximum:
+        raise ValueError(f"parser emitted more {fact_name} than the per-file safety limit")
+    try:
+        iterator = iter(values)  # type: ignore[call-overload]
+    except TypeError as exc:
+        raise ValueError(f"parser {fact_name} facts must be iterable") from exc
+    items: list[object] = []
+    for item in iterator:
+        if len(items) >= maximum:
+            raise ValueError(f"parser emitted more {fact_name} than the per-file safety limit")
+        items.append(item)
+    return items
+
+
+def finalize_parse_result(
+    parsed: ParseResult,
+    *,
+    text: str,
+    path: str,
+    language: str,
+    limits: ParseLimits,
+) -> tuple[ParseResult, FactCounts]:
+    """Normalize untrusted parser facts and enforce bounded source postconditions."""
+
+    if not isinstance(parsed, ParseResult):
+        raise ValueError("parser must return ParseResult")
+    if not isinstance(text, str):
+        raise TypeError("parser source text must be a string")
+    _validate_source_identity(path, language)
+    if not isinstance(parsed.is_entry_point, bool):
+        raise ValueError("parser is_entry_point must be true or false")
+    source_lines = text.splitlines(keepends=True)
+    line_count = len(source_lines)
+
+    def valid_range(start: int, end: int) -> bool:
+        return (
+            not isinstance(start, bool)
+            and not isinstance(end, bool)
+            and isinstance(start, int)
+            and isinstance(end, int)
+            and 1 <= start <= end <= line_count
+        )
+
+    raw_symbols = _bounded_items(
+        parsed.symbols,
+        maximum=limits.max_symbols_per_file,
+        fact_name="symbols",
+    )
+    symbols: list[Symbol] = []
+    for symbol in raw_symbols:
+        if not isinstance(symbol, Symbol):
+            raise ValueError("parser emitted a non-Symbol fact")
+        if symbol.path != path or not valid_range(symbol.start_line, symbol.end_line):
+            raise ValueError("parser emitted an invalid symbol source range")
+        _safe_field(symbol.name, "symbol name", limits.max_symbol_name_chars)
+        _safe_field(symbol.kind, "symbol kind", limits.max_kind_chars)
+        _safe_optional_field(symbol.signature, "symbol signature", limits.max_signature_chars)
+        symbols.append(symbol)
+    symbols = sorted(
+        set(symbols),
+        key=lambda item: (
+            item.start_line,
+            item.end_line,
+            item.kind,
+            item.name,
+            item.signature,
+        ),
+    )
+    if len(symbols) > limits.max_symbols_per_file:
+        raise ValueError("parser emitted more symbols than the per-file safety limit")
+    symbol_ranges: dict[str, list[tuple[int, int]]] = {}
+    for symbol in symbols:
+        symbol_ranges.setdefault(symbol.name, []).append((symbol.start_line, symbol.end_line))
+
+    raw_dependencies = _bounded_items(
+        parsed.dependencies,
+        maximum=limits.max_dependencies_per_file,
+        fact_name="dependencies",
+    )
+    dependencies: list[Dependency] = []
+    for dependency in raw_dependencies:
+        if not isinstance(dependency, Dependency):
+            raise ValueError("parser emitted a non-Dependency fact")
+        if dependency.source_path != path or not valid_range(dependency.line, dependency.line):
+            raise ValueError("parser emitted an invalid dependency source line")
+        _safe_field(
+            dependency.target,
+            "dependency target",
+            limits.max_dependency_target_chars,
+        )
+        _safe_field(dependency.kind, "dependency kind", limits.max_kind_chars)
+        dependencies.append(dependency)
+    dependencies = sorted(set(dependencies), key=lambda item: (item.line, item.target, item.kind))
+    if len(dependencies) > limits.max_dependencies_per_file:
+        raise ValueError("parser emitted more dependencies than the per-file safety limit")
+
+    raw_chunks = _bounded_items(
+        parsed.chunks,
+        maximum=limits.max_chunks_per_file,
+        fact_name="chunks",
+    )
+    if text and not raw_chunks:
+        raw_chunks = _bounded_items(
+            semantic_chunks(
+                path=path,
+                text=text,
+                language=language,
+                max_lines=limits.max_chunk_lines,
+                max_chars=limits.max_chunk_chars,
+                max_chunks=limits.max_chunks_per_file,
+            ),
+            maximum=limits.max_chunks_per_file,
+            fact_name="chunks",
+        )
+    chunks: list[Chunk] = []
+    for chunk in raw_chunks:
+        if not isinstance(chunk, Chunk):
+            raise ValueError("parser emitted a non-Chunk fact")
+        if chunk.path != path or chunk.language != language:
+            raise ValueError("parser emitted a chunk for a different source")
+        if not valid_range(chunk.start_line, chunk.end_line):
+            raise ValueError("parser emitted an invalid chunk source range")
+        if chunk.end_line - chunk.start_line + 1 > limits.max_chunk_lines:
+            raise ValueError("parser emitted a chunk beyond the line budget")
+        if len(chunk.content) > limits.max_chunk_chars:
+            raise ValueError("parser emitted a chunk beyond the character budget")
+        # CRLF is a normal source line ending on POSIX as well as Windows.
+        # Remove only intact pairs for the display-control check so a bare CR
+        # remains unsafe and cannot rewrite terminal output.
+        display_content = chunk.content.replace("\r\n", "\n")
+        if has_unsafe_display_controls(display_content, allow_layout=True):
+            raise ValueError("parser emitted unsafe controls in chunk content")
+        _safe_optional_field(chunk.symbol, "chunk symbol", limits.max_symbol_name_chars)
+        if chunk.symbol and not any(
+            start <= chunk.start_line <= chunk.end_line <= end
+            for start, end in symbol_ranges.get(chunk.symbol, [])
+        ):
+            raise ValueError("parser emitted a chunk outside its declared symbol range")
+        source_region = "".join(source_lines[chunk.start_line - 1 : chunk.end_line])
+        if chunk.content not in source_region:
+            raise ValueError("parser emitted chunk content not present in its source range")
+        chunks.append(chunk)
+    chunks = sorted(
+        set(chunks),
+        key=lambda item: (
+            item.start_line,
+            item.end_line,
+            item.symbol,
+            item.content,
+        ),
+    )
+    if len(chunks) > limits.max_chunks_per_file:
+        raise ValueError("parser emitted more chunks than the per-file safety limit")
+    active: list[Chunk] = []
+    for chunk in sorted(chunks, key=lambda item: (item.start_line, -item.end_line)):
+        while active and chunk.start_line > active[-1].end_line:
+            active.pop()
+        if active and chunk.end_line > active[-1].end_line:
+            parent = active[-1]
+            nested_symbols = bool(parent.symbol and chunk.symbol) and any(
+                (first_start <= second_start and second_end <= first_end)
+                or (second_start <= first_start and first_end <= second_end)
+                for first_start, first_end in symbol_ranges.get(parent.symbol, [])
+                for second_start, second_end in symbol_ranges.get(chunk.symbol, [])
+            )
+            if not nested_symbols:
+                raise ValueError("parser emitted partially overlapping chunk ranges")
+        active.append(chunk)
+
+    normalized = ParseResult(
+        symbols=tuple(symbols),
+        dependencies=tuple(dependencies),
+        chunks=tuple(chunks),
+        is_entry_point=parsed.is_entry_point,
+    )
+    return normalized, FactCounts(
+        chunks=len(chunks),
+        symbols=len(symbols),
+        dependencies=len(dependencies),
+    )

--- a/src/repolocus/security/__init__.py
+++ b/src/repolocus/security/__init__.py
@@ -1,5 +1,6 @@
 """Security and privacy boundaries used across RepoLocus."""
 
+from .atomic_write import AtomicWriteError, atomic_write_within_root
 from .display import escape_untrusted_display, has_unsafe_display_controls
 from .network import is_loopback_url
 from .paths import PathSecurityError, ensure_within_root, is_within_root, resolve_within_root
@@ -23,12 +24,14 @@ from .redaction import (
 from .secrets import SecretMatch, contains_high_confidence_secret, find_likely_secrets
 
 __all__ = [
+    "AtomicWriteError",
     "CloudSendPreview",
     "ConsentRequiredError",
     "PathSecurityError",
     "PrivacyStore",
     "PrivacyStoreError",
     "SecretMatch",
+    "atomic_write_within_root",
     "build_cloud_send_preview",
     "canonical_endpoint",
     "contains_high_confidence_secret",

--- a/src/repolocus/security/__init__.py
+++ b/src/repolocus/security/__init__.py
@@ -1,6 +1,6 @@
 """Security and privacy boundaries used across RepoLocus."""
 
-from .atomic_write import AtomicWriteError, atomic_write_within_root
+from .atomic_write import AtomicWriteError, AtomicWriteResult, atomic_write_within_root
 from .display import escape_untrusted_display, has_unsafe_display_controls
 from .network import is_loopback_url
 from .paths import PathSecurityError, ensure_within_root, is_within_root, resolve_within_root
@@ -25,6 +25,7 @@ from .secrets import SecretMatch, contains_high_confidence_secret, find_likely_s
 
 __all__ = [
     "AtomicWriteError",
+    "AtomicWriteResult",
     "CloudSendPreview",
     "ConsentRequiredError",
     "PathSecurityError",

--- a/src/repolocus/security/atomic_write.py
+++ b/src/repolocus/security/atomic_write.py
@@ -1,0 +1,952 @@
+"""Descriptor-bound atomic writes for generated repository documents."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+import sys
+from contextlib import suppress
+from pathlib import Path, PurePosixPath
+
+_REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+_MARKER_READ_LIMIT = 4096
+
+
+class AtomicWriteError(ValueError):
+    """Raised when a repository output cannot be written without escaping its root."""
+
+
+def _checkpoint(stage: str, root: Path, relative_path: PurePosixPath) -> None:
+    """Race-test seam; production calls intentionally do nothing."""
+
+    del stage, root, relative_path
+
+
+def _is_reparse_point(metadata: os.stat_result) -> bool:
+    return bool(getattr(metadata, "st_file_attributes", 0) & _REPARSE_POINT)
+
+
+def _same_identity(first: os.stat_result, second: os.stat_result) -> bool:
+    return (first.st_dev, first.st_ino) == (second.st_dev, second.st_ino)
+
+
+def _same_file_state(first: os.stat_result, second: os.stat_result) -> bool:
+    return (
+        _same_identity(first, second)
+        and first.st_size == second.st_size
+        and first.st_mtime_ns == second.st_mtime_ns
+        and first.st_ctime_ns == second.st_ctime_ns
+        and stat.S_IFMT(first.st_mode) == stat.S_IFMT(second.st_mode)
+    )
+
+
+def _same_published_file(first: os.stat_result, second: os.stat_result) -> bool:
+    """Compare an inode across link/rename operations that may update ctime."""
+
+    return (
+        _same_identity(first, second)
+        and first.st_size == second.st_size
+        and first.st_mtime_ns == second.st_mtime_ns
+        and stat.S_IFMT(first.st_mode) == stat.S_IFMT(second.st_mode)
+    )
+
+
+def _validated_relative_path(relative_path: PurePosixPath) -> PurePosixPath:
+    if not isinstance(relative_path, PurePosixPath):
+        raise TypeError("relative_path must be a PurePosixPath")
+    rendered = str(relative_path)
+    if (
+        not rendered
+        or rendered == "."
+        or "\\" in rendered
+        or "\x00" in rendered
+        or relative_path.is_absolute()
+        or any(part in {"", ".", ".."} for part in relative_path.parts)
+    ):
+        raise AtomicWriteError("output path must be normalized repository-relative POSIX text")
+    return relative_path
+
+
+def _write_all(descriptor: int, content: bytes) -> None:
+    view = memoryview(content)
+    offset = 0
+    while offset < len(view):
+        written = os.write(descriptor, view[offset:])
+        if written <= 0:
+            raise OSError("short write while creating generated output")
+        offset += written
+
+
+def _generated_marker(payload: bytes) -> bool:
+    from repolocus.scanner.filters import is_generated_document
+
+    return is_generated_document(payload.decode("utf-8", errors="replace"))
+
+
+def _target_state_at(parent_fd: int, name: str) -> os.stat_result | None:
+    try:
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise AtomicWriteError(f"cannot inspect generated output target: {name}") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or _is_reparse_point(metadata)
+    ):
+        raise AtomicWriteError(f"refusing to replace non-regular output: {name}")
+    return metadata
+
+
+def _raw_state_at(parent_fd: int, name: str) -> os.stat_result | None:
+    try:
+        return os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+
+
+def _rename_exchange_at(parent_fd: int, first: str, second: str) -> None:
+    """Atomically exchange two names without discarding either object."""
+
+    import ctypes
+
+    library = ctypes.CDLL(None, use_errno=True)
+    first_bytes = os.fsencode(first)
+    second_bytes = os.fsencode(second)
+    if sys.platform.startswith("linux"):
+        rename = getattr(library, "renameat2", None)
+        flag = 0x2  # RENAME_EXCHANGE
+    elif sys.platform == "darwin":
+        rename = getattr(library, "renameatx_np", None)
+        flag = 0x00000002  # RENAME_SWAP
+    else:
+        rename = None
+        flag = 0
+    if rename is None:
+        raise AtomicWriteError(
+            "atomic generated-output replacement is unavailable on this platform"
+        )
+    rename.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    rename.restype = ctypes.c_int
+    if rename(parent_fd, first_bytes, parent_fd, second_bytes, flag) != 0:
+        error = ctypes.get_errno()
+        raise AtomicWriteError(
+            "the filesystem does not support atomic generated-output replacement"
+        ) from OSError(error, os.strerror(error))
+
+
+def _cleanup_owned_temporary_at(
+    parent_fd: int,
+    temporary_name: str,
+    temporary_fd: int,
+    *,
+    required: bool,
+) -> bool:
+    """Unlink *temporary_name* only while it still names our open inode."""
+
+    try:
+        expected = os.fstat(temporary_fd)
+        current = _raw_state_at(parent_fd, temporary_name)
+    except OSError as exc:
+        if required:
+            raise AtomicWriteError(
+                f"generated output cleanup could not be verified; preserved: {temporary_name}"
+            ) from exc
+        return False
+    if current is None:
+        return True
+    if not _same_identity(expected, current):
+        if required:
+            raise AtomicWriteError(
+                f"generated output cleanup raced; preserved unverified object: {temporary_name}"
+            )
+        return False
+    try:
+        os.unlink(temporary_name, dir_fd=parent_fd)
+    except OSError as exc:
+        if required:
+            raise AtomicWriteError(
+                f"generated output cleanup failed; preserved: {temporary_name}"
+            ) from exc
+        return False
+    return True
+
+
+def _cleanup_displaced_at(
+    parent_fd: int,
+    temporary_name: str,
+    expected: os.stat_result,
+) -> None:
+    """Remove a verified displaced target, preserving any later competitor."""
+
+    current = _raw_state_at(parent_fd, temporary_name)
+    if current is None:
+        return
+    if not _same_published_file(expected, current):
+        raise AtomicWriteError(
+            f"generated output cleanup raced; preserved unverified object: {temporary_name}"
+        )
+    try:
+        os.unlink(temporary_name, dir_fd=parent_fd)
+    except OSError as exc:
+        raise AtomicWriteError(
+            f"generated output cleanup failed; preserved: {temporary_name}"
+        ) from exc
+
+
+def _commit_new_at(
+    parent_fd: int,
+    temporary_name: str,
+    name: str,
+    expected_temporary: os.stat_result,
+) -> None:
+    """Publish a new output with create-if-absent semantics."""
+
+    try:
+        os.link(
+            temporary_name,
+            name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+    except OSError as exc:
+        raise AtomicWriteError("generated output appeared before it could be created") from exc
+    installed = _raw_state_at(parent_fd, name)
+    if (
+        installed is not None
+        and stat.S_ISREG(installed.st_mode)
+        and _same_published_file(expected_temporary, installed)
+    ):
+        return
+    raise AtomicWriteError(
+        f"generated output temporary changed during publication; preserved target: {name}"
+    )
+
+
+def _commit_exchange_at(
+    parent_fd: int,
+    temporary_name: str,
+    name: str,
+    expected_temporary: os.stat_result,
+    expected_target: os.stat_result,
+) -> None:
+    """Publish over one exact target, preserving it until CAS validation succeeds."""
+
+    _rename_exchange_at(parent_fd, temporary_name, name)
+    try:
+        installed = _raw_state_at(parent_fd, name)
+        displaced = _raw_state_at(parent_fd, temporary_name)
+    except OSError as exc:
+        raise AtomicWriteError(
+            "generated-output replacement could not be verified; preserved target and "
+            f"backup names: {name}, {temporary_name}"
+        ) from exc
+    installed_matches = (
+        installed is not None
+        and stat.S_ISREG(installed.st_mode)
+        and _same_published_file(expected_temporary, installed)
+    )
+    displaced_matches = (
+        displaced is not None
+        and stat.S_ISREG(displaced.st_mode)
+        and _same_published_file(expected_target, displaced)
+    )
+    if installed_matches and displaced_matches:
+        return
+    raise AtomicWriteError(
+        "generated output or target changed during atomic replacement; "
+        f"preserved recoverable names: {name}, {temporary_name}"
+    )
+
+
+def _validate_generated_at(parent_fd: int, name: str, expected: os.stat_result) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_BINARY", 0)
+    try:
+        descriptor = os.open(name, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise AtomicWriteError(f"generated output changed while it was inspected: {name}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or not _same_file_state(expected, opened):
+            raise AtomicWriteError(f"generated output changed while it was inspected: {name}")
+        payload = os.read(descriptor, _MARKER_READ_LIMIT)
+        finished = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    current = _target_state_at(parent_fd, name)
+    if (
+        current is None
+        or not _same_file_state(opened, finished)
+        or not _same_file_state(finished, current)
+    ):
+        raise AtomicWriteError(f"generated output changed while it was inspected: {name}")
+    if not _generated_marker(payload):
+        raise AtomicWriteError(
+            f"output already exists and is not recognized as generated: {name}; "
+            "pass --force to replace it"
+        )
+
+
+def _open_directory_at(parent_fd: int, name: str, *, create: bool) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        return os.open(name, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        if not create:
+            raise
+        with suppress(FileExistsError):
+            os.mkdir(name, 0o755, dir_fd=parent_fd)
+        return os.open(name, flags, dir_fd=parent_fd)
+
+
+def _attest_posix_chain(
+    root: Path,
+    parent_parts: tuple[str, ...],
+    expected_root: os.stat_result,
+    expected_parent: os.stat_result,
+) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptors: list[int] = []
+    try:
+        descriptor = os.open(root, flags)
+        descriptors.append(descriptor)
+        opened_root = os.fstat(descriptor)
+        if not _same_identity(expected_root, opened_root):
+            raise AtomicWriteError("repository root changed during generated output write")
+        for part in parent_parts:
+            descriptor = os.open(part, flags, dir_fd=descriptor)
+            descriptors.append(descriptor)
+        if not _same_identity(expected_parent, os.fstat(descriptor)):
+            raise AtomicWriteError("output parent changed during generated output write")
+    except AtomicWriteError:
+        raise
+    except OSError as exc:
+        raise AtomicWriteError(
+            "output directory tree changed during generated output write"
+        ) from exc
+    finally:
+        for descriptor in reversed(descriptors):
+            with suppress(OSError):
+                os.close(descriptor)
+
+
+def _atomic_write_posix(
+    root: Path,
+    relative_path: PurePosixPath,
+    content: bytes,
+    *,
+    replace_generated_only: bool,
+) -> None:
+    root_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    root_flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptors: list[int] = []
+    temporary_name: str | None = None
+    temporary_fd: int | None = None
+    parent_fd: int | None = None
+    try:
+        supplied_root = root.lstat()
+        if (
+            not stat.S_ISDIR(supplied_root.st_mode)
+            or stat.S_ISLNK(supplied_root.st_mode)
+            or _is_reparse_point(supplied_root)
+        ):
+            raise AtomicWriteError("repository root must be a real directory")
+        root_fd = os.open(root, root_flags)
+        descriptors.append(root_fd)
+        opened_root = os.fstat(root_fd)
+        if not _same_identity(supplied_root, opened_root):
+            raise AtomicWriteError("repository root changed while it was opened")
+        parent_fd = root_fd
+        for part in relative_path.parts[:-1]:
+            parent_fd = _open_directory_at(parent_fd, part, create=True)
+            descriptors.append(parent_fd)
+            metadata = os.fstat(parent_fd)
+            if not stat.S_ISDIR(metadata.st_mode) or _is_reparse_point(metadata):
+                raise AtomicWriteError("output parent is not a safe directory")
+        parent_state = os.fstat(parent_fd)
+        name = relative_path.name
+        initial_target = _target_state_at(parent_fd, name)
+        if initial_target is not None and replace_generated_only:
+            _validate_generated_at(parent_fd, name, initial_target)
+
+        for _attempt in range(128):
+            candidate = f".{name}.{secrets.token_hex(12)}.tmp"
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            flags |= getattr(os, "O_BINARY", 0)
+            try:
+                temporary_fd = os.open(candidate, flags, 0o600, dir_fd=parent_fd)
+            except FileExistsError:
+                continue
+            temporary_name = candidate
+            break
+        else:  # pragma: no cover - cryptographically improbable collision exhaustion
+            raise AtomicWriteError("could not allocate a temporary generated output")
+        _write_all(temporary_fd, content)
+        os.fsync(temporary_fd)
+        temporary_state = os.fstat(temporary_fd)
+
+        _checkpoint("temporary-synced", root, relative_path)
+        _attest_posix_chain(
+            root,
+            tuple(relative_path.parts[:-1]),
+            opened_root,
+            parent_state,
+        )
+        current_target = _target_state_at(parent_fd, name)
+        if (initial_target is None) != (current_target is None) or (
+            initial_target is not None
+            and current_target is not None
+            and not _same_file_state(initial_target, current_target)
+        ):
+            raise AtomicWriteError("generated output target changed before replacement")
+        if current_target is not None and replace_generated_only:
+            _validate_generated_at(parent_fd, name, current_target)
+        _checkpoint("target-validated", root, relative_path)
+        _attest_posix_chain(
+            root,
+            tuple(relative_path.parts[:-1]),
+            opened_root,
+            parent_state,
+        )
+        final_target = _target_state_at(parent_fd, name)
+        if (current_target is None) != (final_target is None) or (
+            current_target is not None
+            and final_target is not None
+            and not _same_file_state(current_target, final_target)
+        ):
+            raise AtomicWriteError("generated output target changed before replacement")
+        temporary_path_state = _target_state_at(parent_fd, temporary_name)
+        if temporary_path_state is None or not _same_file_state(
+            temporary_state, temporary_path_state
+        ):
+            raise AtomicWriteError("generated output temporary changed before replacement")
+        _checkpoint("commit-ready", root, relative_path)
+        if final_target is None:
+            _commit_new_at(parent_fd, temporary_name, name, temporary_state)
+            _cleanup_owned_temporary_at(
+                parent_fd,
+                temporary_name,
+                temporary_fd,
+                required=True,
+            )
+        else:
+            _commit_exchange_at(
+                parent_fd,
+                temporary_name,
+                name,
+                temporary_state,
+                final_target,
+            )
+            _cleanup_displaced_at(parent_fd, temporary_name, final_target)
+        temporary_name = None
+        os.fsync(parent_fd)
+        _attest_posix_chain(
+            root,
+            tuple(relative_path.parts[:-1]),
+            opened_root,
+            parent_state,
+        )
+    except AtomicWriteError:
+        raise
+    except (OSError, ValueError) as exc:
+        raise AtomicWriteError(
+            f"cannot safely write generated output {relative_path}: {exc}"
+        ) from exc
+    finally:
+        if temporary_name is not None and parent_fd is not None and temporary_fd is not None:
+            _cleanup_owned_temporary_at(
+                parent_fd,
+                temporary_name,
+                temporary_fd,
+                required=False,
+            )
+        if temporary_fd is not None:
+            with suppress(OSError):
+                os.close(temporary_fd)
+        for descriptor in reversed(descriptors):
+            with suppress(OSError):
+                os.close(descriptor)
+
+
+def _safe_fallback_state(path: Path, *, directory: bool) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise AtomicWriteError(f"cannot inspect output path: {path}") from exc
+    expected = stat.S_ISDIR(metadata.st_mode) if directory else stat.S_ISREG(metadata.st_mode)
+    if not expected or stat.S_ISLNK(metadata.st_mode) or _is_reparse_point(metadata):
+        kind = "directory" if directory else "regular file"
+        raise AtomicWriteError(f"output path is not a safe {kind}: {path}")
+    return metadata
+
+
+def _read_fallback_marker(path: Path, expected: os.stat_result) -> bytes:
+    """Read only the bounded marker prefix from the exact validated file."""
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise AtomicWriteError("cannot validate existing generated output") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _is_reparse_point(opened)
+            or not _same_file_state(expected, opened)
+        ):
+            raise AtomicWriteError("generated output changed while it was inspected")
+        payload = os.read(descriptor, _MARKER_READ_LIMIT)
+        finished = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    current = _safe_fallback_state(path, directory=False)
+    if not _same_file_state(opened, finished) or not _same_file_state(finished, current):
+        raise AtomicWriteError("generated output changed while it was inspected")
+    return payload
+
+
+def _attest_fallback_chain(  # pragma: no cover - exercised by Windows CI
+    root: Path,
+    parent_parts: tuple[str, ...],
+    expected_root: os.stat_result,
+    expected_parent: os.stat_result,
+) -> None:
+    current = _safe_fallback_state(root, directory=True)
+    if not _same_identity(current, expected_root):
+        raise AtomicWriteError("repository root changed during generated output write")
+    parent = root
+    for part in parent_parts:
+        parent /= part
+        current = _safe_fallback_state(parent, directory=True)
+    if not _same_identity(current, expected_parent):
+        raise AtomicWriteError("output parent changed during generated output write")
+
+
+def _open_fallback_temporary(  # pragma: no cover - exercised by Windows CI
+    path: Path,
+    *,
+    replace_existing: bool,
+) -> int:
+    if os.name != "nt":
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+        return os.open(path, flags, 0o600)
+
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    desired_access = 0x40000000 | 0x00010000  # GENERIC_WRITE | DELETE
+    del replace_existing
+    share_mode = 0x00000001 | 0x00000004  # FILE_SHARE_READ | FILE_SHARE_DELETE
+    handle = create_file(
+        str(path),
+        desired_access,
+        share_mode,
+        None,
+        1,  # CREATE_NEW
+        0x00000100,  # FILE_ATTRIBUTE_TEMPORARY
+        None,
+    )
+    if handle == wintypes.HANDLE(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        return msvcrt.open_osfhandle(handle, os.O_WRONLY | getattr(os, "O_BINARY", 0))
+    except BaseException:
+        kernel32.CloseHandle(handle)
+        raise
+
+
+def _replace_file_windows(  # pragma: no cover - exercised by Windows CI
+    destination: Path,
+    replacement: Path,
+    backup: Path,
+) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    replace_file = kernel32.ReplaceFileW
+    replace_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.LPCWSTR,
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    ]
+    replace_file.restype = wintypes.BOOL
+    if not replace_file(str(destination), str(replacement), str(backup), 0, None, None):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _move_file_windows(  # pragma: no cover - exercised by Windows CI
+    source: Path,
+    destination: Path,
+) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    move_file = kernel32.MoveFileExW
+    move_file.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
+    move_file.restype = wintypes.BOOL
+    if not move_file(str(source), str(destination), 0x00000008):  # MOVEFILE_WRITE_THROUGH
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _cleanup_owned_fallback_temporary(  # pragma: no cover - exercised by Windows CI
+    temporary: Path,
+    descriptor: int,
+    *,
+    required: bool,
+) -> bool:
+    """Remove a fallback temporary only while its open handle proves ownership."""
+
+    try:
+        expected = os.fstat(descriptor)
+        current = temporary.lstat()
+    except FileNotFoundError:
+        return True
+    except OSError as exc:
+        if required:
+            raise AtomicWriteError(
+                f"generated output cleanup could not be verified; preserved: {temporary}"
+            ) from exc
+        return False
+    if not _same_identity(expected, current):
+        if required:
+            raise AtomicWriteError(
+                f"generated output cleanup raced; preserved unverified object: {temporary}"
+            )
+        return False
+    try:
+        temporary.unlink()
+    except OSError as exc:
+        if required:
+            raise AtomicWriteError(
+                f"generated output cleanup failed; preserved: {temporary}"
+            ) from exc
+        return False
+    return True
+
+
+def _cleanup_displaced_fallback(  # pragma: no cover - exercised by Windows CI
+    path: Path,
+    expected: os.stat_result,
+) -> None:
+    """Remove only the exact displaced object verified after publication."""
+
+    try:
+        current = path.lstat()
+    except FileNotFoundError:
+        return
+    if not _same_published_file(expected, current):
+        raise AtomicWriteError(
+            f"generated output cleanup raced; preserved unverified object: {path}"
+        )
+    try:
+        path.unlink()
+    except OSError as exc:
+        raise AtomicWriteError(f"generated output cleanup failed; preserved: {path}") from exc
+
+
+def _windows_commit_new(  # pragma: no cover - exercised by Windows CI
+    temporary: Path,
+    destination: Path,
+    expected_temporary: os.stat_result,
+) -> None:
+    """Publish one pinned Windows temporary without replacing an existing name."""
+
+    try:
+        _move_file_windows(temporary, destination)
+    except OSError as exc:
+        raise AtomicWriteError("generated output appeared before it could be created") from exc
+    try:
+        installed = destination.lstat()
+    except OSError:
+        installed = None
+    installed_matches = (
+        installed is not None
+        and stat.S_ISREG(installed.st_mode)
+        and not _is_reparse_point(installed)
+        and _same_published_file(expected_temporary, installed)
+    )
+    if installed_matches:
+        return
+    raise AtomicWriteError(
+        f"generated output temporary changed during publication; preserved: {destination}"
+    )
+
+
+def _windows_commit_exchange(  # pragma: no cover - exercised by Windows CI
+    destination: Path,
+    temporary: Path,
+    expected_temporary: os.stat_result,
+    expected_target: os.stat_result,
+) -> None:
+    """Use ReplaceFileW's backup as a recoverable compare-and-swap witness."""
+
+    backup = destination.parent / f".{destination.name}.{secrets.token_hex(12)}.rollback"
+    try:
+        _replace_file_windows(destination, temporary, backup)
+        try:
+            installed = destination.lstat()
+        except OSError:
+            installed = None
+        try:
+            displaced = backup.lstat()
+        except OSError:
+            displaced = None
+        installed_matches = (
+            installed is not None
+            and stat.S_ISREG(installed.st_mode)
+            and not _is_reparse_point(installed)
+            and _same_published_file(expected_temporary, installed)
+        )
+        displaced_matches = (
+            displaced is not None
+            and stat.S_ISREG(displaced.st_mode)
+            and not _is_reparse_point(displaced)
+            and _same_published_file(expected_target, displaced)
+        )
+        if installed_matches and displaced_matches:
+            _cleanup_displaced_fallback(backup, expected_target)
+            return
+        raise AtomicWriteError(
+            "generated output or target changed during atomic replacement; "
+            f"preserved recoverable names: {destination}, {backup}"
+        )
+    except AtomicWriteError:
+        raise
+    except OSError as exc:
+        raise AtomicWriteError("Windows could not atomically replace the generated output") from exc
+
+
+def _fallback_commit_new(  # pragma: no cover - exercised by Windows CI
+    temporary: Path,
+    destination: Path,
+    expected_temporary: os.stat_result,
+) -> None:
+    try:
+        os.link(temporary, destination, follow_symlinks=False)
+    except OSError as exc:
+        raise AtomicWriteError("generated output appeared before it could be created") from exc
+    installed = destination.lstat()
+    if stat.S_ISREG(installed.st_mode) and _same_published_file(expected_temporary, installed):
+        return
+    raise AtomicWriteError(
+        f"generated output temporary changed during publication; preserved: {destination}"
+    )
+
+
+def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
+    root: Path,
+    relative_path: PurePosixPath,
+    content: bytes,
+    *,
+    replace_generated_only: bool,
+) -> None:
+    """Handle-validated Windows fallback; every component rejects reparse points."""
+
+    root_state = _safe_fallback_state(root, directory=True)
+    parent = root
+    for part in relative_path.parts[:-1]:
+        parent /= part
+        with suppress(FileExistsError):
+            parent.mkdir(mode=0o755)
+        _safe_fallback_state(parent, directory=True)
+    parent_state = _safe_fallback_state(parent, directory=True)
+    destination = parent / relative_path.name
+    try:
+        initial_target = destination.lstat()
+    except FileNotFoundError:
+        initial_target = None
+    if initial_target is not None:
+        initial_target = _safe_fallback_state(destination, directory=False)
+        if replace_generated_only:
+            payload = _read_fallback_marker(destination, initial_target)
+            if not _generated_marker(payload):
+                raise AtomicWriteError(
+                    f"output already exists and is not recognized as generated: {destination}; "
+                    "pass --force to replace it"
+                )
+    temporary: Path | None = None
+    descriptor: int | None = None
+    try:
+        for _attempt in range(128):
+            temporary = parent / f".{destination.name}.{secrets.token_hex(12)}.tmp"
+            try:
+                descriptor = _open_fallback_temporary(
+                    temporary,
+                    replace_existing=initial_target is not None,
+                )
+            except FileExistsError:
+                continue
+            break
+        else:  # pragma: no cover - cryptographically improbable collision exhaustion
+            raise AtomicWriteError("could not allocate a temporary generated output")
+        _write_all(descriptor, content)
+        os.fsync(descriptor)
+        temporary_state = os.fstat(descriptor)
+        _checkpoint("temporary-synced", root, relative_path)
+        _attest_fallback_chain(
+            root,
+            tuple(relative_path.parts[:-1]),
+            root_state,
+            parent_state,
+        )
+        try:
+            current_target = destination.lstat()
+        except FileNotFoundError:
+            current_target = None
+        if current_target is not None:
+            current_target = _safe_fallback_state(destination, directory=False)
+        if (initial_target is None) != (current_target is None) or (
+            initial_target is not None
+            and current_target is not None
+            and not _same_file_state(initial_target, current_target)
+        ):
+            raise AtomicWriteError("generated output target changed before replacement")
+        _checkpoint("target-validated", root, relative_path)
+        _attest_fallback_chain(
+            root,
+            tuple(relative_path.parts[:-1]),
+            root_state,
+            parent_state,
+        )
+        try:
+            final_target = destination.lstat()
+        except FileNotFoundError:
+            final_target = None
+        if final_target is not None:
+            final_target = _safe_fallback_state(destination, directory=False)
+        if (current_target is None) != (final_target is None) or (
+            current_target is not None
+            and final_target is not None
+            and not _same_file_state(current_target, final_target)
+        ):
+            raise AtomicWriteError("generated output target changed before replacement")
+        temporary_path_state = _safe_fallback_state(temporary, directory=False)
+        if not _same_file_state(temporary_state, temporary_path_state):
+            raise AtomicWriteError("generated output temporary changed before replacement")
+        _checkpoint("commit-ready", root, relative_path)
+        if final_target is None:
+            if os.name == "nt":
+                _windows_commit_new(temporary, destination, temporary_state)
+            else:
+                _fallback_commit_new(temporary, destination, temporary_state)
+                _cleanup_owned_fallback_temporary(
+                    temporary,
+                    descriptor,
+                    required=True,
+                )
+        elif os.name == "nt":
+            _windows_commit_exchange(
+                destination,
+                temporary,
+                temporary_state,
+                final_target,
+            )
+        else:
+            raise AtomicWriteError(
+                "atomic generated-output replacement is unavailable on this platform"
+            )
+        temporary = None
+        _attest_fallback_chain(
+            root,
+            tuple(relative_path.parts[:-1]),
+            root_state,
+            parent_state,
+        )
+    except AtomicWriteError:
+        raise
+    except OSError as exc:
+        raise AtomicWriteError(
+            f"cannot safely write generated output {relative_path}: {exc}"
+        ) from exc
+    finally:
+        if temporary is not None and descriptor is not None:
+            _cleanup_owned_fallback_temporary(
+                temporary,
+                descriptor,
+                required=False,
+            )
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+
+
+def atomic_write_within_root(
+    root: Path,
+    relative_path: PurePosixPath,
+    content: bytes,
+    *,
+    replace_generated_only: bool,
+) -> None:
+    """Atomically write bytes below a pinned repository root.
+
+    POSIX uses descriptor-relative traversal and replacement. Windows and other
+    platforms without the required ``dir_fd`` operations use a conservative
+    component-by-component identity/reparse validation path.
+    """
+
+    if not isinstance(root, Path):
+        raise TypeError("root must be a Path")
+    relative = _validated_relative_path(relative_path)
+    if not isinstance(content, bytes):
+        raise TypeError("content must be bytes")
+    if not isinstance(replace_generated_only, bool):
+        raise TypeError("replace_generated_only must be true or false")
+    root_path = root.expanduser().absolute()
+    supports_descriptor_write = (
+        os.name != "nt"
+        and bool(getattr(os, "O_NOFOLLOW", 0))
+        and os.open in os.supports_dir_fd
+        and os.mkdir in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.link in os.supports_dir_fd
+        and os.link in os.supports_follow_symlinks
+        and os.unlink in os.supports_dir_fd
+    )
+    if supports_descriptor_write:
+        _atomic_write_posix(
+            root_path,
+            relative,
+            content,
+            replace_generated_only=replace_generated_only,
+        )
+    else:  # pragma: no cover - exercised by Windows CI
+        _atomic_write_fallback(
+            root_path,
+            relative,
+            content,
+            replace_generated_only=replace_generated_only,
+        )

--- a/src/repolocus/security/atomic_write.py
+++ b/src/repolocus/security/atomic_write.py
@@ -2,19 +2,52 @@
 
 from __future__ import annotations
 
+import errno
+import hashlib
 import os
 import secrets
 import stat
 import sys
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+
+from repolocus.security.display import has_unsafe_display_controls
 
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 _MARKER_READ_LIMIT = 4096
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
+    | {f"COM{number}" for number in range(1, 10)}
+    | {f"LPT{number}" for number in range(1, 10)}
+    | {f"COM{number}" for number in "¹²³"}
+    | {f"LPT{number}" for number in "¹²³"}
+)
 
 
 class AtomicWriteError(ValueError):
     """Raised when a repository output cannot be written without escaping its root."""
+
+
+@dataclass(frozen=True, slots=True)
+class AtomicWriteResult:
+    """Outcome of an atomic write, including any intentionally retained recovery file."""
+
+    recovery_path: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _WindowsFileState:
+    """Stable state read through a Windows file handle, not CRT stat variants."""
+
+    volume_serial: int
+    file_id: bytes
+    size: int
+    last_write: int
+    type_attributes: int
+
+
+_FallbackState = os.stat_result | _WindowsFileState
 
 
 def _checkpoint(stage: str, root: Path, relative_path: PurePosixPath) -> None:
@@ -56,13 +89,22 @@ def _validated_relative_path(relative_path: PurePosixPath) -> PurePosixPath:
     if not isinstance(relative_path, PurePosixPath):
         raise TypeError("relative_path must be a PurePosixPath")
     rendered = str(relative_path)
+    unsafe_windows_component = any(
+        part.endswith((" ", "."))
+        or part.split(".", 1)[0].rstrip(" ").upper() in _WINDOWS_RESERVED_NAMES
+        for part in relative_path.parts
+    )
     if (
         not rendered
         or rendered == "."
         or "\\" in rendered
+        or ":" in rendered
         or "\x00" in rendered
+        or any(character in '<>"|?*' for character in rendered)
+        or has_unsafe_display_controls(rendered)
         or relative_path.is_absolute()
         or any(part in {"", ".", ".."} for part in relative_path.parts)
+        or unsafe_windows_component
     ):
         raise AtomicWriteError("output path must be normalized repository-relative POSIX text")
     return relative_path
@@ -143,63 +185,42 @@ def _rename_exchange_at(parent_fd: int, first: str, second: str) -> None:
         ) from OSError(error, os.strerror(error))
 
 
-def _cleanup_owned_temporary_at(
-    parent_fd: int,
-    temporary_name: str,
-    temporary_fd: int,
-    *,
-    required: bool,
-) -> bool:
-    """Unlink *temporary_name* only while it still names our open inode."""
+def _rename_noreplace_at(parent_fd: int, source: str, destination: str) -> None:
+    """Atomically consume *source* only when *destination* is absent."""
 
-    try:
-        expected = os.fstat(temporary_fd)
-        current = _raw_state_at(parent_fd, temporary_name)
-    except OSError as exc:
-        if required:
-            raise AtomicWriteError(
-                f"generated output cleanup could not be verified; preserved: {temporary_name}"
-            ) from exc
-        return False
-    if current is None:
-        return True
-    if not _same_identity(expected, current):
-        if required:
-            raise AtomicWriteError(
-                f"generated output cleanup raced; preserved unverified object: {temporary_name}"
-            )
-        return False
-    try:
-        os.unlink(temporary_name, dir_fd=parent_fd)
-    except OSError as exc:
-        if required:
-            raise AtomicWriteError(
-                f"generated output cleanup failed; preserved: {temporary_name}"
-            ) from exc
-        return False
-    return True
+    import ctypes
 
-
-def _cleanup_displaced_at(
-    parent_fd: int,
-    temporary_name: str,
-    expected: os.stat_result,
-) -> None:
-    """Remove a verified displaced target, preserving any later competitor."""
-
-    current = _raw_state_at(parent_fd, temporary_name)
-    if current is None:
-        return
-    if not _same_published_file(expected, current):
+    library = ctypes.CDLL(None, use_errno=True)
+    source_bytes = os.fsencode(source)
+    destination_bytes = os.fsencode(destination)
+    if sys.platform.startswith("linux"):
+        rename = getattr(library, "renameat2", None)
+        flag = 0x1  # RENAME_NOREPLACE
+    elif sys.platform == "darwin":
+        rename = getattr(library, "renameatx_np", None)
+        flag = 0x00000004  # RENAME_EXCL
+    else:
+        rename = None
+        flag = 0
+    if rename is None:
         raise AtomicWriteError(
-            f"generated output cleanup raced; preserved unverified object: {temporary_name}"
+            "atomic create-if-absent generated-output publication is unavailable"
         )
-    try:
-        os.unlink(temporary_name, dir_fd=parent_fd)
-    except OSError as exc:
-        raise AtomicWriteError(
-            f"generated output cleanup failed; preserved: {temporary_name}"
-        ) from exc
+    rename.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    rename.restype = ctypes.c_int
+    if rename(parent_fd, source_bytes, parent_fd, destination_bytes, flag) != 0:
+        error = ctypes.get_errno()
+        if error == errno.EEXIST:
+            message = "generated output appeared before it could be created"
+        else:
+            message = "the filesystem does not support safe create-if-absent publication"
+        raise AtomicWriteError(message) from OSError(error, os.strerror(error))
 
 
 def _commit_new_at(
@@ -210,16 +231,7 @@ def _commit_new_at(
 ) -> None:
     """Publish a new output with create-if-absent semantics."""
 
-    try:
-        os.link(
-            temporary_name,
-            name,
-            src_dir_fd=parent_fd,
-            dst_dir_fd=parent_fd,
-            follow_symlinks=False,
-        )
-    except OSError as exc:
-        raise AtomicWriteError("generated output appeared before it could be created") from exc
+    _rename_noreplace_at(parent_fd, temporary_name, name)
     installed = _raw_state_at(parent_fd, name)
     if (
         installed is not None
@@ -349,13 +361,14 @@ def _atomic_write_posix(
     content: bytes,
     *,
     replace_generated_only: bool,
-) -> None:
+) -> AtomicWriteResult:
     root_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
     root_flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptors: list[int] = []
     temporary_name: str | None = None
     temporary_fd: int | None = None
     parent_fd: int | None = None
+    recovery_path: Path | None = None
     try:
         supplied_root = root.lstat()
         if (
@@ -383,7 +396,8 @@ def _atomic_write_posix(
             _validate_generated_at(parent_fd, name, initial_target)
 
         for _attempt in range(128):
-            candidate = f".{name}.{secrets.token_hex(12)}.tmp"
+            suffix = "rollback" if initial_target is not None else "tmp"
+            candidate = f".{name}.{secrets.token_hex(12)}.{suffix}"
             flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
             flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
             flags |= getattr(os, "O_BINARY", 0)
@@ -437,12 +451,7 @@ def _atomic_write_posix(
         _checkpoint("commit-ready", root, relative_path)
         if final_target is None:
             _commit_new_at(parent_fd, temporary_name, name, temporary_state)
-            _cleanup_owned_temporary_at(
-                parent_fd,
-                temporary_name,
-                temporary_fd,
-                required=True,
-            )
+            temporary_name = None
         else:
             _commit_exchange_at(
                 parent_fd,
@@ -451,8 +460,11 @@ def _atomic_write_posix(
                 temporary_state,
                 final_target,
             )
-            _cleanup_displaced_at(parent_fd, temporary_name, final_target)
-        temporary_name = None
+            recovery_path = root.joinpath(
+                *relative_path.parts[:-1],
+                temporary_name,
+            )
+            temporary_name = None
         os.fsync(parent_fd)
         _attest_posix_chain(
             root,
@@ -460,20 +472,29 @@ def _atomic_write_posix(
             opened_root,
             parent_state,
         )
-    except AtomicWriteError:
+        return AtomicWriteResult(recovery_path=recovery_path)
+    except AtomicWriteError as exc:
+        if temporary_name is not None:
+            preserved = root.joinpath(*relative_path.parts[:-1], temporary_name)
+            raise AtomicWriteError(
+                f"{exc}; generated temporary preserved if present: {preserved}"
+            ) from exc
+        if recovery_path is not None:
+            raise AtomicWriteError(
+                f"{exc}; previous output preserved for recovery: {recovery_path}"
+            ) from exc
         raise
     except (OSError, ValueError) as exc:
+        preserved_detail = ""
+        if temporary_name is not None:
+            preserved = root.joinpath(*relative_path.parts[:-1], temporary_name)
+            preserved_detail = f"; generated temporary preserved if present: {preserved}"
+        elif recovery_path is not None:
+            preserved_detail = f"; previous output preserved for recovery: {recovery_path}"
         raise AtomicWriteError(
-            f"cannot safely write generated output {relative_path}: {exc}"
+            f"cannot safely write generated output {relative_path}: {exc}{preserved_detail}"
         ) from exc
     finally:
-        if temporary_name is not None and parent_fd is not None and temporary_fd is not None:
-            _cleanup_owned_temporary_at(
-                parent_fd,
-                temporary_name,
-                temporary_fd,
-                required=False,
-            )
         if temporary_fd is not None:
             with suppress(OSError):
                 os.close(temporary_fd)
@@ -494,7 +515,344 @@ def _safe_fallback_state(path: Path, *, directory: bool) -> os.stat_result:
     return metadata
 
 
-def _read_fallback_marker(path: Path, expected: os.stat_result) -> bytes:
+def _windows_file_state_from_handle(  # pragma: no cover - exercised by Windows CI
+    handle: int,
+) -> _WindowsFileState:
+    import ctypes
+    from ctypes import wintypes
+
+    class _FileTime(ctypes.Structure):
+        _fields_ = [
+            ("low", wintypes.DWORD),
+            ("high", wintypes.DWORD),
+        ]
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("attributes", wintypes.DWORD),
+            ("creation_time", _FileTime),
+            ("last_access_time", _FileTime),
+            ("last_write_time", _FileTime),
+            ("volume_serial", wintypes.DWORD),
+            ("size_high", wintypes.DWORD),
+            ("size_low", wintypes.DWORD),
+            ("link_count", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    class _FileId128(ctypes.Structure):
+        _fields_ = [("identifier", wintypes.BYTE * 16)]
+
+    class _FileIdInformation(ctypes.Structure):
+        _fields_ = [
+            ("volume_serial", ctypes.c_ulonglong),
+            ("file_id", _FileId128),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_information = kernel32.GetFileInformationByHandle
+    get_information.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    get_information.restype = wintypes.BOOL
+    information = _ByHandleFileInformation()
+    if not get_information(wintypes.HANDLE(handle), ctypes.byref(information)):
+        raise ctypes.WinError(ctypes.get_last_error())
+    get_information_ex = kernel32.GetFileInformationByHandleEx
+    get_information_ex.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    get_information_ex.restype = wintypes.BOOL
+    file_id = _FileIdInformation()
+    if not get_information_ex(
+        wintypes.HANDLE(handle),
+        18,  # FileIdInfo
+        ctypes.byref(file_id),
+        ctypes.sizeof(file_id),
+    ):
+        raise ctypes.WinError(ctypes.get_last_error())
+    type_mask = 0x00000010 | _REPARSE_POINT  # FILE_ATTRIBUTE_DIRECTORY | reparse
+    return _WindowsFileState(
+        volume_serial=int(file_id.volume_serial),
+        file_id=bytes(file_id.file_id.identifier),
+        size=(int(information.size_high) << 32) | int(information.size_low),
+        last_write=(int(information.last_write_time.high) << 32)
+        | int(information.last_write_time.low),
+        type_attributes=int(information.attributes) & type_mask,
+    )
+
+
+def _windows_file_state_from_descriptor(  # pragma: no cover - exercised by Windows CI
+    descriptor: int,
+) -> _WindowsFileState:
+    import msvcrt
+
+    return _windows_file_state_from_handle(msvcrt.get_osfhandle(descriptor))
+
+
+def _windows_open_path_handle(  # pragma: no cover - exercised by Windows CI
+    path: Path,
+    *,
+    desired_access: int,
+    share_mode: int,
+) -> int:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(path),
+        desired_access,
+        share_mode,
+        None,
+        3,  # OPEN_EXISTING
+        0x00200000 | 0x02000000,  # OPEN_REPARSE_POINT | BACKUP_SEMANTICS
+        None,
+    )
+    if handle == wintypes.HANDLE(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    return int(handle)
+
+
+def _windows_close_handle(  # pragma: no cover - exercised by Windows CI
+    handle: int,
+) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    if not close_handle(wintypes.HANDLE(handle)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _windows_file_state_from_path(  # pragma: no cover - exercised by Windows CI
+    path: Path,
+) -> _WindowsFileState:
+    handle = _windows_open_path_handle(
+        path,
+        desired_access=0x00000080,  # FILE_READ_ATTRIBUTES
+        share_mode=0x00000001 | 0x00000002 | 0x00000004,
+    )
+    try:
+        return _windows_file_state_from_handle(handle)
+    finally:
+        _windows_close_handle(handle)
+
+
+def _windows_digest_from_handle(  # pragma: no cover - exercised by Windows CI
+    handle: int,
+) -> bytes:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    read_file = kernel32.ReadFile
+    read_file.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.c_void_p,
+    ]
+    read_file.restype = wintypes.BOOL
+    digest = hashlib.sha256()
+    buffer = ctypes.create_string_buffer(64 * 1024)
+    while True:
+        count = wintypes.DWORD()
+        if not read_file(
+            wintypes.HANDLE(handle),
+            buffer,
+            len(buffer),
+            ctypes.byref(count),
+            None,
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        if count.value == 0:
+            return digest.digest()
+        digest.update(buffer.raw[: count.value])
+
+
+def _windows_hash_path(  # pragma: no cover - exercised by Windows CI
+    path: Path,
+    expected: _WindowsFileState,
+    *,
+    allow_last_write_settle: bool = False,
+) -> tuple[_WindowsFileState, bytes]:
+    handle = _windows_open_path_handle(
+        path,
+        desired_access=0x80000000 | 0x00000080,  # GENERIC_READ | READ_ATTRIBUTES
+        share_mode=0x00000001,  # share read only; deny writers and name deletion
+    )
+    try:
+        opened = _windows_file_state_from_handle(handle)
+        if opened.type_attributes & (0x00000010 | _REPARSE_POINT):
+            raise AtomicWriteError(f"output path is not a safe regular file: {path}")
+        matches = (
+            _same_fallback_object_after_close(expected, opened)
+            if allow_last_write_settle
+            else _same_fallback_state(expected, opened)
+        )
+        if not matches:
+            raise AtomicWriteError(f"output file changed before it could be hashed: {path}")
+        digest = _windows_digest_from_handle(handle)
+        finished = _windows_file_state_from_handle(handle)
+        if not _same_fallback_state(opened, finished):
+            raise AtomicWriteError(f"output file changed while it was hashed: {path}")
+        return finished, digest
+    finally:
+        _windows_close_handle(handle)
+
+
+def _windows_set_delete_disposition(  # pragma: no cover - exercised by Windows CI
+    handle: int,
+) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    class _FileDispositionInformation(ctypes.Structure):
+        _fields_ = [("delete_file", wintypes.BYTE)]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    set_information = kernel32.SetFileInformationByHandle
+    set_information.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    set_information.restype = wintypes.BOOL
+    disposition = _FileDispositionInformation(1)
+    if not set_information(
+        wintypes.HANDLE(handle),
+        4,  # FileDispositionInfo
+        ctypes.byref(disposition),
+        ctypes.sizeof(disposition),
+    ):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _windows_delete_verified_path(  # pragma: no cover - exercised by Windows CI
+    path: Path,
+    expected: _WindowsFileState,
+    *,
+    expected_digest: bytes,
+) -> None:
+    handle = _windows_open_path_handle(
+        path,
+        desired_access=0x80000000 | 0x00010000 | 0x00000080,
+        share_mode=0x00000001,  # deny share-write/delete until disposition is set
+    )
+    try:
+        opened = _windows_file_state_from_handle(handle)
+        if not _same_fallback_state(expected, opened):
+            raise AtomicWriteError(
+                f"generated output cleanup raced; preserved unverified object: {path}"
+            )
+        digest = _windows_digest_from_handle(handle)
+        finished = _windows_file_state_from_handle(handle)
+        if digest != expected_digest or not _same_fallback_state(opened, finished):
+            raise AtomicWriteError(
+                f"generated output cleanup raced; preserved unverified object: {path}"
+            )
+        _windows_set_delete_disposition(handle)
+    finally:
+        _windows_close_handle(handle)
+
+
+def _capture_fallback_state(path: Path, *, directory: bool) -> _FallbackState:
+    metadata = _safe_fallback_state(path, directory=directory)
+    if os.name != "nt":
+        return metadata
+    try:
+        state = _windows_file_state_from_path(path)
+    except OSError as exc:
+        raise AtomicWriteError(f"cannot inspect output path: {path}") from exc
+    is_directory = bool(state.type_attributes & 0x00000010)
+    if is_directory != directory or bool(state.type_attributes & _REPARSE_POINT):
+        kind = "directory" if directory else "regular file"
+        raise AtomicWriteError(f"output path is not a safe {kind}: {path}")
+    return state
+
+
+def _capture_fallback_descriptor_state(descriptor: int) -> _FallbackState:
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or _is_reparse_point(metadata)
+    ):
+        raise AtomicWriteError("generated output handle is not a safe regular file")
+    if os.name == "nt":
+        return _windows_file_state_from_descriptor(descriptor)
+    return metadata
+
+
+def _same_fallback_identity(first: _FallbackState, second: _FallbackState) -> bool:
+    if isinstance(first, _WindowsFileState) or isinstance(second, _WindowsFileState):
+        return (
+            isinstance(first, _WindowsFileState)
+            and isinstance(second, _WindowsFileState)
+            and first.volume_serial == second.volume_serial
+            and first.file_id == second.file_id
+        )
+    return _same_identity(first, second)
+
+
+def _same_fallback_state(
+    first: _FallbackState,
+    second: _FallbackState,
+    *,
+    published: bool = False,
+) -> bool:
+    if isinstance(first, _WindowsFileState) or isinstance(second, _WindowsFileState):
+        return (
+            isinstance(first, _WindowsFileState)
+            and isinstance(second, _WindowsFileState)
+            and first == second
+        )
+    if published:
+        return _same_published_file(first, second)
+    return _same_file_state(first, second)
+
+
+def _same_fallback_object_after_close(
+    opened: _FallbackState,
+    closed: _FallbackState,
+) -> bool:
+    """Allow only the last-write timestamp to settle when a Windows writer closes."""
+
+    if isinstance(opened, _WindowsFileState) or isinstance(closed, _WindowsFileState):
+        return (
+            isinstance(opened, _WindowsFileState)
+            and isinstance(closed, _WindowsFileState)
+            and opened.volume_serial == closed.volume_serial
+            and opened.file_id == closed.file_id
+            and opened.size == closed.size
+            and opened.type_attributes == closed.type_attributes
+        )
+    return _same_file_state(opened, closed)
+
+
+def _read_fallback_marker(path: Path, expected: _FallbackState) -> bytes:
     """Read only the bounded marker prefix from the exact validated file."""
 
     flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NONBLOCK", 0)
@@ -504,19 +862,15 @@ def _read_fallback_marker(path: Path, expected: os.stat_result) -> bytes:
     except OSError as exc:
         raise AtomicWriteError("cannot validate existing generated output") from exc
     try:
-        opened = os.fstat(descriptor)
-        if (
-            not stat.S_ISREG(opened.st_mode)
-            or _is_reparse_point(opened)
-            or not _same_file_state(expected, opened)
-        ):
+        opened = _capture_fallback_descriptor_state(descriptor)
+        if not _same_fallback_state(expected, opened):
             raise AtomicWriteError("generated output changed while it was inspected")
         payload = os.read(descriptor, _MARKER_READ_LIMIT)
-        finished = os.fstat(descriptor)
+        finished = _capture_fallback_descriptor_state(descriptor)
     finally:
         os.close(descriptor)
-    current = _safe_fallback_state(path, directory=False)
-    if not _same_file_state(opened, finished) or not _same_file_state(finished, current):
+    current = _capture_fallback_state(path, directory=False)
+    if not _same_fallback_state(opened, finished) or not _same_fallback_state(finished, current):
         raise AtomicWriteError("generated output changed while it was inspected")
     return payload
 
@@ -524,17 +878,17 @@ def _read_fallback_marker(path: Path, expected: os.stat_result) -> bytes:
 def _attest_fallback_chain(  # pragma: no cover - exercised by Windows CI
     root: Path,
     parent_parts: tuple[str, ...],
-    expected_root: os.stat_result,
-    expected_parent: os.stat_result,
+    expected_root: _FallbackState,
+    expected_parent: _FallbackState,
 ) -> None:
-    current = _safe_fallback_state(root, directory=True)
-    if not _same_identity(current, expected_root):
+    current = _capture_fallback_state(root, directory=True)
+    if not _same_fallback_identity(current, expected_root):
         raise AtomicWriteError("repository root changed during generated output write")
     parent = root
     for part in parent_parts:
         parent /= part
-        current = _safe_fallback_state(parent, directory=True)
-    if not _same_identity(current, expected_parent):
+        current = _capture_fallback_state(parent, directory=True)
+    if not _same_fallback_identity(current, expected_parent):
         raise AtomicWriteError("output parent changed during generated output write")
 
 
@@ -580,7 +934,7 @@ def _open_fallback_temporary(  # pragma: no cover - exercised by Windows CI
     try:
         return msvcrt.open_osfhandle(handle, os.O_WRONLY | getattr(os, "O_BINARY", 0))
     except BaseException:
-        kernel32.CloseHandle(handle)
+        _windows_close_handle(int(handle))
         raise
 
 
@@ -624,64 +978,89 @@ def _move_file_windows(  # pragma: no cover - exercised by Windows CI
 
 def _cleanup_owned_fallback_temporary(  # pragma: no cover - exercised by Windows CI
     temporary: Path,
-    descriptor: int,
+    descriptor: int | None,
     *,
+    expected: _FallbackState | None = None,
+    expected_digest: bytes | None = None,
     required: bool,
 ) -> bool:
-    """Remove a fallback temporary only while its open handle proves ownership."""
+    """Remove a fallback temporary only while a handle-derived identity proves ownership."""
 
     try:
-        expected = os.fstat(descriptor)
-        current = temporary.lstat()
+        if descriptor is not None:
+            expected = _capture_fallback_descriptor_state(descriptor)
+        if expected is None:
+            raise AtomicWriteError("generated output cleanup has no ownership witness")
+        if os.name == "nt":
+            import msvcrt
+
+            if not isinstance(expected, _WindowsFileState):
+                raise AtomicWriteError("Windows cleanup has no native ownership witness")
+            if descriptor is not None:
+                current = _windows_file_state_from_path(temporary)
+                if not _same_fallback_identity(expected, current):
+                    raise AtomicWriteError(
+                        f"generated output cleanup raced; preserved: {temporary}"
+                    )
+                _windows_set_delete_disposition(msvcrt.get_osfhandle(descriptor))
+            else:
+                if expected_digest is None:
+                    raise AtomicWriteError("Windows cleanup has no content witness")
+                _windows_delete_verified_path(
+                    temporary,
+                    expected,
+                    expected_digest=expected_digest,
+                )
+            return True
+        current = _capture_fallback_state(temporary, directory=False)
     except FileNotFoundError:
         return True
-    except OSError as exc:
+    except (AtomicWriteError, OSError) as exc:
         if required:
             raise AtomicWriteError(
                 f"generated output cleanup could not be verified; preserved: {temporary}"
             ) from exc
         return False
-    if not _same_identity(expected, current):
+    if not _same_fallback_identity(expected, current):
         if required:
             raise AtomicWriteError(
                 f"generated output cleanup raced; preserved unverified object: {temporary}"
             )
         return False
-    try:
-        temporary.unlink()
-    except OSError as exc:
-        if required:
-            raise AtomicWriteError(
-                f"generated output cleanup failed; preserved: {temporary}"
-            ) from exc
-        return False
-    return True
+    # POSIX has no portable unlink-by-handle primitive. Preserve the verified
+    # object instead of reopening a check-then-unlink race.
+    return False
 
 
 def _cleanup_displaced_fallback(  # pragma: no cover - exercised by Windows CI
     path: Path,
-    expected: os.stat_result,
+    expected: _FallbackState,
+    *,
+    expected_digest: bytes,
 ) -> None:
     """Remove only the exact displaced object verified after publication."""
 
+    if os.name == "nt":
+        if not isinstance(expected, _WindowsFileState):
+            raise AtomicWriteError("Windows cleanup has no native ownership witness")
+        _windows_delete_verified_path(path, expected, expected_digest=expected_digest)
+        return
     try:
-        current = path.lstat()
+        current = _capture_fallback_state(path, directory=False)
     except FileNotFoundError:
         return
-    if not _same_published_file(expected, current):
+    if not _same_fallback_state(expected, current, published=True):
         raise AtomicWriteError(
             f"generated output cleanup raced; preserved unverified object: {path}"
         )
-    try:
-        path.unlink()
-    except OSError as exc:
-        raise AtomicWriteError(f"generated output cleanup failed; preserved: {path}") from exc
+    raise AtomicWriteError(f"safe generated output cleanup is unavailable; preserved: {path}")
 
 
 def _windows_commit_new(  # pragma: no cover - exercised by Windows CI
     temporary: Path,
     destination: Path,
-    expected_temporary: os.stat_result,
+    expected_temporary: _FallbackState,
+    expected_digest: bytes,
 ) -> None:
     """Publish one pinned Windows temporary without replacing an existing name."""
 
@@ -689,17 +1068,21 @@ def _windows_commit_new(  # pragma: no cover - exercised by Windows CI
         _move_file_windows(temporary, destination)
     except OSError as exc:
         raise AtomicWriteError("generated output appeared before it could be created") from exc
+    if not isinstance(expected_temporary, _WindowsFileState):
+        raise AtomicWriteError("Windows publication has no native ownership witness")
     try:
-        installed = destination.lstat()
-    except OSError:
+        installed, installed_digest = _windows_hash_path(
+            destination,
+            expected_temporary,
+        )
+    except (AtomicWriteError, OSError):
         installed = None
-    installed_matches = (
+        installed_digest = None
+    if (
         installed is not None
-        and stat.S_ISREG(installed.st_mode)
-        and not _is_reparse_point(installed)
-        and _same_published_file(expected_temporary, installed)
-    )
-    if installed_matches:
+        and _same_fallback_state(expected_temporary, installed, published=True)
+        and installed_digest == expected_digest
+    ):
         return
     raise AtomicWriteError(
         f"generated output temporary changed during publication; preserved: {destination}"
@@ -709,36 +1092,49 @@ def _windows_commit_new(  # pragma: no cover - exercised by Windows CI
 def _windows_commit_exchange(  # pragma: no cover - exercised by Windows CI
     destination: Path,
     temporary: Path,
-    expected_temporary: os.stat_result,
-    expected_target: os.stat_result,
+    expected_temporary: _FallbackState,
+    expected_target: _FallbackState,
+    expected_temporary_digest: bytes,
+    expected_target_digest: bytes,
 ) -> None:
     """Use ReplaceFileW's backup as a recoverable compare-and-swap witness."""
 
     backup = destination.parent / f".{destination.name}.{secrets.token_hex(12)}.rollback"
+    if not isinstance(expected_temporary, _WindowsFileState) or not isinstance(
+        expected_target, _WindowsFileState
+    ):
+        raise AtomicWriteError("Windows replacement has no native ownership witness")
     try:
         _replace_file_windows(destination, temporary, backup)
         try:
-            installed = destination.lstat()
-        except OSError:
+            installed, installed_digest = _windows_hash_path(
+                destination,
+                expected_temporary,
+            )
+        except (AtomicWriteError, OSError):
             installed = None
+            installed_digest = None
         try:
-            displaced = backup.lstat()
-        except OSError:
+            displaced, displaced_digest = _windows_hash_path(backup, expected_target)
+        except (AtomicWriteError, OSError):
             displaced = None
+            displaced_digest = None
         installed_matches = (
             installed is not None
-            and stat.S_ISREG(installed.st_mode)
-            and not _is_reparse_point(installed)
-            and _same_published_file(expected_temporary, installed)
+            and _same_fallback_state(expected_temporary, installed, published=True)
+            and installed_digest == expected_temporary_digest
         )
         displaced_matches = (
             displaced is not None
-            and stat.S_ISREG(displaced.st_mode)
-            and not _is_reparse_point(displaced)
-            and _same_published_file(expected_target, displaced)
+            and _same_fallback_state(expected_target, displaced, published=True)
+            and displaced_digest == expected_target_digest
         )
         if installed_matches and displaced_matches:
-            _cleanup_displaced_fallback(backup, expected_target)
+            _cleanup_displaced_fallback(
+                backup,
+                expected_target,
+                expected_digest=expected_target_digest,
+            )
             return
         raise AtomicWriteError(
             "generated output or target changed during atomic replacement; "
@@ -750,47 +1146,32 @@ def _windows_commit_exchange(  # pragma: no cover - exercised by Windows CI
         raise AtomicWriteError("Windows could not atomically replace the generated output") from exc
 
 
-def _fallback_commit_new(  # pragma: no cover - exercised by Windows CI
-    temporary: Path,
-    destination: Path,
-    expected_temporary: os.stat_result,
-) -> None:
-    try:
-        os.link(temporary, destination, follow_symlinks=False)
-    except OSError as exc:
-        raise AtomicWriteError("generated output appeared before it could be created") from exc
-    installed = destination.lstat()
-    if stat.S_ISREG(installed.st_mode) and _same_published_file(expected_temporary, installed):
-        return
-    raise AtomicWriteError(
-        f"generated output temporary changed during publication; preserved: {destination}"
-    )
-
-
 def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
     root: Path,
     relative_path: PurePosixPath,
     content: bytes,
     *,
     replace_generated_only: bool,
-) -> None:
+) -> AtomicWriteResult:
     """Handle-validated Windows fallback; every component rejects reparse points."""
 
-    root_state = _safe_fallback_state(root, directory=True)
+    if os.name != "nt":
+        raise AtomicWriteError("Windows generated-output writer called on another platform")
+    root_state = _capture_fallback_state(root, directory=True)
     parent = root
     for part in relative_path.parts[:-1]:
         parent /= part
         with suppress(FileExistsError):
             parent.mkdir(mode=0o755)
-        _safe_fallback_state(parent, directory=True)
-    parent_state = _safe_fallback_state(parent, directory=True)
+        _capture_fallback_state(parent, directory=True)
+    parent_state = _capture_fallback_state(parent, directory=True)
     destination = parent / relative_path.name
     try:
         initial_target = destination.lstat()
     except FileNotFoundError:
         initial_target = None
     if initial_target is not None:
-        initial_target = _safe_fallback_state(destination, directory=False)
+        initial_target = _capture_fallback_state(destination, directory=False)
         if replace_generated_only:
             payload = _read_fallback_marker(destination, initial_target)
             if not _generated_marker(payload):
@@ -800,6 +1181,9 @@ def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
                 )
     temporary: Path | None = None
     descriptor: int | None = None
+    temporary_state: _FallbackState | None = None
+    target_digest: bytes | None = None
+    content_digest = hashlib.sha256(content).digest()
     try:
         for _attempt in range(128):
             temporary = parent / f".{destination.name}.{secrets.token_hex(12)}.tmp"
@@ -815,7 +1199,7 @@ def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
             raise AtomicWriteError("could not allocate a temporary generated output")
         _write_all(descriptor, content)
         os.fsync(descriptor)
-        temporary_state = os.fstat(descriptor)
+        temporary_state = _capture_fallback_descriptor_state(descriptor)
         _checkpoint("temporary-synced", root, relative_path)
         _attest_fallback_chain(
             root,
@@ -828,11 +1212,11 @@ def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
         except FileNotFoundError:
             current_target = None
         if current_target is not None:
-            current_target = _safe_fallback_state(destination, directory=False)
+            current_target = _capture_fallback_state(destination, directory=False)
         if (initial_target is None) != (current_target is None) or (
             initial_target is not None
             and current_target is not None
-            and not _same_file_state(initial_target, current_target)
+            and not _same_fallback_state(initial_target, current_target)
         ):
             raise AtomicWriteError("generated output target changed before replacement")
         _checkpoint("target-validated", root, relative_path)
@@ -847,37 +1231,63 @@ def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
         except FileNotFoundError:
             final_target = None
         if final_target is not None:
-            final_target = _safe_fallback_state(destination, directory=False)
+            final_target = _capture_fallback_state(destination, directory=False)
         if (current_target is None) != (final_target is None) or (
             current_target is not None
             and final_target is not None
-            and not _same_file_state(current_target, final_target)
+            and not _same_fallback_state(current_target, final_target)
         ):
             raise AtomicWriteError("generated output target changed before replacement")
-        temporary_path_state = _safe_fallback_state(temporary, directory=False)
-        if not _same_file_state(temporary_state, temporary_path_state):
+        temporary_path_state = _capture_fallback_state(temporary, directory=False)
+        if not _same_fallback_state(temporary_state, temporary_path_state):
             raise AtomicWriteError("generated output temporary changed before replacement")
         _checkpoint("commit-ready", root, relative_path)
-        if final_target is None:
-            if os.name == "nt":
-                _windows_commit_new(temporary, destination, temporary_state)
-            else:
-                _fallback_commit_new(temporary, destination, temporary_state)
-                _cleanup_owned_fallback_temporary(
-                    temporary,
-                    descriptor,
-                    required=True,
+        if os.name == "nt":
+            # ReplaceFileW opens its replacement with no sharing. Close our writer,
+            # then pin the exact path state used as the publication witness.
+            pre_close_state = _capture_fallback_descriptor_state(descriptor)
+            os.close(descriptor)
+            descriptor = None
+            if not isinstance(pre_close_state, _WindowsFileState):
+                raise AtomicWriteError("Windows temporary has no native ownership witness")
+            closed_path_state, closed_digest = _windows_hash_path(
+                temporary,
+                pre_close_state,
+                allow_last_write_settle=True,
+            )
+            if closed_digest != content_digest:
+                raise AtomicWriteError("generated output temporary changed before replacement")
+            temporary_state = closed_path_state
+            if final_target is not None:
+                if not isinstance(final_target, _WindowsFileState):
+                    raise AtomicWriteError("Windows target has no native ownership witness")
+                final_target, target_digest = _windows_hash_path(
+                    destination,
+                    final_target,
                 )
-        elif os.name == "nt":
+            _attest_fallback_chain(
+                root,
+                tuple(relative_path.parts[:-1]),
+                root_state,
+                parent_state,
+            )
+        if final_target is None:
+            _windows_commit_new(
+                temporary,
+                destination,
+                temporary_state,
+                content_digest,
+            )
+        else:
+            if target_digest is None:
+                raise AtomicWriteError("Windows target has no content witness")
             _windows_commit_exchange(
                 destination,
                 temporary,
                 temporary_state,
                 final_target,
-            )
-        else:
-            raise AtomicWriteError(
-                "atomic generated-output replacement is unavailable on this platform"
+                content_digest,
+                target_digest,
             )
         temporary = None
         _attest_fallback_chain(
@@ -886,6 +1296,7 @@ def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
             root_state,
             parent_state,
         )
+        return AtomicWriteResult()
     except AtomicWriteError:
         raise
     except OSError as exc:
@@ -893,10 +1304,12 @@ def _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
             f"cannot safely write generated output {relative_path}: {exc}"
         ) from exc
     finally:
-        if temporary is not None and descriptor is not None:
+        if temporary is not None and (descriptor is not None or temporary_state is not None):
             _cleanup_owned_fallback_temporary(
                 temporary,
                 descriptor,
+                expected=temporary_state,
+                expected_digest=content_digest,
                 required=False,
             )
         if descriptor is not None:
@@ -910,7 +1323,7 @@ def atomic_write_within_root(
     content: bytes,
     *,
     replace_generated_only: bool,
-) -> None:
+) -> AtomicWriteResult:
     """Atomically write bytes below a pinned repository root.
 
     POSIX uses descriptor-relative traversal and replacement. Windows and other
@@ -932,21 +1345,21 @@ def atomic_write_within_root(
         and os.open in os.supports_dir_fd
         and os.mkdir in os.supports_dir_fd
         and os.stat in os.supports_dir_fd
-        and os.link in os.supports_dir_fd
-        and os.link in os.supports_follow_symlinks
-        and os.unlink in os.supports_dir_fd
     )
     if supports_descriptor_write:
-        _atomic_write_posix(
+        return _atomic_write_posix(
             root_path,
             relative,
             content,
             replace_generated_only=replace_generated_only,
         )
-    else:  # pragma: no cover - exercised by Windows CI
-        _atomic_write_fallback(
-            root_path,
-            relative,
-            content,
-            replace_generated_only=replace_generated_only,
+    if os.name != "nt":
+        raise AtomicWriteError(
+            "descriptor-bound generated-output writes are unavailable on this platform"
         )
+    return _atomic_write_fallback(  # pragma: no cover - exercised by Windows CI
+        root_path,
+        relative,
+        content,
+        replace_generated_only=replace_generated_only,
+    )

--- a/src/repolocus/security/privacy.py
+++ b/src/repolocus/security/privacy.py
@@ -11,9 +11,10 @@ import tempfile
 import threading
 from collections.abc import Iterable, Mapping
 from contextlib import contextmanager, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -22,7 +23,8 @@ from .redaction import redact_secrets_with_count
 
 _STATE_LOCKS_GUARD = threading.Lock()
 _STATE_LOCKS: dict[str, threading.RLock] = {}
-_STATE_VERSION = 3
+_WINDOWS_OVERLAPPED: dict[int, object] = {}
+_STATE_VERSION = 4
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 
 
@@ -172,13 +174,28 @@ class PrivacyStore:
         providers = entry.get("providers", {})
         if not isinstance(providers, dict):
             raise PrivacyStoreError("privacy state contains an invalid providers table")
-        return {
-            str(provider): tuple(sorted(str(endpoint) for endpoint in endpoints))
-            for provider, endpoints in sorted(providers.items())
-            if isinstance(endpoints, dict) and endpoints
-        }
+        details: dict[str, tuple[str, ...]] = {}
+        for provider, grants in sorted(providers.items()):
+            if not isinstance(grants, dict) or not grants:
+                continue
+            endpoints = {
+                str(grant.get("endpoint"))
+                for grant in grants.values()
+                if isinstance(grant, dict) and isinstance(grant.get("endpoint"), str)
+            }
+            if endpoints:
+                details[str(provider)] = tuple(sorted(endpoints))
+        return details
 
-    def grant(self, root: Path | str, provider: str, endpoint: str | None = None) -> None:
+    def grant(
+        self,
+        root: Path | str,
+        provider: str,
+        endpoint: str | None = None,
+        *,
+        transport_identity: str | None = None,
+        transport: Mapping[str, str] | None = None,
+    ) -> None:
         """Remember consent for one provider endpoint and repository."""
 
         family = provider_family(provider)
@@ -187,6 +204,12 @@ class PrivacyStore:
         if endpoint is None:
             raise PrivacyStoreError("a canonical endpoint is required for remembered cloud consent")
         endpoint_identity = canonical_endpoint(endpoint)
+        if transport_identity is not None and transport is None:
+            raise PrivacyStoreError(
+                "transport details are required for a non-default consent route"
+            )
+        route_identity = _validated_transport_identity(transport_identity)
+        route_display = _normalized_transport_display(transport)
         root_path, identity = self._repository_context(root)
         self._ensure_outside_repository(root_path)
         with self._locked_state():
@@ -198,10 +221,16 @@ class PrivacyStore:
             repository["path"] = str(root_path)
             repository["identity"] = identity
             providers = repository.setdefault("providers", {})
-            endpoints = providers.setdefault(family, {})
-            if not isinstance(endpoints, dict):
+            grants = providers.setdefault(family, {})
+            if not isinstance(grants, dict):
                 raise PrivacyStoreError("privacy state contains an invalid endpoint grants table")
-            endpoints[endpoint_identity] = {"granted_at": datetime.now(timezone.utc).isoformat()}
+            grant_id = _grant_id(endpoint_identity, route_identity)
+            grants[grant_id] = {
+                "endpoint": endpoint_identity,
+                "transport_identity": route_identity,
+                "transport": route_display,
+                "granted_at": datetime.now(timezone.utc).isoformat(),
+            }
             _require_same_repository_identity(root_path, identity)
             self._write(state)
 
@@ -232,6 +261,8 @@ class PrivacyStore:
         root: Path | str,
         provider: str,
         endpoint: str | None = None,
+        *,
+        transport_identity: str | None = None,
     ) -> bool:
         """Return whether local use or remembered cloud consent permits use."""
 
@@ -241,6 +272,7 @@ class PrivacyStore:
         if endpoint is None:
             return False
         endpoint_identity = canonical_endpoint(endpoint)
+        route_identity = _validated_transport_identity(transport_identity)
         root_path, identity = self._repository_context(root)
         self._ensure_outside_repository(root_path)
         with self._locked_state():
@@ -252,10 +284,10 @@ class PrivacyStore:
         providers = entry.get("providers", {})
         if not isinstance(providers, dict):
             raise PrivacyStoreError("privacy state contains an invalid providers table")
-        endpoints = providers.get(family, {})
-        if not isinstance(endpoints, dict):
+        grants = providers.get(family, {})
+        if not isinstance(grants, dict):
             raise PrivacyStoreError("privacy state contains an invalid endpoint grants table")
-        return endpoint_identity in endpoints
+        return _grant_id(endpoint_identity, route_identity) in grants
 
     @staticmethod
     def _repository_context(root: Path | str) -> tuple[Path, dict[str, object]]:
@@ -288,7 +320,7 @@ class PrivacyStore:
 
     @contextmanager
     def _locked_state(self):  # type: ignore[no-untyped-def]
-        """Serialize read-modify-write cycles across threads and POSIX processes."""
+        """Serialize read-modify-write cycles across threads and processes."""
 
         lock_key = str(self.path.expanduser().resolve(strict=False))
         with _STATE_LOCKS_GUARD:
@@ -298,22 +330,20 @@ class PrivacyStore:
             try:
                 lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
                 descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+                with suppress(OSError):
+                    os.chmod(lock_path, 0o600)
             except OSError as exc:
                 raise PrivacyStoreError(
                     f"cannot open privacy state lock {lock_path}: {exc}"
                 ) from exc
             try:
-                if os.name != "nt":
-                    import fcntl
-
-                    fcntl.flock(descriptor, fcntl.LOCK_EX)
+                _lock_file_descriptor(descriptor)
                 yield
             finally:
-                if os.name != "nt":
-                    import fcntl
-
-                    fcntl.flock(descriptor, fcntl.LOCK_UN)
-                os.close(descriptor)
+                try:
+                    _unlock_file_descriptor(descriptor)
+                finally:
+                    os.close(descriptor)
 
     def _read(self) -> dict[str, Any]:
         path = self.path.expanduser()
@@ -323,7 +353,12 @@ class PrivacyStore:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise PrivacyStoreError(f"cannot read privacy state {path}: {exc}") from exc
-        if not isinstance(data, dict) or data.get("version") not in {1, 2, _STATE_VERSION}:
+        if not isinstance(data, dict) or data.get("version") not in {
+            1,
+            2,
+            3,
+            _STATE_VERSION,
+        }:
             raise PrivacyStoreError("privacy state has an unsupported format")
         repositories = data.get("repositories")
         if not isinstance(repositories, dict):
@@ -334,7 +369,7 @@ class PrivacyStore:
             providers = repository.get("providers", {})
             if not isinstance(providers, dict):
                 raise PrivacyStoreError("privacy state contains an invalid providers table")
-        if data.get("version") in {1, 2}:
+        if data.get("version") in {1, 2, 3}:
             # Older grants were bound only to a path (and v1 only to a provider
             # family). They cannot be safely attached to the repository object
             # currently occupying that path, so migration deliberately drops them.
@@ -345,13 +380,18 @@ class PrivacyStore:
             ):
                 raise PrivacyStoreError("privacy state contains an invalid repository identity")
             providers = repository.get("providers", {})
-            for endpoints in providers.values():
-                if not isinstance(endpoints, dict):
+            for grants in providers.values():
+                if not isinstance(grants, dict):
                     raise PrivacyStoreError(
                         "privacy state contains an invalid endpoint grants table"
                     )
-                for endpoint, grant in endpoints.items():
-                    if not isinstance(endpoint, str) or not isinstance(grant, dict):
+                for grant_id, grant in grants.items():
+                    if not isinstance(grant_id, str) or not isinstance(grant, dict):
+                        raise PrivacyStoreError("privacy state contains an invalid endpoint grant")
+                    endpoint = grant.get("endpoint")
+                    route_identity = grant.get("transport_identity")
+                    transport = grant.get("transport")
+                    if not isinstance(endpoint, str) or not isinstance(route_identity, str):
                         raise PrivacyStoreError("privacy state contains an invalid endpoint grant")
                     try:
                         canonical = canonical_endpoint(endpoint)
@@ -363,6 +403,15 @@ class PrivacyStore:
                         raise PrivacyStoreError(
                             "privacy state contains a non-canonical endpoint identity"
                         )
+                    try:
+                        validated_route = _validated_transport_identity(route_identity)
+                        _normalized_transport_display(transport)
+                    except (TypeError, ValueError) as exc:
+                        raise PrivacyStoreError(
+                            "privacy state contains an invalid transport route"
+                        ) from exc
+                    if grant_id != _grant_id(endpoint, validated_route):
+                        raise PrivacyStoreError("privacy state contains an invalid grant identity")
         return data
 
     def _write(self, state: Mapping[str, Any]) -> None:
@@ -394,6 +443,96 @@ class PrivacyStore:
 
 def _is_reparse_point(metadata: os.stat_result) -> bool:
     return bool(getattr(metadata, "st_file_attributes", 0) & _REPARSE_POINT)
+
+
+def _lock_file_descriptor(descriptor: int) -> None:
+    """Acquire an exclusive whole-file lock on POSIX or Windows."""
+
+    if os.name != "nt":
+        import fcntl
+
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        return
+    _lock_file_descriptor_windows(descriptor)
+
+
+def _lock_file_descriptor_windows(  # pragma: no cover - exercised by Windows CI
+    descriptor: int,
+) -> None:
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    class Overlapped(ctypes.Structure):
+        _fields_ = [
+            ("Internal", ctypes.c_size_t),
+            ("InternalHigh", ctypes.c_size_t),
+            ("Offset", wintypes.DWORD),
+            ("OffsetHigh", wintypes.DWORD),
+            ("hEvent", wintypes.HANDLE),
+        ]
+
+    lock_file_ex = ctypes.windll.kernel32.LockFileEx
+    lock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(Overlapped),
+    ]
+    lock_file_ex.restype = wintypes.BOOL
+    handle = msvcrt.get_osfhandle(descriptor)
+    overlapped = Overlapped()
+    if not lock_file_ex(
+        handle,
+        0x00000002,  # LOCKFILE_EXCLUSIVE_LOCK
+        0,
+        0xFFFFFFFF,
+        0xFFFFFFFF,
+        ctypes.byref(overlapped),
+    ):
+        raise ctypes.WinError()
+    _WINDOWS_OVERLAPPED[descriptor] = overlapped
+
+
+def _unlock_file_descriptor(descriptor: int) -> None:
+    if os.name != "nt":
+        import fcntl
+
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        return
+    _unlock_file_descriptor_windows(descriptor)
+
+
+def _unlock_file_descriptor_windows(  # pragma: no cover - exercised by Windows CI
+    descriptor: int,
+) -> None:
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    overlapped = _WINDOWS_OVERLAPPED.pop(descriptor, None)
+    if overlapped is None:
+        return
+    unlock_file_ex = ctypes.windll.kernel32.UnlockFileEx
+    unlock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+    ]
+    unlock_file_ex.restype = wintypes.BOOL
+    handle = msvcrt.get_osfhandle(descriptor)
+    if not unlock_file_ex(
+        handle,
+        0,
+        0xFFFFFFFF,
+        0xFFFFFFFF,
+        ctypes.byref(overlapped),
+    ):
+        raise ctypes.WinError()
 
 
 def _same_identity(first: os.stat_result, second: os.stat_result) -> bool:
@@ -496,6 +635,73 @@ def _repository_id(root: Path, identity: Mapping[str, object]) -> str:
     return hashlib.sha256(payload.encode("utf-8", errors="surrogatepass")).hexdigest()
 
 
+def _default_transport_identity() -> str:
+    payload = json.dumps(
+        {"mode": "direct", "policy": "disabled", "proxy": None},
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _validated_transport_identity(value: str | None) -> str:
+    identity = _default_transport_identity() if value is None else value
+    if not isinstance(identity, str) or len(identity) != 64:
+        raise ValueError("transport identity must be a SHA-256 digest")
+    try:
+        bytes.fromhex(identity)
+    except ValueError as exc:
+        raise ValueError("transport identity must be a SHA-256 digest") from exc
+    return identity.casefold()
+
+
+def _normalized_transport_display(value: object) -> dict[str, str]:
+    if value is None:
+        return {"mode": "direct", "policy": "disabled"}
+    if not isinstance(value, Mapping):
+        raise TypeError("transport display must be a mapping")
+    mode = value.get("mode")
+    policy = value.get("policy")
+    if mode not in {"direct", "proxy"} or policy not in {
+        "disabled",
+        "environment",
+        "explicit",
+    }:
+        raise ValueError("transport display contains an invalid mode or policy")
+    expected_keys = {"mode", "policy"} if mode == "direct" else {"mode", "policy", "proxy"}
+    if set(value) != expected_keys:
+        raise ValueError("transport display contains unexpected fields")
+    normalized = {"mode": str(mode), "policy": str(policy)}
+    if mode == "proxy":
+        proxy = value.get("proxy")
+        if not isinstance(proxy, str) or not proxy:
+            raise ValueError("proxy transport display is missing its route")
+        parsed = urlsplit(proxy)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+            or parsed.path not in {"", "/"}
+        ):
+            raise ValueError("proxy transport display is not credential-free")
+        normalized["proxy"] = proxy.rstrip("/")
+    return normalized
+
+
+def _grant_id(endpoint: str, transport_identity: str) -> str:
+    payload = json.dumps(
+        {"endpoint": endpoint, "transport_identity": transport_identity},
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 def require_provider_consent(
     root: Path | str,
     provider: str,
@@ -503,10 +709,20 @@ def require_provider_consent(
     *,
     allow_once: bool = False,
     endpoint: str | None = None,
+    transport_identity: str | None = None,
 ) -> None:
     """Enforce cloud consent at the service/CLI boundary."""
 
-    if is_local_provider(provider) or allow_once or store.is_allowed(root, provider, endpoint):
+    if (
+        is_local_provider(provider)
+        or allow_once
+        or store.is_allowed(
+            root,
+            provider,
+            endpoint,
+            transport_identity=transport_identity,
+        )
+    ):
         return
     family = provider_family(provider)
     raise ConsentRequiredError(
@@ -526,6 +742,9 @@ class CloudSendPreview:
     model: str = ""
     endpoint: str | None = None
     payload_bytes: int = 0
+    transport: Mapping[str, str] = field(
+        default_factory=lambda: MappingProxyType({"mode": "direct", "policy": "disabled"})
+    )
 
     def __post_init__(self) -> None:
         if not isinstance(self.provider, str) or not self.provider.strip():
@@ -536,6 +755,11 @@ class CloudSendPreview:
             raise ValueError("preview model must be a string")
         if self.endpoint is not None and canonical_endpoint(self.endpoint) != self.endpoint:
             raise ValueError("preview endpoint must be canonical")
+        object.__setattr__(
+            self,
+            "transport",
+            MappingProxyType(_normalized_transport_display(self.transport)),
+        )
         for name in (
             "fragment_count",
             "estimated_tokens",
@@ -563,6 +787,7 @@ class CloudSendPreview:
             "model": self.model,
             "endpoint": self.endpoint,
             "payload_bytes": self.payload_bytes,
+            "transport": dict(self.transport),
         }
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,6 +68,48 @@ def test_self_hosted_api_health_and_local_workflow(
     assert ask.json()["evidence"]
 
 
+def test_scan_api_exposes_auto_always_and_rebuild_refresh_modes(
+    sample_repo: Path, isolated_user_dirs: Path
+) -> None:
+    application = create_app(sample_repo)
+
+    auto = _request(
+        application,
+        "POST",
+        "/v1/scan",
+        json={"path": str(sample_repo), "refresh": "auto"},
+    )
+    always = _request(
+        application,
+        "POST",
+        "/v1/scan",
+        json={"path": str(sample_repo), "refresh": "always"},
+    )
+    rebuild = _request(
+        application,
+        "POST",
+        "/v1/scan",
+        json={"path": str(sample_repo), "refresh": "rebuild"},
+    )
+    never = _request(
+        application,
+        "POST",
+        "/v1/scan",
+        json={"path": str(sample_repo), "refresh": "never"},
+    )
+
+    assert auto.status_code == 200, auto.text
+    assert always.status_code == 200, always.text
+    assert rebuild.status_code == 200, rebuild.text
+    updates = [response.json()["update"] for response in (auto, always, rebuild)]
+    assert [update["scan_revision"] for update in updates] == [1, 2, 3]
+    assert len({update["content_generation"] for update in updates}) == 1
+    assert always.json()["scan"]["content_reads"] == always.json()["scan"]["indexed_files"]
+    assert always.json()["scan"]["parsed_files"] == 0
+    assert rebuild.json()["scan"]["parsed_files"] == rebuild.json()["scan"]["indexed_files"]
+    assert never.status_code == 422
+
+
 def test_self_hosted_api_enforces_cloud_consent(
     sample_repo: Path, isolated_user_dirs: Path
 ) -> None:
@@ -212,7 +254,10 @@ def test_cloud_api_uses_single_use_immutable_preview_and_cannot_remember_consent
                 "[[src/demo/config.py:1]]"
             )
 
-    monkeypatch.setattr("repolocus.core.service.create_provider", lambda *_args: FakeProvider())
+    monkeypatch.setattr(
+        "repolocus.core.service.create_provider",
+        lambda *_args, **_kwargs: FakeProvider(),
+    )
     application = create_app(sample_repo, allow_cloud_requests=True)
     preview = _request(
         application,
@@ -293,10 +338,10 @@ def test_api_concurrency_limit_rejects_excess_work(
     started = threading.Event()
     release = threading.Event()
 
-    def slow_scan(self, root):  # type: ignore[no-untyped-def]
+    def slow_scan(self, root, *, refresh="auto"):  # type: ignore[no-untyped-def]
         started.set()
         release.wait(timeout=5)
-        return original_scan(self, root)
+        return original_scan(self, root, refresh=refresh)
 
     monkeypatch.setattr(RepoLocusService, "scan", slow_scan)
     application = create_app(sample_repo, max_concurrent_requests=1)

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -217,7 +217,10 @@ def test_temporary_file_swap_at_commit_cannot_publish_a_symlink(
 
     with pytest.raises(
         AtomicWriteError,
-        match=r"appeared before it could be created|temporary changed|atomic replacement",
+        match=(
+            r"appeared before it could be created|temporary changed|atomic replacement|"
+            r"not a safe regular file"
+        ),
     ):
         atomic_write_within_root(
             root,

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path, PurePosixPath
 
@@ -15,7 +16,7 @@ def test_atomic_write_creates_nested_output_and_replaces_only_generated(tmp_path
     root.mkdir()
     relative = PurePosixPath("docs/generated/PROJECT_MAP.md")
 
-    atomic_write_within_root(
+    created = atomic_write_within_root(
         root,
         relative,
         _GENERATED,
@@ -23,15 +24,22 @@ def test_atomic_write_creates_nested_output_and_replaces_only_generated(tmp_path
     )
     output = root / "docs" / "generated" / "PROJECT_MAP.md"
     assert output.read_bytes() == _GENERATED
+    assert created.recovery_path is None
 
     replacement = _GENERATED.replace(b"new", b"replacement")
-    atomic_write_within_root(
+    replaced = atomic_write_within_root(
         root,
         relative,
         replacement,
         replace_generated_only=True,
     )
     assert output.read_bytes() == replacement
+    if os.name == "nt":
+        assert replaced.recovery_path is None
+    else:
+        assert replaced.recovery_path is not None
+        assert replaced.recovery_path.read_bytes() == _GENERATED
+        assert replaced.recovery_path.suffix == ".rollback"
     assert not list(output.parent.glob(f".{output.name}.*.tmp"))
 
 
@@ -88,7 +96,7 @@ def test_fallback_generated_marker_read_is_bounded(tmp_path: Path) -> None:
 
     output = tmp_path / "PROJECT_MAP.md"
     output.write_bytes(_GENERATED + (b"x" * 1_000_000))
-    expected = output.lstat()
+    expected = writer._capture_fallback_state(output, directory=False)
 
     payload = writer._read_fallback_marker(output, expected)
 
@@ -130,7 +138,9 @@ def test_parent_symlink_swap_fails_without_writing_outside(
 
     assert swapped
     assert not (outside / "PROJECT_MAP.md").exists()
-    assert not list(moved.glob(".*.tmp"))
+    preserved = list(moved.glob(".*.tmp"))
+    assert len(preserved) == 1
+    assert preserved[0].read_bytes() == _GENERATED
 
 
 def test_target_file_to_symlink_race_fails_closed(
@@ -158,7 +168,10 @@ def test_target_file_to_symlink_race_fails_closed(
 
     monkeypatch.setattr(writer, "_checkpoint", swap)
 
-    with pytest.raises(AtomicWriteError, match=r"non-regular|safe regular"):
+    with pytest.raises(
+        AtomicWriteError,
+        match=r"non-regular|safe regular|changed while it was inspected",
+    ):
         atomic_write_within_root(
             root,
             PurePosixPath("PROJECT_MAP.md"),
@@ -168,7 +181,12 @@ def test_target_file_to_symlink_race_fails_closed(
 
     assert swapped
     assert outside.read_bytes() == b"outside\n"
-    assert not list(root.glob(".*.tmp"))
+    if os.name == "nt":
+        assert not list(root.glob(".*.tmp"))
+    else:
+        preserved = list(root.glob(".*.rollback"))
+        assert len(preserved) == 1
+        assert preserved[0].read_bytes() == _GENERATED
 
 
 def test_temporary_file_swap_at_commit_cannot_publish_a_symlink(
@@ -181,9 +199,10 @@ def test_temporary_file_swap_at_commit_cannot_publish_a_symlink(
     outside = tmp_path / "outside.md"
     outside.write_bytes(b"outside\n")
     swapped = False
+    swapped_temporary: Path | None = None
 
     def swap(stage: str, _root: Path, _relative: PurePosixPath) -> None:
-        nonlocal swapped
+        nonlocal swapped, swapped_temporary
         if stage == "commit-ready" and not swapped:
             temporary = next(root.glob(".PROJECT_MAP.md.*.tmp"))
             temporary.unlink()
@@ -191,6 +210,7 @@ def test_temporary_file_swap_at_commit_cannot_publish_a_symlink(
                 temporary.symlink_to(outside)
             except OSError as exc:  # pragma: no cover - Windows policy dependent
                 pytest.skip(f"symlinks unavailable: {exc}")
+            swapped_temporary = temporary
             swapped = True
 
     monkeypatch.setattr(writer, "_checkpoint", swap)
@@ -207,9 +227,14 @@ def test_temporary_file_swap_at_commit_cannot_publish_a_symlink(
         )
 
     assert swapped
-    assert (root / "PROJECT_MAP.md").is_symlink()
     assert outside.read_bytes() == b"outside\n"
-    assert list(root.glob(".*.tmp"))
+    assert swapped_temporary is not None
+    if os.name == "nt":
+        assert not (root / "PROJECT_MAP.md").exists()
+        assert swapped_temporary.is_symlink()
+    else:
+        assert (root / "PROJECT_MAP.md").is_symlink()
+        assert not list(root.glob(".*.tmp"))
 
 
 def test_generated_only_commit_preserves_a_last_moment_target_swap(
@@ -233,7 +258,10 @@ def test_generated_only_commit_preserves_a_last_moment_target_swap(
 
     monkeypatch.setattr(writer, "_checkpoint", swap)
 
-    with pytest.raises(AtomicWriteError, match="changed during atomic replacement"):
+    with pytest.raises(
+        AtomicWriteError,
+        match=r"changed during atomic replacement|changed before it could be hashed",
+    ):
         atomic_write_within_root(
             root,
             PurePosixPath("PROJECT_MAP.md"),
@@ -242,10 +270,14 @@ def test_generated_only_commit_preserves_a_last_moment_target_swap(
         )
 
     assert swapped
-    assert output.read_bytes() == _GENERATED.replace(b"new", b"replacement")
-    recovery = list(root.glob(".*.tmp"))
-    assert len(recovery) == 1
-    assert recovery[0].read_bytes() == raced_content
+    if os.name == "nt":
+        assert output.read_bytes() == raced_content
+        assert list(root.iterdir()) == [output]
+    else:
+        assert output.read_bytes() == _GENERATED.replace(b"new", b"replacement")
+        recovery = [path for path in root.iterdir() if path != output]
+        assert len(recovery) == 1
+        assert recovery[0].read_bytes() == raced_content
 
 
 @pytest.mark.skipif(os.name != "posix", reason="requires atomic POSIX name exchange")
@@ -319,10 +351,11 @@ def test_post_exchange_target_race_preserves_the_competing_file(
 
     assert raced
     assert output.read_bytes() == raced_content
-    assert _GENERATED in {path.read_bytes() for path in root.glob(".*.tmp") if path.is_file()}
+    assert _GENERATED in {path.read_bytes() for path in root.glob(".*.rollback") if path.is_file()}
 
 
-def test_post_link_target_race_preserves_the_competing_file(
+@pytest.mark.skipif(os.name != "posix", reason="requires descriptor-relative POSIX rename")
+def test_post_noreplace_target_race_preserves_the_competing_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from repolocus.security import atomic_write as writer
@@ -357,6 +390,7 @@ def test_post_link_target_race_preserves_the_competing_file(
     assert not list(root.glob(".*.tmp"))
 
 
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows file identity")
 def test_windows_new_commit_mismatch_preserves_the_competing_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -365,7 +399,7 @@ def test_windows_new_commit_mismatch_preserves_the_competing_file(
     temporary = tmp_path / ".PROJECT_MAP.md.tmp"
     destination = tmp_path / "PROJECT_MAP.md"
     temporary.write_bytes(_GENERATED)
-    expected = temporary.lstat()
+    expected = writer._capture_fallback_state(temporary, directory=False)
     raced_content = b"windows competitor after move\n"
 
     def move_then_race(source: Path, target: Path) -> None:
@@ -376,11 +410,17 @@ def test_windows_new_commit_mismatch_preserves_the_competing_file(
     monkeypatch.setattr(writer, "_move_file_windows", move_then_race)
 
     with pytest.raises(AtomicWriteError, match="preserved"):
-        writer._windows_commit_new(temporary, destination, expected)
+        writer._windows_commit_new(
+            temporary,
+            destination,
+            expected,
+            hashlib.sha256(_GENERATED).digest(),
+        )
 
     assert destination.read_bytes() == raced_content
 
 
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows file identity")
 def test_windows_exchange_mismatch_preserves_destination_and_backup(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -390,8 +430,8 @@ def test_windows_exchange_mismatch_preserves_destination_and_backup(
     temporary = tmp_path / ".PROJECT_MAP.md.tmp"
     destination.write_bytes(_GENERATED)
     temporary.write_bytes(_GENERATED.replace(b"new", b"replacement"))
-    expected_target = destination.lstat()
-    expected_temporary = temporary.lstat()
+    expected_target = writer._capture_fallback_state(destination, directory=False)
+    expected_temporary = writer._capture_fallback_state(temporary, directory=False)
     raced_content = b"windows competitor after replace\n"
 
     def replace_then_race(target: Path, replacement: Path, backup: Path) -> None:
@@ -408,6 +448,8 @@ def test_windows_exchange_mismatch_preserves_destination_and_backup(
             temporary,
             expected_temporary,
             expected_target,
+            hashlib.sha256(_GENERATED.replace(b"new", b"replacement")).digest(),
+            hashlib.sha256(_GENERATED).digest(),
         )
 
     assert destination.read_bytes() == raced_content
@@ -442,6 +484,9 @@ def test_unsupported_atomic_exchange_fails_without_replacing_the_target(
 
     assert output.read_bytes() == _GENERATED
     assert not list(root.glob(".*.tmp"))
+    recovery = list(root.glob(".*.rollback"))
+    assert len(recovery) == 1
+    assert recovery[0].read_bytes() == _GENERATED.replace(b"new", b"replacement")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO semantics")
@@ -472,12 +517,66 @@ def test_target_file_to_fifo_race_fails_without_blocking(
 
     assert stat_is_fifo(output)
     assert not list(root.glob(".*.tmp"))
+    recovery = list(root.glob(".*.rollback"))
+    assert len(recovery) == 1
+    assert recovery[0].read_bytes() == _GENERATED
 
 
 def stat_is_fifo(path: Path) -> bool:
     import stat
 
     return stat.S_ISFIFO(path.lstat().st_mode)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX descriptor helpers")
+def test_posix_atomic_helpers_fail_closed_on_missing_or_unsupported_objects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.write_bytes(b"source")
+    destination.write_bytes(b"destination")
+    parent_fd = os.open(tmp_path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        assert writer._raw_state_at(parent_fd, "missing") is None
+        with pytest.raises(FileNotFoundError):
+            writer._open_directory_at(parent_fd, "missing", create=False)
+        with pytest.raises(AtomicWriteError, match="appeared before it could be created"):
+            writer._rename_noreplace_at(parent_fd, source.name, destination.name)
+        assert source.read_bytes() == b"source"
+        assert destination.read_bytes() == b"destination"
+        with pytest.raises(AtomicWriteError, match="safe regular file"):
+            writer._capture_fallback_descriptor_state(parent_fd)
+    finally:
+        os.close(parent_fd)
+
+    source_state = writer._safe_fallback_state(source, directory=False)
+    assert writer._same_fallback_state(source_state, source_state, published=True)
+    assert writer._same_fallback_object_after_close(source_state, source_state)
+    with pytest.raises(AtomicWriteError, match="cannot inspect output path"):
+        writer._safe_fallback_state(tmp_path / "missing", directory=False)
+    with pytest.raises(AtomicWriteError, match="safe regular file"):
+        writer._safe_fallback_state(tmp_path, directory=False)
+    with pytest.raises(AtomicWriteError, match="cannot validate existing"):
+        writer._read_fallback_marker(tmp_path / "missing", source_state)
+
+    monkeypatch.setattr(writer.sys, "platform", "unsupported")
+    with pytest.raises(AtomicWriteError, match="replacement is unavailable"):
+        writer._rename_exchange_at(-1, "first", "second")
+    with pytest.raises(AtomicWriteError, match=r"create-if-absent.*unavailable"):
+        writer._rename_noreplace_at(-1, "source", "destination")
+
+    monkeypatch.setattr(writer.os, "supports_dir_fd", frozenset())
+    with pytest.raises(AtomicWriteError, match=r"descriptor-bound.*unavailable"):
+        atomic_write_within_root(
+            tmp_path,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -488,6 +587,16 @@ def stat_is_fifo(path: Path) -> bool:
         PurePosixPath("."),
         PurePosixPath("bad\\name.md"),
         PurePosixPath("bad\0name.md"),
+        PurePosixPath("C:/outside.md"),
+        PurePosixPath("docs/C:/outside.md"),
+        PurePosixPath("PROJECT_MAP.md:stream"),
+        PurePosixPath(".. /outside.md"),
+        PurePosixPath("docs./PROJECT_MAP.md"),
+        PurePosixPath("NUL.md"),
+        PurePosixPath("COM¹.md"),
+        PurePosixPath("bad|name.md"),
+        PurePosixPath("bad\x1fname.md"),
+        PurePosixPath("safe\u202eevil.md"),
     ],
 )
 def test_atomic_write_rejects_non_relative_paths(tmp_path: Path, relative: PurePosixPath) -> None:

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,0 +1,542 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from repolocus.security import AtomicWriteError, atomic_write_within_root
+
+_GENERATED = b"<!-- Generator: RepoLocus 0.1.5; deterministic source map. -->\nnew\n"
+
+
+def test_atomic_write_creates_nested_output_and_replaces_only_generated(tmp_path: Path) -> None:
+    root = tmp_path / "repository"
+    root.mkdir()
+    relative = PurePosixPath("docs/generated/PROJECT_MAP.md")
+
+    atomic_write_within_root(
+        root,
+        relative,
+        _GENERATED,
+        replace_generated_only=True,
+    )
+    output = root / "docs" / "generated" / "PROJECT_MAP.md"
+    assert output.read_bytes() == _GENERATED
+
+    replacement = _GENERATED.replace(b"new", b"replacement")
+    atomic_write_within_root(
+        root,
+        relative,
+        replacement,
+        replace_generated_only=True,
+    )
+    assert output.read_bytes() == replacement
+    assert not list(output.parent.glob(f".{output.name}.*.tmp"))
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        b"user-authored notes\n",
+        b"User text mentioning Generator: RepoLocus is not a marker.\n",
+    ],
+)
+def test_atomic_write_refuses_user_or_forged_generated_files(
+    tmp_path: Path, existing: bytes
+) -> None:
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    output.write_bytes(existing)
+
+    with pytest.raises(AtomicWriteError, match="not recognized as generated"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
+
+    assert output.read_bytes() == existing
+
+
+def test_atomic_write_force_still_rejects_symlink_targets(tmp_path: Path) -> None:
+    root = tmp_path / "repository"
+    root.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(b"outside\n")
+    target = root / "PROJECT_MAP.md"
+    try:
+        target.symlink_to(outside)
+    except OSError as exc:  # pragma: no cover - Windows policy dependent
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(AtomicWriteError, match=r"non-regular|safe regular"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=False,
+        )
+
+    assert outside.read_bytes() == b"outside\n"
+
+
+def test_fallback_generated_marker_read_is_bounded(tmp_path: Path) -> None:
+    from repolocus.security import atomic_write as writer
+
+    output = tmp_path / "PROJECT_MAP.md"
+    output.write_bytes(_GENERATED + (b"x" * 1_000_000))
+    expected = output.lstat()
+
+    payload = writer._read_fallback_marker(output, expected)
+
+    assert payload == (_GENERATED + (b"x" * writer._MARKER_READ_LIMIT))[: writer._MARKER_READ_LIMIT]
+    assert len(payload) == writer._MARKER_READ_LIMIT
+
+
+def test_parent_symlink_swap_fails_without_writing_outside(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    if os.name == "nt":
+        pytest.skip("Windows reparse-point race is covered by the Windows-specific path")
+    root = tmp_path / "repository"
+    parent = root / "docs"
+    parent.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    moved = root / "original-docs"
+    swapped = False
+
+    def swap(stage: str, _root: Path, _relative: PurePosixPath) -> None:
+        nonlocal swapped
+        if stage == "temporary-synced" and not swapped:
+            parent.rename(moved)
+            parent.symlink_to(outside, target_is_directory=True)
+            swapped = True
+
+    monkeypatch.setattr(writer, "_checkpoint", swap)
+
+    with pytest.raises(AtomicWriteError, match=r"directory tree|output parent"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("docs/PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
+
+    assert swapped
+    assert not (outside / "PROJECT_MAP.md").exists()
+    assert not list(moved.glob(".*.tmp"))
+
+
+def test_target_file_to_symlink_race_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    output.write_bytes(_GENERATED)
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(b"outside\n")
+    swapped = False
+
+    def swap(stage: str, _root: Path, _relative: PurePosixPath) -> None:
+        nonlocal swapped
+        if stage == "target-validated" and not swapped:
+            output.unlink()
+            try:
+                output.symlink_to(outside)
+            except OSError as exc:  # pragma: no cover - Windows policy dependent
+                pytest.skip(f"symlinks unavailable: {exc}")
+            swapped = True
+
+    monkeypatch.setattr(writer, "_checkpoint", swap)
+
+    with pytest.raises(AtomicWriteError, match=r"non-regular|safe regular"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
+
+    assert swapped
+    assert outside.read_bytes() == b"outside\n"
+    assert not list(root.glob(".*.tmp"))
+
+
+def test_temporary_file_swap_at_commit_cannot_publish_a_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(b"outside\n")
+    swapped = False
+
+    def swap(stage: str, _root: Path, _relative: PurePosixPath) -> None:
+        nonlocal swapped
+        if stage == "commit-ready" and not swapped:
+            temporary = next(root.glob(".PROJECT_MAP.md.*.tmp"))
+            temporary.unlink()
+            try:
+                temporary.symlink_to(outside)
+            except OSError as exc:  # pragma: no cover - Windows policy dependent
+                pytest.skip(f"symlinks unavailable: {exc}")
+            swapped = True
+
+    monkeypatch.setattr(writer, "_checkpoint", swap)
+
+    with pytest.raises(
+        AtomicWriteError,
+        match=r"appeared before it could be created|temporary changed|atomic replacement",
+    ):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
+
+    assert swapped
+    assert (root / "PROJECT_MAP.md").is_symlink()
+    assert outside.read_bytes() == b"outside\n"
+    assert list(root.glob(".*.tmp"))
+
+
+def test_generated_only_commit_preserves_a_last_moment_target_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    output.write_bytes(_GENERATED)
+    raced_content = b"user-authored during final commit race\n"
+    swapped = False
+
+    def swap(stage: str, _root: Path, _relative: PurePosixPath) -> None:
+        nonlocal swapped
+        if stage == "commit-ready" and not swapped:
+            output.unlink()
+            output.write_bytes(raced_content)
+            swapped = True
+
+    monkeypatch.setattr(writer, "_checkpoint", swap)
+
+    with pytest.raises(AtomicWriteError, match="changed during atomic replacement"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED.replace(b"new", b"replacement"),
+            replace_generated_only=True,
+        )
+
+    assert swapped
+    assert output.read_bytes() == _GENERATED.replace(b"new", b"replacement")
+    recovery = list(root.glob(".*.tmp"))
+    assert len(recovery) == 1
+    assert recovery[0].read_bytes() == raced_content
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires atomic POSIX name exchange")
+def test_exchange_verification_error_preserves_both_recoverable_objects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    output.write_bytes(_GENERATED)
+    original_state_at = writer._raw_state_at
+    failed = False
+
+    def fail_once(parent_fd: int, name: str) -> os.stat_result | None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise OSError("simulated post-exchange inspection failure")
+        return original_state_at(parent_fd, name)
+
+    monkeypatch.setattr(writer, "_raw_state_at", fail_once)
+
+    replacement = _GENERATED.replace(b"new", b"replacement")
+    with pytest.raises(AtomicWriteError, match="could not be verified; preserved"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            replacement,
+            replace_generated_only=True,
+        )
+
+    assert failed
+    contents = {path.read_bytes() for path in root.iterdir() if path.is_file()}
+    assert contents == {_GENERATED, replacement}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires atomic POSIX name exchange")
+def test_post_exchange_target_race_preserves_the_competing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    output.write_bytes(_GENERATED)
+    replacement = _GENERATED.replace(b"new", b"replacement")
+    raced_content = b"user-authored after exchange\n"
+    original_state_at = writer._raw_state_at
+    raced = False
+
+    def race_after_exchange(parent_fd: int, name: str) -> os.stat_result | None:
+        nonlocal raced
+        if not raced:
+            raced = True
+            output.unlink()
+            output.write_bytes(raced_content)
+        return original_state_at(parent_fd, name)
+
+    monkeypatch.setattr(writer, "_raw_state_at", race_after_exchange)
+
+    with pytest.raises(AtomicWriteError, match="preserved recoverable names"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            replacement,
+            replace_generated_only=True,
+        )
+
+    assert raced
+    assert output.read_bytes() == raced_content
+    assert _GENERATED in {path.read_bytes() for path in root.glob(".*.tmp") if path.is_file()}
+
+
+def test_post_link_target_race_preserves_the_competing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    raced_content = b"user-authored after link\n"
+    original_state_at = writer._raw_state_at
+    raced = False
+
+    def race_after_link(parent_fd: int, name: str) -> os.stat_result | None:
+        nonlocal raced
+        if not raced:
+            raced = True
+            output.unlink()
+            output.write_bytes(raced_content)
+        return original_state_at(parent_fd, name)
+
+    monkeypatch.setattr(writer, "_raw_state_at", race_after_link)
+
+    with pytest.raises(AtomicWriteError, match="preserved target"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
+
+    assert raced
+    assert output.read_bytes() == raced_content
+    assert not list(root.glob(".*.tmp"))
+
+
+def test_windows_new_commit_mismatch_preserves_the_competing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    temporary = tmp_path / ".PROJECT_MAP.md.tmp"
+    destination = tmp_path / "PROJECT_MAP.md"
+    temporary.write_bytes(_GENERATED)
+    expected = temporary.lstat()
+    raced_content = b"windows competitor after move\n"
+
+    def move_then_race(source: Path, target: Path) -> None:
+        source.rename(target)
+        target.unlink()
+        target.write_bytes(raced_content)
+
+    monkeypatch.setattr(writer, "_move_file_windows", move_then_race)
+
+    with pytest.raises(AtomicWriteError, match="preserved"):
+        writer._windows_commit_new(temporary, destination, expected)
+
+    assert destination.read_bytes() == raced_content
+
+
+def test_windows_exchange_mismatch_preserves_destination_and_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    destination = tmp_path / "PROJECT_MAP.md"
+    temporary = tmp_path / ".PROJECT_MAP.md.tmp"
+    destination.write_bytes(_GENERATED)
+    temporary.write_bytes(_GENERATED.replace(b"new", b"replacement"))
+    expected_target = destination.lstat()
+    expected_temporary = temporary.lstat()
+    raced_content = b"windows competitor after replace\n"
+
+    def replace_then_race(target: Path, replacement: Path, backup: Path) -> None:
+        target.rename(backup)
+        replacement.rename(target)
+        target.unlink()
+        target.write_bytes(raced_content)
+
+    monkeypatch.setattr(writer, "_replace_file_windows", replace_then_race)
+
+    with pytest.raises(AtomicWriteError, match="preserved recoverable names"):
+        writer._windows_commit_exchange(
+            destination,
+            temporary,
+            expected_temporary,
+            expected_target,
+        )
+
+    assert destination.read_bytes() == raced_content
+    backups = list(tmp_path.glob(".PROJECT_MAP.md.*.rollback"))
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == _GENERATED
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires descriptor-relative POSIX path")
+def test_unsupported_atomic_exchange_fails_without_replacing_the_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    output.write_bytes(_GENERATED)
+
+    def unsupported(_parent_fd: int, _first: str, _second: str) -> None:
+        raise AtomicWriteError("atomic exchange unsupported")
+
+    monkeypatch.setattr(writer, "_rename_exchange_at", unsupported)
+
+    with pytest.raises(AtomicWriteError, match="atomic exchange unsupported"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED.replace(b"new", b"replacement"),
+            replace_generated_only=True,
+        )
+
+    assert output.read_bytes() == _GENERATED
+    assert not list(root.glob(".*.tmp"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO semantics")
+def test_target_file_to_fifo_race_fails_without_blocking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    output = root / "PROJECT_MAP.md"
+    output.write_bytes(_GENERATED)
+
+    def swap(stage: str, _root: Path, _relative: PurePosixPath) -> None:
+        if stage == "target-validated":
+            output.unlink()
+            os.mkfifo(output)
+
+    monkeypatch.setattr(writer, "_checkpoint", swap)
+
+    with pytest.raises(AtomicWriteError, match="non-regular"):
+        atomic_write_within_root(
+            root,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
+
+    assert stat_is_fifo(output)
+    assert not list(root.glob(".*.tmp"))
+
+
+def stat_is_fifo(path: Path) -> bool:
+    import stat
+
+    return stat.S_ISFIFO(path.lstat().st_mode)
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        PurePosixPath("../outside.md"),
+        PurePosixPath("/absolute.md"),
+        PurePosixPath("."),
+        PurePosixPath("bad\\name.md"),
+        PurePosixPath("bad\0name.md"),
+    ],
+)
+def test_atomic_write_rejects_non_relative_paths(tmp_path: Path, relative: PurePosixPath) -> None:
+    with pytest.raises(AtomicWriteError, match="repository-relative"):
+        atomic_write_within_root(
+            tmp_path,
+            relative,
+            _GENERATED,
+            replace_generated_only=True,
+        )
+
+
+def test_atomic_write_rejects_invalid_public_argument_types(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="root must be a Path"):
+        atomic_write_within_root(  # type: ignore[arg-type]
+            str(tmp_path),
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=True,
+        )
+    with pytest.raises(TypeError, match="relative_path must be a PurePosixPath"):
+        atomic_write_within_root(  # type: ignore[arg-type]
+            tmp_path,
+            "PROJECT_MAP.md",
+            _GENERATED,
+            replace_generated_only=True,
+        )
+    with pytest.raises(TypeError, match="content must be bytes"):
+        atomic_write_within_root(  # type: ignore[arg-type]
+            tmp_path,
+            PurePosixPath("PROJECT_MAP.md"),
+            "content",
+            replace_generated_only=True,
+        )
+    with pytest.raises(TypeError, match="replace_generated_only must be true or false"):
+        atomic_write_within_root(  # type: ignore[arg-type]
+            tmp_path,
+            PurePosixPath("PROJECT_MAP.md"),
+            _GENERATED,
+            replace_generated_only=1,
+        )
+
+
+def test_atomic_write_rejects_a_zero_length_low_level_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.security import atomic_write as writer
+
+    monkeypatch.setattr(writer.os, "write", lambda _descriptor, _content: 0)
+
+    with pytest.raises(OSError, match="short write"):
+        writer._write_all(1, b"content")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,7 +109,10 @@ def test_remembered_cloud_grant_still_prints_exact_preview(
         "openai",
         "https://api.openai.com/v1/chat/completions",
     )
-    monkeypatch.setattr("repolocus.core.service.create_provider", lambda *_args: FakeProvider())
+    monkeypatch.setattr(
+        "repolocus.core.service.create_provider",
+        lambda *_args, **_kwargs: FakeProvider(),
+    )
 
     result = runner.invoke(
         app,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from urllib.parse import unquote
@@ -235,6 +236,12 @@ def test_generated_output_migrates_the_pre_rename_marker(
     generated = output.read_text(encoding="utf-8")
     assert "Generator: RepoLocus" in generated
     assert "Generator: DevPilot" not in generated
+    if os.name != "nt":
+        assert "previous output preserved at" in result.output
+        assert "repository writers are quiescent" in result.output
+        recovery = list(sample_repo.glob(".PROJECT_MAP.md.*.rollback"))
+        assert len(recovery) == 1
+        assert "Generator: DevPilot" in recovery[0].read_text(encoding="utf-8")
 
 
 def test_generated_commands_require_markdown_outputs_and_fix_nested_links(

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -70,6 +72,7 @@ def test_evaluation_reports_complete_ranked_and_no_answer_metrics() -> None:
     assert metrics["by_language"]["en"]["cases"] == 2  # type: ignore[index]
     assert metrics["by_language"]["zh"]["answerable_cases"] == 0  # type: ignore[index]
     assert metrics["by_language"]["zh"]["macro_recall_at_k"] is None  # type: ignore[index]
+    assert metrics["by_repository"]["unspecified"]["cases"] == 4  # type: ignore[index]
     assert metrics["by_query_type"]["unspecified"]["cases"] == 4  # type: ignore[index]
 
 
@@ -169,3 +172,68 @@ def test_repository_question_set_keeps_top_five_path_hit_rate(
     assert metrics["by_language"]["zh"]["macro_recall_at_k"] == 1.0  # type: ignore[index]
     assert metrics["by_query_type"]["identifier"]["answerable_cases"] >= 1  # type: ignore[index,operator]
     assert all(outcome["language"] in {"en", "zh"} for outcome in outcomes)
+
+
+def test_external_multi_repository_release_gate_is_reproducible() -> None:
+    repository = Path(__file__).resolve().parents[1]
+    command = [
+        sys.executable,
+        str(repository / "scripts" / "evaluate_external_repositories.py"),
+        str(repository / "evaluation"),
+    ]
+    results = [
+        subprocess.run(
+            command,
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        for _ in range(2)
+    ]
+
+    assert all(result.returncode == 0 for result in results), "\n".join(
+        result.stderr or result.stdout for result in results
+    )
+    assert results[0].stdout == results[1].stdout
+    reports = [json.loads(result.stdout) for result in results]
+    assert reports[0] == reports[1]
+    report = reports[0]
+    metrics = report["metrics"]
+    assert report["manifest"] == "external-manifest.json"
+    assert report["fixture_count"] == 6
+    assert report["qrels"] == 18
+    assert report["answerable_qrels"] == 12
+    assert report["no_answer_qrels"] == 6
+    assert report["citation_qrels"] == 12
+    assert report["gate"] == {
+        "passed": True,
+        "thresholds": {
+            "maximum_must_not_return_rate": 0.0,
+            "minimum_citation_recall": 1.0,
+            "minimum_hit_rate": 0.9,
+            "minimum_macro_recall": 0.8,
+            "minimum_mrr": 0.75,
+            "minimum_no_answer_f1": 0.8,
+        },
+    }
+    assert metrics["any_expected_path_rate"] >= 0.90
+    assert metrics["macro_recall_at_k"] >= 0.80
+    assert metrics["mrr"] >= 0.75
+    assert metrics["citation_recall"] >= 1.0
+    assert metrics["no_answer_f1"] >= 0.80
+    assert metrics["must_not_return_violation_rate"] == 0.0
+    assert set(metrics["by_repository"]) == {
+        "cpp-cmake",
+        "go-service",
+        "java-gradle",
+        "python-small",
+        "rust-cli",
+        "typescript-web",
+    }
+    assert all(bucket["cases"] == 3 for bucket in metrics["by_repository"].values())
+    assert all(fixture["revision"] == "fixture-v1" for fixture in report["fixtures"])
+    assert all(fixture["content_generation"] == 1 for fixture in report["fixtures"])
+    assert all(fixture["scan_revision"] == 1 for fixture in report["fixtures"])
+    assert all(outcome["qrel_line"] for outcome in report["outcomes"])

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -196,6 +196,7 @@ def test_external_multi_repository_release_gate_is_reproducible() -> None:
     assert all(result.returncode == 0 for result in results), "\n".join(
         result.stderr or result.stdout for result in results
     )
+    assert results[0].stdout.isascii()
     assert results[0].stdout == results[1].stdout
     reports = [json.loads(result.stdout) for result in results]
     assert reports[0] == reports[1]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -237,3 +237,12 @@ def test_external_multi_repository_release_gate_is_reproducible() -> None:
     assert all(fixture["content_generation"] == 1 for fixture in report["fixtures"])
     assert all(fixture["scan_revision"] == 1 for fixture in report["fixtures"])
     assert all(outcome["qrel_line"] for outcome in report["outcomes"])
+
+
+def test_external_fixture_bytes_are_lf_pinned_for_cross_platform_git_checkouts() -> None:
+    repository = Path(__file__).resolve().parents[1]
+    attributes = (repository / ".gitattributes").read_text(encoding="utf-8").splitlines()
+
+    assert "evaluation/repos/** text eol=lf" in attributes
+    assert "evaluation/qrels/** text eol=lf" in attributes
+    assert "evaluation/external-manifest.json text eol=lf" in attributes

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -91,7 +91,7 @@ def test_path_boundary_rejects_a_regular_file_as_root(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "state",
     [
-        {"version": 4, "repositories": {}},
+        {"version": 5, "repositories": {}},
         {"version": 1, "repositories": []},
     ],
 )
@@ -175,6 +175,8 @@ def test_oversize_ignore_file_fails_closed_and_is_reported(tmp_path: Path) -> No
 def test_parser_plugins_cannot_cross_source_boundaries(tmp_path: Path, invalid_fact: str) -> None:
     class InvalidParser:
         languages = frozenset({"python"})
+        cache_key = "test-invalid:v1"
+        priority = 0
 
         def parse(self, path: str, text: str, language: str, **kwargs: object) -> ParseResult:
             if invalid_fact == "symbol":
@@ -290,7 +292,10 @@ def test_cloud_model_success_can_remember_repository_scoped_consent(
                 "[[src/demo/config.py:1-2]]"
             )
 
-    monkeypatch.setattr("repolocus.core.service.create_provider", lambda *_args: FakeProvider())
+    monkeypatch.setattr(
+        "repolocus.core.service.create_provider",
+        lambda *_args, **_kwargs: FakeProvider(),
+    )
     privacy = PrivacyStore(isolated_user_dirs / "privacy.json")
     service = RepoLocusService(Settings(model="openai/test-model"), privacy=privacy)
 
@@ -318,7 +323,10 @@ def test_unverifiable_model_response_falls_back_to_source_evidence(
         def generate(self, system_prompt: str, user_prompt: str) -> str:
             return "Trust me: configuration is definitely uploaded elsewhere."
 
-    monkeypatch.setattr("repolocus.core.service.create_provider", lambda *_args: FakeProvider())
+    monkeypatch.setattr(
+        "repolocus.core.service.create_provider",
+        lambda *_args, **_kwargs: FakeProvider(),
+    )
     service = RepoLocusService(
         Settings(model="openai/test-model"),
         privacy=PrivacyStore(isolated_user_dirs / "privacy.json"),
@@ -375,7 +383,10 @@ def test_remote_ollama_can_use_explicitly_remembered_remote_scope(
                 "[[src/demo/config.py:1]]"
             )
 
-    monkeypatch.setattr("repolocus.core.service.create_provider", lambda *_args: FakeProvider())
+    monkeypatch.setattr(
+        "repolocus.core.service.create_provider",
+        lambda *_args, **_kwargs: FakeProvider(),
+    )
     privacy = PrivacyStore(isolated_user_dirs / "privacy.json")
     privacy.grant(
         sample_repo,

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -561,6 +561,134 @@ def test_v2_index_migration_invalidates_untrusted_existing_facts(tmp_path: Path)
         assert migrated.get_files() == []
 
 
+def test_legacy_v3_search_layout_migrates_to_v5_without_reusing_facts(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    cache = tmp_path / "cache"
+    source = _file("legacy.py", "LEGACY_FACT = True\n", symbol="legacy_fact")
+
+    with RepositoryIndex.open(repository, cache) as index:
+        database = index.db_path
+        committed = index.update(_scan(repository, source))
+
+    connection = sqlite3.connect(database)
+    for trigger in (
+        "chunks_after_insert",
+        "chunks_after_delete",
+        "chunks_after_update",
+    ):
+        connection.execute(f"DROP TRIGGER {trigger}")  # nosec B608
+    connection.execute("DROP TABLE chunks_fts")
+    connection.execute("DROP TABLE chunk_terms")
+    connection.execute("ALTER TABLE files DROP COLUMN facts_sha256")
+    connection.execute(
+        """
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            path,
+            symbol,
+            content,
+            tokenize = 'unicode61 remove_diacritics 2'
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TRIGGER chunks_after_insert AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts(rowid, path, symbol, content)
+            VALUES (new.id, new.file_path, new.symbol, new.content);
+        END
+        """
+    )
+    connection.execute(
+        """
+        CREATE TRIGGER chunks_after_delete AFTER DELETE ON chunks BEGIN
+            DELETE FROM chunks_fts WHERE rowid = old.id;
+        END
+        """
+    )
+    connection.execute(
+        """
+        CREATE TRIGGER chunks_after_update AFTER UPDATE ON chunks BEGIN
+            DELETE FROM chunks_fts WHERE rowid = old.id;
+            INSERT INTO chunks_fts(rowid, path, symbol, content)
+            VALUES (new.id, new.file_path, new.symbol, new.content);
+        END
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO chunks_fts(rowid, path, symbol, content)
+        SELECT id, file_path, symbol, content FROM chunks
+        """
+    )
+    connection.execute(
+        "DELETE FROM meta WHERE key IN "
+        "('content_generation', 'scan_revision', 'scan_fingerprint', "
+        "'parser_fingerprint', 'term_index_fingerprint', "
+        "'retrieval_fingerprint', 'repository_identity')"
+    )
+    connection.execute("UPDATE meta SET value = '3' WHERE key = 'schema_version'")
+    connection.execute("UPDATE meta SET value = '3' WHERE key = 'index_format_version'")
+    connection.execute("PRAGMA user_version = 3")
+    connection.commit()
+    assert [row[1] for row in connection.execute("PRAGMA table_info(chunks_fts)")] == [
+        "path",
+        "symbol",
+        "content",
+    ]
+    assert connection.execute("SELECT count(*) FROM chunks_fts").fetchone()[0] == 1
+    connection.close()
+
+    with RepositoryIndex.open(repository, cache) as migrated:
+        metadata = migrated.get_metadata()
+        tables = {
+            str(row[0])
+            for row in migrated._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        file_columns = {
+            str(row[1]) for row in migrated._connection.execute("PRAGMA table_info(files)")
+        }
+        fts_columns = [
+            str(row[1]) for row in migrated._connection.execute("PRAGMA table_info(chunks_fts)")
+        ]
+        chunk_term_indexes = {
+            str(row[1]) for row in migrated._connection.execute("PRAGMA index_list('chunk_terms')")
+        }
+        trigger_sql = {
+            str(row[0]): str(row[1])
+            for row in migrated._connection.execute(
+                "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'chunks'"
+            )
+        }
+
+        assert migrated.get_files() == []
+        assert migrated.get_symbols() == []
+        assert migrated.search_chunks("LEGACY_FACT") == []
+        assert migrated.generation() == committed.generation + 1
+        assert metadata["schema_version"] == "5"
+        assert metadata["index_format_version"] == "5"
+        assert metadata["content_generation"] == str(committed.generation + 1)
+        assert metadata["scan_revision"] == str(committed.generation + 1)
+        assert int(migrated._connection.execute("PRAGMA user_version").fetchone()[0]) == 5
+        assert "chunk_terms" in tables
+        assert "facts_sha256" in file_columns
+        assert fts_columns == ["file_path", "symbol", "content"]
+        assert "chunk_terms_chunk_idx" in chunk_term_indexes
+        assert set(trigger_sql) == {
+            "chunks_after_insert",
+            "chunks_after_delete",
+            "chunks_after_update",
+        }
+        assert all("file_path" in statement for statement in trigger_sql.values())
+        assert migrated._connection.execute("SELECT count(*) FROM chunks").fetchone()[0] == 0
+        assert migrated._connection.execute("SELECT count(*) FROM chunk_terms").fetchone()[0] == 0
+        assert migrated._connection.execute("SELECT count(*) FROM chunks_fts").fetchone()[0] == 0
+
+
 def test_same_path_repository_replacement_invalidates_index_identity(tmp_path: Path) -> None:
     repository = tmp_path / "repository"
     repository.mkdir()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -548,8 +548,10 @@ def test_v2_index_migration_invalidates_untrusted_existing_facts(tmp_path: Path)
         assert migrated.search_chunks("VALUE") == []
         assert migrated.generation() == 1
         assert metadata["analysis_version"] == ""
-        assert metadata["schema_version"] == "4"
-        assert metadata["index_format_version"] == "4"
+        assert metadata["schema_version"] == "5"
+        assert metadata["index_format_version"] == "5"
+        assert metadata["content_generation"] == "1"
+        assert metadata["scan_revision"] == "1"
         assert len(metadata["repository_identity"]) == 64
         indexes = {
             str(row[1]) for row in migrated._connection.execute("PRAGMA index_list('chunk_terms')")

--- a/tests/test_index_state_machine.py
+++ b/tests/test_index_state_machine.py
@@ -38,8 +38,8 @@ class IndexRevisionStateMachine(RuleBasedStateMachine):
             scanner=self.scanner,
             privacy=PrivacyStore(base / "privacy.json"),
         )
-        self.disk: dict[str, str] = {}
-        self.committed: dict[str, str] = {}
+        self.disk: dict[str, tuple[str, bytes]] = {}
+        self.committed: dict[str, tuple[str, bytes]] = {}
         self.content_generation = 0
         self.scan_revision = 0
         self.has_scanned = False
@@ -54,7 +54,7 @@ class IndexRevisionStateMachine(RuleBasedStateMachine):
         target = self.root / path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
-        self.disk[path] = content
+        self.disk[path] = (content, target.read_bytes())
 
     @rule(path=sampled_from(("a.py", "b.py", "nested/c.py")))
     def delete_file(self, path: str) -> None:
@@ -144,8 +144,8 @@ class IndexRevisionStateMachine(RuleBasedStateMachine):
             return
         indexed = {file.path: file for file in snapshot.files if not file.stale}
         assert set(indexed) == set(self.committed)
-        for path, content in self.committed.items():
-            assert indexed[path].sha256 == hashlib.sha256(content.encode()).hexdigest()
+        for path, (content, raw) in self.committed.items():
+            assert indexed[path].sha256 == hashlib.sha256(raw).hexdigest()
             assert indexed[path].text == content
 
     def _snapshot(self):  # type: ignore[no-untyped-def]

--- a/tests/test_index_state_machine.py
+++ b/tests/test_index_state_machine.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+
+from hypothesis import HealthCheck, assume, settings
+from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, rule
+from hypothesis.strategies import integers, sampled_from
+
+from repolocus.analysis import stable_fingerprint
+from repolocus.config import Settings
+from repolocus.core import RepoLocusService
+from repolocus.index import RepositoryIndex, StaleScanError
+from repolocus.scanner import RepositoryScanner
+from repolocus.security import PrivacyStore
+
+
+@settings(
+    max_examples=20,
+    stateful_step_count=15,
+    deadline=None,
+    suppress_health_check=(HealthCheck.too_slow,),
+)
+class IndexRevisionStateMachine(RuleBasedStateMachine):
+    """Compare randomized filesystem/index transitions with a small reference model."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.temporary = tempfile.TemporaryDirectory(prefix="repolocus-state-machine-")
+        base = Path(self.temporary.name)
+        self.root = base / "repository"
+        self.root.mkdir()
+        self.scanner = RepositoryScanner()
+        self.service = RepoLocusService(
+            Settings(model="local"),
+            scanner=self.scanner,
+            privacy=PrivacyStore(base / "privacy.json"),
+        )
+        self.disk: dict[str, str] = {}
+        self.committed: dict[str, str] = {}
+        self.content_generation = 0
+        self.scan_revision = 0
+        self.has_scanned = False
+        self.fingerprint_revision = 0
+
+    @rule(
+        path=sampled_from(("a.py", "b.py", "nested/c.py")),
+        value=integers(min_value=0, max_value=1_000_000),
+    )
+    def add_or_modify_file(self, path: str, value: int) -> None:
+        content = f"VALUE_{path.replace('/', '_').replace('.', '_')} = {value}\n"
+        target = self.root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        self.disk[path] = content
+
+    @rule(path=sampled_from(("a.py", "b.py", "nested/c.py")))
+    def delete_file(self, path: str) -> None:
+        assume(path in self.disk)
+        (self.root / path).unlink()
+        self.disk.pop(path)
+
+    @rule(mode=sampled_from(("auto", "always", "rebuild")))
+    def refresh(self, mode: str) -> None:
+        dirty = self.disk != self.committed
+        exact_auto_hit = mode == "auto" and self.has_scanned and not dirty
+        operation = self.service.scan(self.root, refresh=mode)  # type: ignore[arg-type]
+        if not exact_auto_hit:
+            self.scan_revision += 1
+        if dirty:
+            self.content_generation += 1
+        self.committed = dict(self.disk)
+        self.has_scanned = True
+        assert operation.update.content_generation == self.content_generation
+        assert operation.update.scan_revision == self.scan_revision
+
+    @precondition(lambda self: self.has_scanned)
+    @rule()
+    def never_reuses_the_committed_snapshot(self) -> None:
+        before = self._snapshot()
+        self.service.evidence("VALUE", self.root, refresh="never")
+        after = self._snapshot()
+        assert after.content_generation == before.content_generation
+        assert after.scan_revision == before.scan_revision
+        assert {file.path: file.text for file in after.files} == {
+            file.path: file.text for file in before.files
+        }
+
+    @precondition(lambda self: self.has_scanned and self.disk == self.committed)
+    @rule()
+    def retrieval_fingerprint_change_has_minimal_scope(self) -> None:
+        self.fingerprint_revision += 1
+        self.scanner.fingerprints = replace(
+            self.scanner.fingerprints,
+            retrieval=stable_fingerprint(
+                "state-machine-retrieval",
+                {"revision": self.fingerprint_revision},
+            ),
+        )
+        operation = self.service.scan(self.root)
+        self.scan_revision += 1
+        assert operation.result.stats.content_reads == 0
+        assert operation.result.stats.parsed_files == 0
+        assert operation.update.content_generation == self.content_generation
+        assert operation.update.scan_revision == self.scan_revision
+
+    @precondition(lambda self: self.has_scanned)
+    @rule()
+    def stale_scan_commit_is_rejected(self) -> None:
+        snapshot = self._snapshot()
+        stale = self.scanner.scan(
+            self.root,
+            cached_files={file.path: file for file in snapshot.files},
+            trusted_cache=False,
+            base_generation=snapshot.content_generation,
+            base_scan_revision=snapshot.scan_revision,
+            refresh_mode="always",
+        )
+        dirty = self.disk != self.committed
+        competing = self.service.scan(self.root, refresh="always")
+        self.scan_revision += 1
+        if dirty:
+            self.content_generation += 1
+        self.committed = dict(self.disk)
+        with RepositoryIndex.open(self.root) as index:
+            try:
+                index.update(stale)
+            except StaleScanError:
+                pass
+            else:  # pragma: no cover - state machine safety assertion
+                raise AssertionError("stale scan commit unexpectedly succeeded")
+        assert competing.update.content_generation == self.content_generation
+        assert competing.update.scan_revision == self.scan_revision
+
+    @invariant()
+    def sqlite_matches_the_reference_model(self) -> None:
+        snapshot = self._snapshot()
+        assert snapshot.content_generation == self.content_generation
+        assert snapshot.scan_revision == self.scan_revision
+        if not self.has_scanned:
+            assert snapshot.files == ()
+            return
+        indexed = {file.path: file for file in snapshot.files if not file.stale}
+        assert set(indexed) == set(self.committed)
+        for path, content in self.committed.items():
+            assert indexed[path].sha256 == hashlib.sha256(content.encode()).hexdigest()
+            assert indexed[path].text == content
+
+    def _snapshot(self):  # type: ignore[no-untyped-def]
+        with RepositoryIndex.open(self.root) as index:
+            return index.snapshot()
+
+    def teardown(self) -> None:
+        self.temporary.cleanup()
+
+
+TestIndexRevisionStateMachine = IndexRevisionStateMachine.TestCase

--- a/tests/test_parser_validation.py
+++ b/tests/test_parser_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -99,14 +100,27 @@ def test_parser_postconditions_reject_unsafe_or_inconsistent_facts(
         )
 
 
-def test_scanner_accepts_crlf_source_without_weakening_bare_cr_controls(tmp_path: Path) -> None:
-    (tmp_path / "value.py").write_bytes(b"VALUE = 1\r\n")
+def test_scanner_normalizes_parser_newlines_without_changing_raw_digests(
+    tmp_path: Path,
+) -> None:
+    lf = b"VALUE = 1\n"
+    crlf = b"VALUE = 1\r\n"
+    (tmp_path / "lf.py").write_bytes(lf)
+    (tmp_path / "crlf.py").write_bytes(crlf)
 
     result = RepositoryScanner().scan(tmp_path)
+    files = {file.path: file for file in result.files}
 
-    assert [file.path for file in result.files] == ["value.py"]
+    assert set(files) == {"crlf.py", "lf.py"}
     assert result.stats.skipped.get("parse_error", 0) == 0
-    assert result.files[0].chunks[0].content == "VALUE = 1\r\n"
+    assert files["lf.py"].size_bytes == len(lf)
+    assert files["crlf.py"].size_bytes == len(crlf)
+    assert files["lf.py"].sha256 == hashlib.sha256(lf).hexdigest()
+    assert files["crlf.py"].sha256 == hashlib.sha256(crlf).hexdigest()
+    assert files["lf.py"].sha256 != files["crlf.py"].sha256
+    assert files["lf.py"].text == files["crlf.py"].text == "VALUE = 1\n"
+    assert files["lf.py"].chunks[0].content == "VALUE = 1\n"
+    assert files["crlf.py"].chunks[0].content == "VALUE = 1\n"
 
 
 def test_per_file_fact_limits_fail_closed_before_indexing() -> None:

--- a/tests/test_parser_validation.py
+++ b/tests/test_parser_validation.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repolocus.models import Chunk, Dependency, Symbol
+from repolocus.parsers import ParseResult, ParserRegistry
+from repolocus.scanner import RepositoryScanner
+from repolocus.scanner.validation import ParseLimits, finalize_parse_result
+
+
+def _limits(**overrides: int) -> ParseLimits:
+    values = {
+        "max_chunk_lines": 160,
+        "max_chunk_chars": 16_000,
+        "max_dependencies_per_file": 10_000,
+        "max_symbols_per_file": 10_000,
+        "max_chunks_per_file": 10_000,
+    }
+    values.update(overrides)
+    return ParseLimits(**values)
+
+
+def test_empty_plugin_chunks_use_bounded_semantic_chunking_for_near_megabyte_source() -> None:
+    text = "".join(f"{index:06d}:" + ("x" * 993) for index in range(1_000))
+
+    normalized, counts = finalize_parse_result(
+        ParseResult(),
+        text=text,
+        path="large.py",
+        language="python",
+        limits=_limits(),
+    )
+
+    assert len(text) == 1_000_000
+    assert counts.chunks == len(normalized.chunks)
+    assert len(normalized.chunks) > 1
+    assert all(chunk.end_line - chunk.start_line + 1 <= 160 for chunk in normalized.chunks)
+    assert all(len(chunk.content) <= 16_000 for chunk in normalized.chunks)
+
+
+def test_empty_plugin_chunk_fallback_stops_at_the_per_file_chunk_limit() -> None:
+    with pytest.raises(ValueError, match="configured chunk limit"):
+        finalize_parse_result(
+            ParseResult(),
+            text="x" * 100_000,
+            path="large.py",
+            language="python",
+            limits=_limits(max_chunk_chars=1, max_chunks_per_file=2),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parsed", "message"),
+    [
+        (
+            ParseResult(symbols=(Symbol("bad\u202e", "function", "a.py", 1, 1),)),
+            "unsafe controls",
+        ),
+        (
+            ParseResult(symbols=(Symbol("name", "function", "a.py", 0, 1),)),
+            "invalid symbol source range",
+        ),
+        (
+            ParseResult(dependencies=(Dependency("a.py", "x" * 1_025, "import", 1),)),
+            "oversized dependency target",
+        ),
+        (
+            ParseResult(chunks=(Chunk("a.py", 1, 1, "not in source", "python"),)),
+            "not present",
+        ),
+        (
+            ParseResult(
+                chunks=(
+                    Chunk("a.py", 1, 2, "one\ntwo\n", "python"),
+                    Chunk("a.py", 2, 3, "two\nthree\n", "python"),
+                )
+            ),
+            "partially overlapping",
+        ),
+        (
+            ParseResult(chunks=(Chunk("a.py", 1, 1, "one\r", "python"),)),
+            "unsafe controls",
+        ),
+    ],
+)
+def test_parser_postconditions_reject_unsafe_or_inconsistent_facts(
+    parsed: ParseResult,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        finalize_parse_result(
+            parsed,
+            text="one\ntwo\nthree\n",
+            path="a.py",
+            language="python",
+            limits=_limits(),
+        )
+
+
+def test_scanner_accepts_crlf_source_without_weakening_bare_cr_controls(tmp_path: Path) -> None:
+    (tmp_path / "value.py").write_bytes(b"VALUE = 1\r\n")
+
+    result = RepositoryScanner().scan(tmp_path)
+
+    assert [file.path for file in result.files] == ["value.py"]
+    assert result.stats.skipped.get("parse_error", 0) == 0
+    assert result.files[0].chunks[0].content == "VALUE = 1\r\n"
+
+
+def test_per_file_fact_limits_fail_closed_before_indexing() -> None:
+    dependencies = tuple(
+        Dependency("a.py", f"dependency-{index}", "import", 1) for index in range(3)
+    )
+
+    with pytest.raises(ValueError, match="per-file safety limit"):
+        finalize_parse_result(
+            ParseResult(dependencies=dependencies),
+            text="value = 1\n",
+            path="a.py",
+            language="python",
+            limits=_limits(max_dependencies_per_file=2),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "fact", "limit_name"),
+    [
+        ("symbols", Symbol("value", "variable", "a.py", 1, 1), "max_symbols_per_file"),
+        (
+            "dependencies",
+            Dependency("a.py", "target", "import", 1),
+            "max_dependencies_per_file",
+        ),
+        ("chunks", Chunk("a.py", 1, 1, "value = 1\n", "python"), "max_chunks_per_file"),
+    ],
+)
+def test_unbounded_plugin_fact_iterables_stop_at_the_per_file_limit(
+    field: str,
+    fact: object,
+    limit_name: str,
+) -> None:
+    class InfiniteFacts:
+        def __init__(self) -> None:
+            self.emitted = 0
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            while True:
+                self.emitted += 1
+                yield fact
+
+    emitted = InfiniteFacts()
+    values: dict[str, object] = {
+        "symbols": (),
+        "dependencies": (),
+        "chunks": (),
+    }
+    values[field] = emitted
+    parsed = ParseResult(**values)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="per-file safety limit"):
+        finalize_parse_result(
+            parsed,
+            text="value = 1\n",
+            path="a.py",
+            language="python",
+            limits=_limits(**{limit_name: 2}),
+        )
+
+    assert emitted.emitted == 3
+
+
+def test_finite_generator_facts_are_normalized_without_full_materialization() -> None:
+    symbols = (Symbol(name, "variable", "a.py", 1, 1) for name in ("first", "second"))
+
+    normalized, counts = finalize_parse_result(
+        ParseResult(symbols=symbols),  # type: ignore[arg-type]
+        text="value = 1\n",
+        path="a.py",
+        language="python",
+        limits=_limits(max_symbols_per_file=2),
+    )
+
+    assert counts.symbols == 2
+    assert [symbol.name for symbol in normalized.symbols] == ["first", "second"]
+
+
+def test_non_iterable_plugin_fact_collection_fails_closed() -> None:
+    with pytest.raises(ValueError, match="facts must be iterable"):
+        finalize_parse_result(
+            ParseResult(symbols=object()),  # type: ignore[arg-type]
+            text="value = 1\n",
+            path="a.py",
+            language="python",
+            limits=_limits(),
+        )
+
+
+def test_validation_failure_does_not_consume_repository_fact_budget(tmp_path: Path) -> None:
+    class FailingThenValidParser:
+        languages = frozenset({"python"})
+        cache_key = "test-transactional-budget:v1"
+        priority = 0
+
+        def parse(
+            self,
+            path: str,
+            text: str,
+            language: str,
+            *,
+            max_chunk_lines: int,
+            max_chunk_chars: int,
+        ) -> ParseResult:
+            del text, language, max_chunk_lines, max_chunk_chars
+            start_line = 0 if path == "a.py" else 1
+            return ParseResult(
+                symbols=(Symbol("value", "variable", path, start_line, 1),),
+            )
+
+    (tmp_path / "a.py").write_text("a = 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("b = 2\n", encoding="utf-8")
+    registry = ParserRegistry()
+    registry.register(FailingThenValidParser())
+
+    result = RepositoryScanner(
+        parser_registry=registry,
+        max_repository_symbols=1,
+    ).scan(tmp_path)
+
+    assert [file.path for file in result.files] == ["b.py"]
+    assert result.stats.skipped["parse_error"] == 1
+    assert len(result.files[0].symbols) == 1
+
+
+def test_repository_dependency_budget_is_enforced(tmp_path: Path) -> None:
+    class DependencyParser:
+        languages = frozenset({"python"})
+        cache_key = "test-dependency-budget:v1"
+        priority = 0
+
+        def parse(
+            self,
+            path: str,
+            text: str,
+            language: str,
+            *,
+            max_chunk_lines: int,
+            max_chunk_chars: int,
+        ) -> ParseResult:
+            del text, language, max_chunk_lines, max_chunk_chars
+            return ParseResult(
+                dependencies=(Dependency(path, "target", "import", 1),),
+            )
+
+    (tmp_path / "a.py").write_text("a = 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("b = 2\n", encoding="utf-8")
+    registry = ParserRegistry()
+    registry.register(DependencyParser())
+
+    result = RepositoryScanner(
+        parser_registry=registry,
+        max_repository_dependencies=1,
+    ).scan(tmp_path)
+
+    assert [file.path for file in result.files] == ["a.py"]
+    assert result.stats.skipped["repository_budget"] == 1
+    assert any("dependency count" in warning for warning in result.warnings)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -221,6 +221,8 @@ def test_registry_is_deterministic_and_supports_plugins() -> None:
     @dataclass(frozen=True)
     class CustomParser:
         languages = frozenset({"custom"})
+        cache_key = "test-custom:v1"
+        priority = 0
 
         def parse(
             self,

--- a/tests/test_privacy_locking.py
+++ b/tests/test_privacy_locking.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+from pathlib import Path
+
+from repolocus.security import PrivacyStore, canonical_endpoint
+
+
+def _grant_worker(
+    state_path: str,
+    root: str,
+    provider: str,
+    endpoint: str,
+    start: multiprocessing.synchronize.Event,
+) -> None:
+    start.wait(10)
+    PrivacyStore(state_path).grant(root, provider, endpoint)
+
+
+def _revoke_worker(
+    state_path: str,
+    root: str,
+    start: multiprocessing.synchronize.Event,
+) -> None:
+    start.wait(10)
+    PrivacyStore(state_path).revoke(root)
+
+
+def _crash_with_lock(
+    state_path: str,
+    ready: multiprocessing.synchronize.Event,
+) -> None:
+    store = PrivacyStore(state_path)
+    with store._locked_state():
+        ready.set()
+        os._exit(0)
+
+
+def _join(process: multiprocessing.Process) -> None:
+    process.join(15)
+    if process.is_alive():
+        process.terminate()
+        process.join(5)
+        raise AssertionError("privacy lock worker deadlocked")
+    assert process.exitcode == 0
+
+
+def test_cross_process_grants_preserve_both_providers(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    root = tmp_path / "repository"
+    root.mkdir()
+    state_path = tmp_path / "state" / "privacy.json"
+    start = context.Event()
+    workers = [
+        context.Process(
+            target=_grant_worker,
+            args=(
+                str(state_path),
+                str(root),
+                "openai",
+                "https://api.openai.com/v1/chat/completions",
+                start,
+            ),
+        ),
+        context.Process(
+            target=_grant_worker,
+            args=(
+                str(state_path),
+                str(root),
+                "anthropic",
+                "https://api.anthropic.com/v1/messages",
+                start,
+            ),
+        ),
+    ]
+    for worker in workers:
+        worker.start()
+    start.set()
+    for worker in workers:
+        _join(worker)
+
+    assert PrivacyStore(state_path).grant_details(root) == {
+        "anthropic": (canonical_endpoint("https://api.anthropic.com/v1/messages"),),
+        "openai": (canonical_endpoint("https://api.openai.com/v1/chat/completions"),),
+    }
+
+
+def test_cross_process_grant_and_revoke_are_serializable(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    root = tmp_path / "repository"
+    root.mkdir()
+    state_path = tmp_path / "state" / "privacy.json"
+    store = PrivacyStore(state_path)
+    store.grant(root, "openai", "https://api.openai.com/v1/chat/completions")
+    start = context.Event()
+    grant = context.Process(
+        target=_grant_worker,
+        args=(
+            str(state_path),
+            str(root),
+            "anthropic",
+            "https://api.anthropic.com/v1/messages",
+            start,
+        ),
+    )
+    revoke = context.Process(
+        target=_revoke_worker,
+        args=(str(state_path), str(root), start),
+    )
+    grant.start()
+    revoke.start()
+    start.set()
+    _join(grant)
+    _join(revoke)
+
+    details = store.grant_details(root)
+    assert details in (
+        {},
+        {"anthropic": (canonical_endpoint("https://api.anthropic.com/v1/messages"),)},
+    )
+
+
+def test_process_exit_releases_privacy_lock(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    state_path = tmp_path / "state" / "privacy.json"
+    ready = context.Event()
+    worker = context.Process(target=_crash_with_lock, args=(str(state_path), ready))
+    worker.start()
+    assert ready.wait(10)
+    _join(worker)
+
+    root = tmp_path / "repository"
+    root.mkdir()
+    store = PrivacyStore(state_path)
+    store.grant(root, "openai", "https://api.openai.com/v1/chat/completions")
+    assert store.status(root) == {"openai": True}

--- a/tests/test_proxy_policy.py
+++ b/tests/test_proxy_policy.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from repolocus.config import ConfigError, Settings
+from repolocus.core import PrivacyRequiredError, RepoLocusService
+from repolocus.providers import (
+    OpenAICompatibleProvider,
+    ProviderTransport,
+    build_provider_transport,
+    create_provider,
+    proxy_transport,
+)
+from repolocus.security import PrivacyStore
+
+
+def test_default_transport_ignores_malicious_proxy_environment() -> None:
+    route = build_provider_transport(
+        Settings(),
+        "https://api.openai.com/v1/chat/completions",
+        environ={
+            "HTTPS_PROXY": "https://attacker.invalid:8443",
+            "ALL_PROXY": "https://other-attacker.invalid:9443",
+        },
+    )
+
+    assert Settings().trust_env is False
+    assert route.mode == "direct"
+    assert route.policy == "disabled"
+    assert route.proxy_url is None
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        (("invalid", "direct", "0" * 64), "policy"),
+        (("disabled", "invalid", "0" * 64), "mode"),
+        (("disabled", "direct", "short"), "SHA-256"),
+        (("disabled", "direct", "g" * 64), "SHA-256"),
+        (
+            (
+                "disabled",
+                "direct",
+                "0" * 64,
+                "https://proxy.example.com:443",
+                "https://proxy.example.com:443",
+            ),
+            "direct transport",
+        ),
+        (("explicit", "proxy", "0" * 64), "proxy transport"),
+    ],
+)
+def test_transport_model_rejects_inconsistent_routes(
+    arguments: tuple[object, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        ProviderTransport(*arguments)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("proxy_url", "message"),
+    [
+        ("", "non-empty"),
+        ("https://proxy.example.com\n", "control"),
+        ("https://proxy.example.com:99999", "invalid port"),
+        ("socks5://proxy.example.com", "absolute http"),
+        ("https://proxy.example.com/path", "path"),
+        ("https://./", "hostname"),
+    ],
+)
+def test_proxy_url_validation_fails_closed(proxy_url: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        proxy_transport("explicit", proxy_url)
+
+
+def test_proxy_url_canonicalizes_ipv6_and_username_without_leaking_to_preview() -> None:
+    ipv6 = proxy_transport("explicit", "https://[2001:0db8::1]")
+    username = proxy_transport("explicit", "http://alice@Proxy.Example./")
+
+    assert ipv6.proxy_url == "https://[2001:db8::1]:443"
+    assert ipv6.preview()["proxy"] == "https://[2001:db8::1]:443"
+    assert username.proxy_url == "http://alice@proxy.example:80"
+    assert username.preview()["proxy"] == "http://proxy.example:80"
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "no_proxy", "expected_mode"),
+    [
+        ("https://api.openai.com/v1", "*", "direct"),
+        ("https://api.openai.com/v1", "https://api.openai.com:443", "direct"),
+        ("https://api.openai.com/v1", "api.openai.com:444", "proxy"),
+        ("https://api.openai.com/v1", ", api.openai.com:notaport", "proxy"),
+        ("https://192.0.2.5/v1", "192.0.2.0/24", "direct"),
+        ("https://[2001:db8::1]/v1", "2001:db8::/32", "direct"),
+    ],
+)
+def test_environment_no_proxy_matching_is_explicit_and_bounded(
+    endpoint: str,
+    no_proxy: str,
+    expected_mode: str,
+) -> None:
+    route = build_provider_transport(
+        Settings(proxy_mode="environment"),
+        endpoint,
+        environ={
+            "NO_PROXY": no_proxy,
+            "ALL_PROXY": "https://proxy.example.com:8443",
+        },
+    )
+
+    assert route.mode == expected_mode
+
+
+def test_environment_policy_without_proxy_is_direct_and_invalid_policy_fails() -> None:
+    direct = build_provider_transport(
+        Settings(proxy_mode="environment"),
+        "https://api.openai.com/v1",
+        environ={},
+    )
+    assert direct.mode == "direct"
+    assert direct.policy == "environment"
+
+    invalid = SimpleNamespace(proxy_mode="invalid", proxy_url="")
+    with pytest.raises(ValueError, match="proxy_mode"):
+        build_provider_transport(  # type: ignore[arg-type]
+            invalid,
+            "https://api.openai.com/v1",
+            environ={},
+        )
+
+
+def test_provider_client_disables_ambient_proxy_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.providers import http as provider_http
+
+    original_client = httpx.Client
+    client_options: list[dict[str, object]] = []
+
+    def client(**options: object) -> httpx.Client:
+        client_options.append(dict(options))
+        options["transport"] = httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "safe"}}]},
+            )
+        )
+        return original_client(**options)  # type: ignore[arg-type]
+
+    monkeypatch.setenv("HTTPS_PROXY", "https://attacker.invalid:8443")
+    monkeypatch.setattr(provider_http.httpx, "Client", client)
+    provider = OpenAICompatibleProvider(
+        "test-model",
+        environ={"OPENAI_API_KEY": "test-key"},
+    )
+
+    assert provider.generate("system", "question") == "safe"
+    assert client_options == [
+        {
+            "timeout": httpx.Timeout(30.0),
+            "transport": None,
+            "trust_env": False,
+        }
+    ]
+
+
+def test_provider_client_uses_only_the_frozen_environment_proxy_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from repolocus.providers import http as provider_http
+
+    endpoint = "https://api.openai.com/v1/chat/completions"
+    route = build_provider_transport(
+        Settings(proxy_mode="environment"),
+        endpoint,
+        environ={"HTTPS_PROXY": "https://proxy.example.com:8443"},
+    )
+    original_client = httpx.Client
+    client_options: list[dict[str, object]] = []
+
+    def client(**options: object) -> httpx.Client:
+        client_options.append(dict(options))
+        options.pop("proxy", None)
+        options["transport"] = httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "safe"}}]},
+            )
+        )
+        return original_client(**options)  # type: ignore[arg-type]
+
+    monkeypatch.setenv("HTTPS_PROXY", "https://attacker.invalid:9443")
+    monkeypatch.setattr(provider_http.httpx, "Client", client)
+    provider = OpenAICompatibleProvider(
+        "test-model",
+        environ={"OPENAI_API_KEY": "test-key"},
+        transport_route=route,
+    )
+
+    assert provider.generate("system", "question") == "safe"
+    assert client_options[0]["trust_env"] is False
+    assert client_options[0]["proxy"] == "https://proxy.example.com:8443"
+
+
+def test_environment_proxy_route_is_explicitly_enabled_and_credential_free_in_preview() -> None:
+    secret = "proxy-password-do-not-display"
+    route = build_provider_transport(
+        Settings(proxy_mode="environment"),
+        "https://api.openai.com/v1/chat/completions",
+        environ={"https_proxy": f"https://alice:{secret}@proxy.example.com:8443"},
+    )
+
+    assert route.mode == "proxy"
+    assert route.policy == "environment"
+    assert route.preview() == {
+        "mode": "proxy",
+        "policy": "environment",
+        "proxy": "https://proxy.example.com:8443",
+    }
+    assert secret not in repr(route)
+    assert secret not in str(route.preview())
+    assert secret in (route.proxy_url or "")
+
+
+def test_proxy_mode_and_endpoint_change_transport_identity_without_binding_credentials() -> None:
+    endpoint = "https://api.openai.com/v1/chat/completions"
+    explicit = build_provider_transport(
+        Settings(
+            proxy_mode="explicit",
+            proxy_url="https://alice:first@proxy.example.com:8443",
+        ),
+        endpoint,
+    )
+    changed_credential = build_provider_transport(
+        Settings(
+            proxy_mode="explicit",
+            proxy_url="https://alice:second@proxy.example.com:8443",
+        ),
+        endpoint,
+    )
+    environment = build_provider_transport(
+        Settings(proxy_mode="environment"),
+        endpoint,
+        environ={"HTTPS_PROXY": "https://alice:first@proxy.example.com:8443"},
+    )
+    changed_endpoint = build_provider_transport(
+        Settings(
+            proxy_mode="explicit",
+            proxy_url="https://alice:first@other-proxy.example.com:8443",
+        ),
+        endpoint,
+    )
+
+    assert explicit.identity == changed_credential.identity
+    assert len({explicit.identity, environment.identity, changed_endpoint.identity}) == 3
+    assert explicit.preview()["proxy"] == changed_credential.preview()["proxy"]
+
+
+def test_no_proxy_and_loopback_ollama_force_direct_routes() -> None:
+    environment = Settings(proxy_mode="environment")
+    bypassed = build_provider_transport(
+        environment,
+        "https://api.openai.com/v1/chat/completions",
+        environ={
+            "HTTPS_PROXY": "https://proxy.example.com:8443",
+            "NO_PROXY": ".openai.com",
+        },
+    )
+    loopback = build_provider_transport(
+        Settings(
+            proxy_mode="explicit",
+            proxy_url="https://proxy.example.com:8443",
+        ),
+        "http://127.0.0.1:11434/api/chat",
+    )
+
+    assert bypassed.mode == "direct"
+    assert bypassed.policy == "environment"
+    assert loopback.mode == "direct"
+    assert loopback.policy == "explicit"
+
+
+def test_injected_transport_remains_usable_with_an_explicit_proxy_policy() -> None:
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "safe"}}]},
+        )
+
+    provider = create_provider(
+        "openai/test-model",
+        Settings(
+            proxy_mode="explicit",
+            proxy_url="https://user:secret@proxy.example.com:8443",
+        ),
+        environ={"OPENAI_API_KEY": "test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert provider.generate("system", "question") == "safe"
+    assert len(captured) == 1
+    assert provider.transport_route.mode == "proxy"  # type: ignore[attr-defined]
+
+
+def test_proxy_route_is_bound_to_preview_and_remembered_consent(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    state_path = isolated_user_dirs / "privacy.json"
+    first_settings = Settings(
+        model="openai/test-model",
+        proxy_mode="explicit",
+        proxy_url="https://alice:first@proxy.example.com:8443",
+    )
+    first_service = RepoLocusService(
+        first_settings,
+        privacy=PrivacyStore(state_path),
+    )
+    prepared, _operation = first_service.prepare_ask(
+        "Where is load_config defined?",
+        sample_repo,
+    )
+    assert prepared.transport is not None
+    assert prepared.preview.to_dict()["transport"] == {
+        "mode": "proxy",
+        "policy": "explicit",
+        "proxy": "https://proxy.example.com:8443",
+    }
+    first_service.privacy.grant(
+        sample_repo,
+        prepared.consent_scope,
+        prepared.endpoint,
+        transport_identity=prepared.transport.identity,
+        transport=prepared.transport.preview(),
+    )
+
+    changed_credentials = RepoLocusService(
+        Settings(
+            model="openai/test-model",
+            proxy_mode="explicit",
+            proxy_url="https://alice:second@proxy.example.com:8443",
+        ),
+        privacy=PrivacyStore(state_path),
+    )
+    changed_credentials_route = changed_credentials.consent_transport("openai/test-model")
+    assert changed_credentials_route is not None
+    assert changed_credentials.privacy.is_allowed(
+        sample_repo,
+        prepared.consent_scope,
+        prepared.endpoint,
+        transport_identity=changed_credentials_route.identity,
+    )
+
+    changed = RepoLocusService(
+        Settings(
+            model="openai/test-model",
+            proxy_mode="explicit",
+            proxy_url="https://alice:first@other-proxy.example.com:8443",
+        ),
+        privacy=PrivacyStore(state_path),
+    )
+    with pytest.raises(PrivacyRequiredError):
+        changed.ask("Where is load_config defined?", sample_repo)
+
+    raw_state = state_path.read_text(encoding="utf-8")
+    assert "first" not in raw_state
+    assert "alice" not in raw_state
+    assert "proxy.example.com:8443" in raw_state
+
+
+def test_user_proxy_config_is_allowed_but_repository_proxy_config_is_rejected(
+    tmp_path: Path,
+) -> None:
+    user_config = tmp_path / "user.toml"
+    user_config.write_text(
+        'proxy_mode = "explicit"\nproxy_url = "https://proxy.example.com:8443"\n',
+        encoding="utf-8",
+    )
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    repository_config = repository / ".repolocus.toml"
+    repository_config.write_text('proxy_mode = "environment"\n', encoding="utf-8")
+
+    configured = Settings.load(user_config_path=user_config, environ={})
+    assert configured.proxy_mode == "explicit"
+    assert configured.proxy_url == "https://proxy.example.com:8443"
+
+    with pytest.raises(ConfigError, match="repository config cannot set 'proxy_mode'"):
+        Settings.load(
+            repository,
+            user_config_path=user_config,
+            environ={},
+        )

--- a/tests/test_refresh_semantics.py
+++ b/tests/test_refresh_semantics.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from repolocus.analysis import AnalysisFingerprints, stable_fingerprint
+from repolocus.config import Settings
+from repolocus.core import RepoLocusService
+from repolocus.index import RepositoryIndex, StaleScanError
+from repolocus.models import Symbol
+from repolocus.parsers import ParseResult, ParserRegistry
+from repolocus.scanner import RepositoryScanner
+from repolocus.security import PrivacyStore
+
+
+def _service(
+    root: Path,
+    state: Path,
+    scanner: RepositoryScanner | None = None,
+) -> RepoLocusService:
+    return RepoLocusService(
+        Settings(model="local"),
+        scanner=scanner,
+        privacy=PrivacyStore(state / "privacy.json"),
+    )
+
+
+def test_unchanged_auto_cache_hit_reads_no_content_and_opens_no_update_transaction(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service(sample_repo, isolated_user_dirs)
+    first = service.scan(sample_repo)
+
+    def unexpected_update(_index: RepositoryIndex, _scan) -> None:  # type: ignore[no-untyped-def]
+        raise AssertionError("an exact auto cache hit must not open the fact update transaction")
+
+    monkeypatch.setattr(RepositoryIndex, "update", unexpected_update)
+    second = service.scan(sample_repo, refresh="auto")
+
+    assert second.result.stats.content_reads == 0
+    assert second.result.stats.parsed_files == 0
+    assert second.update.content_generation == first.update.content_generation
+    assert second.update.scan_revision == first.update.scan_revision
+
+
+def test_auto_cache_hit_reads_metadata_and_files_from_one_sqlite_snapshot(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    source = repository / "value.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    service = _service(repository, isolated_user_dirs)
+    first = service.scan(repository)
+    source.write_text("VALUE = 2\n", encoding="utf-8")
+
+    with (
+        RepositoryIndex.open(repository) as reader,
+        RepositoryIndex.open(repository) as writer,
+    ):
+        snapshot = reader.snapshot()
+        candidate = service.scanner.scan(
+            repository,
+            cached_files={file.path: file for file in snapshot.files},
+            trusted_cache=False,
+            base_generation=snapshot.content_generation,
+            base_scan_revision=snapshot.scan_revision,
+            refresh_mode="auto",
+        )
+        # Exercise the cache-hit read path with a candidate that matches the
+        # competing commit. Without one read transaction, metadata can come
+        # from the old snapshot while file rows come from the new snapshot.
+        candidate.stats.content_reads = 0
+        candidate.stats.parsed_files = 0
+        original_get_metadata = reader.get_metadata
+        competing_updates = []
+
+        def commit_between_metadata_and_file_reads() -> dict[str, str]:
+            metadata = original_get_metadata()
+            if not competing_updates:
+                competing_updates.append(writer.update(candidate))
+            return metadata
+
+        monkeypatch.setattr(reader, "get_metadata", commit_between_metadata_and_file_reads)
+
+        cache_hit = reader.auto_cache_hit(candidate)
+
+    assert cache_hit is None
+    assert competing_updates[0].content_generation == first.update.content_generation + 1
+
+
+def test_auto_cache_hit_validates_scan_root_and_rechecks_repository_identity(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    service = _service(repository, isolated_user_dirs)
+    service.scan(repository)
+
+    with RepositoryIndex.open(repository) as index:
+        snapshot = index.snapshot()
+        candidate = service.scanner.scan(
+            repository,
+            cached_files={file.path: file for file in snapshot.files},
+            trusted_cache=True,
+            base_generation=snapshot.content_generation,
+            base_scan_revision=snapshot.scan_revision,
+            refresh_mode="auto",
+        )
+        foreign = tmp_path / "foreign"
+        foreign.mkdir()
+        with pytest.raises(ValueError, match="does not match index root"):
+            index.auto_cache_hit(replace(candidate, root=foreign))
+        with pytest.raises(StaleScanError, match="identity changed"):
+            index.auto_cache_hit(replace(candidate, repository_identity="0" * 64))
+
+        original_get_metadata = index.get_metadata
+        detached = tmp_path / "detached-repository"
+        replaced = False
+
+        def replace_root_after_metadata_read() -> dict[str, str]:
+            nonlocal replaced
+            metadata = original_get_metadata()
+            if not replaced:
+                replaced = True
+                repository.rename(detached)
+                repository.mkdir()
+                (repository / "new.py").write_text("NEW = 1\n", encoding="utf-8")
+            return metadata
+
+        monkeypatch.setattr(index, "get_metadata", replace_root_after_metadata_read)
+
+        with pytest.raises(StaleScanError, match="identity changed"):
+            index.auto_cache_hit(candidate)
+
+
+def test_always_reads_every_supported_file_without_invalidating_content(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    service = _service(sample_repo, isolated_user_dirs)
+    first = service.scan(sample_repo)
+
+    refreshed = service.scan(sample_repo, refresh="always")
+
+    assert refreshed.result.stats.content_reads == refreshed.result.stats.indexed_files
+    assert refreshed.result.stats.parsed_files == 0
+    assert refreshed.update.content_generation == first.update.content_generation
+    assert refreshed.update.scan_revision == first.update.scan_revision + 1
+
+
+def test_rebuild_reinvokes_parser_even_when_source_hash_is_unchanged(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    class CountingParser:
+        languages = frozenset({"python"})
+        cache_key = "test-rebuild-count:v1"
+        priority = 0
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def parse(
+            self,
+            path: str,
+            text: str,
+            language: str,
+            *,
+            max_chunk_lines: int,
+            max_chunk_chars: int,
+        ) -> ParseResult:
+            del path, text, language, max_chunk_lines, max_chunk_chars
+            self.calls += 1
+            return ParseResult()
+
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    parser = CountingParser()
+    registry = ParserRegistry()
+    registry.register(parser)
+    service = _service(
+        repository,
+        isolated_user_dirs,
+        RepositoryScanner(parser_registry=registry),
+    )
+    first = service.scan(repository)
+
+    rebuilt = service.scan(repository, refresh="rebuild")
+
+    assert parser.calls == 2
+    assert rebuilt.result.stats.content_reads == 1
+    assert rebuilt.result.stats.parsed_files == 1
+    assert rebuilt.update.content_generation == first.update.content_generation
+    assert rebuilt.update.scan_revision == first.update.scan_revision + 1
+
+
+def test_multiple_changed_files_advance_content_generation_once(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    first_path = repository / "a.py"
+    second_path = repository / "b.py"
+    first_path.write_text("A = 1\n", encoding="utf-8")
+    second_path.write_text("B = 1\n", encoding="utf-8")
+    service = _service(repository, isolated_user_dirs)
+    first = service.scan(repository)
+    first_path.write_text("A = 2\n", encoding="utf-8")
+    second_path.write_text("B = 2\n", encoding="utf-8")
+
+    changed = service.scan(repository)
+
+    assert changed.update.changed == 2
+    assert changed.update.content_generation == first.update.content_generation + 1
+    assert changed.update.scan_revision == first.update.scan_revision + 1
+
+
+def test_diagnostic_change_advances_only_scan_revision(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    class DiagnosticScanner(RepositoryScanner):
+        add_warning = False
+
+        def scan(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            result = super().scan(*args, **kwargs)
+            if self.add_warning:
+                result.warnings.append("diagnostic changed")
+            return result
+
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    scanner = DiagnosticScanner()
+    service = _service(repository, isolated_user_dirs, scanner)
+    first = service.scan(repository)
+    scanner.add_warning = True
+
+    diagnostic = service.scan(repository)
+
+    assert diagnostic.result.stats.content_reads == 0
+    assert diagnostic.update.content_generation == first.update.content_generation
+    assert diagnostic.update.scan_revision == first.update.scan_revision + 1
+
+
+def test_scan_revision_cas_rejects_stale_commit_even_when_content_is_unchanged(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    scanner = RepositoryScanner()
+    service = _service(repository, isolated_user_dirs, scanner)
+    service.scan(repository)
+    with RepositoryIndex.open(repository) as index:
+        snapshot = index.snapshot()
+    stale = scanner.scan(
+        repository,
+        cached_files={file.path: file for file in snapshot.files},
+        trusted_cache=False,
+        base_generation=snapshot.content_generation,
+        base_scan_revision=snapshot.scan_revision,
+        refresh_mode="always",
+    )
+    competing = service.scan(repository, refresh="always")
+
+    with RepositoryIndex.open(repository) as index:
+        with pytest.raises(StaleScanError, match="scan revision"):
+            index.update(stale)
+        current = index.snapshot()
+    assert current.scan_revision == competing.update.scan_revision
+    assert current.content_generation == competing.update.content_generation
+
+
+class _EmptyParser:
+    priority = 0
+
+    def __init__(self, language: str, cache_key: str, calls: list[str] | None = None) -> None:
+        self.languages = frozenset({language})
+        self.cache_key = cache_key
+        self.calls = calls
+
+    def parse(
+        self,
+        path: str,
+        text: str,
+        language: str,
+        *,
+        max_chunk_lines: int,
+        max_chunk_chars: int,
+    ) -> ParseResult:
+        del text, language, max_chunk_lines, max_chunk_chars
+        if self.calls is not None:
+            self.calls.append(path)
+        return ParseResult()
+
+
+def test_parser_manifest_and_fingerprint_ignore_registration_and_dict_order() -> None:
+    first = ParserRegistry()
+    first.register(_EmptyParser("python", "python-test:v1"))
+    first.register(_EmptyParser("go", "go-test:v1"))
+    second = ParserRegistry()
+    second.register(_EmptyParser("go", "go-test:v1"))
+    second.register(_EmptyParser("python", "python-test:v1"))
+
+    assert first.cache_manifest() == second.cache_manifest()
+    assert stable_fingerprint("test", {"b": 2, "a": 1}) == stable_fingerprint(
+        "test", {"a": 1, "b": 2}
+    )
+
+
+def test_component_fingerprint_validation_fails_closed() -> None:
+    with pytest.raises(ValueError, match="component must not be empty"):
+        stable_fingerprint("", {})
+    with pytest.raises(ValueError, match="SHA-256"):
+        AnalysisFingerprints("short", "0" * 64, "0" * 64, "0" * 64)
+    with pytest.raises(ValueError, match="SHA-256"):
+        AnalysisFingerprints("g" * 64, "0" * 64, "0" * 64, "0" * 64)
+    with pytest.raises(ValueError, match="incomplete"):
+        AnalysisFingerprints.from_metadata({"scan_fingerprint": "0" * 64})
+
+
+def test_parser_cache_key_change_reparses_but_preserves_equal_content_facts(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    first_registry = ParserRegistry()
+    first_registry.register(_EmptyParser("python", "python-test:v1"))
+    first_service = _service(
+        repository,
+        isolated_user_dirs,
+        RepositoryScanner(parser_registry=first_registry),
+    )
+    first = first_service.scan(repository)
+    calls: list[str] = []
+    second_registry = ParserRegistry()
+    second_registry.register(_EmptyParser("python", "python-test:v2", calls))
+    second_service = _service(
+        repository,
+        isolated_user_dirs,
+        RepositoryScanner(parser_registry=second_registry),
+    )
+
+    reparsed = second_service.scan(repository)
+
+    assert calls == ["value.py"]
+    assert reparsed.result.stats.content_reads == 1
+    assert reparsed.result.stats.parsed_files == 1
+    assert reparsed.update.content_generation == first.update.content_generation
+    assert reparsed.update.scan_revision == first.update.scan_revision + 1
+
+
+def test_scanner_freezes_parser_selection_and_cache_identity_at_construction(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+) -> None:
+    class SymbolParser:
+        languages = frozenset({"python"})
+        priority = 0
+
+        def __init__(self, cache_key: str, symbol: str) -> None:
+            self.cache_key = cache_key
+            self.symbol = symbol
+            self.calls = 0
+
+        def parse(
+            self,
+            path: str,
+            text: str,
+            language: str,
+            *,
+            max_chunk_lines: int,
+            max_chunk_chars: int,
+        ) -> ParseResult:
+            del text, language, max_chunk_lines, max_chunk_chars
+            self.calls += 1
+            return ParseResult(symbols=(Symbol(self.symbol, "variable", path, 1, 1),))
+
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    original = SymbolParser("symbol-parser:v1", "ORIGINAL")
+    replacement = SymbolParser("symbol-parser:v2", "REPLACEMENT")
+    registry = ParserRegistry()
+    registry.register(original)
+    scanner = RepositoryScanner(parser_registry=registry)
+    frozen_manifest = scanner.parser_registry.cache_manifest()
+    registry.register(replacement, replace=True)
+
+    with pytest.raises(RuntimeError, match="frozen parser registry"):
+        scanner.parser_registry.register(replacement, replace=True)
+    service = _service(repository, isolated_user_dirs, scanner)
+    first = service.scan(repository)
+    second = service.scan(repository)
+    with RepositoryIndex.open(repository) as index:
+        symbols = [symbol.name for symbol in index.get_symbols()]
+
+    assert scanner.parser_registry.cache_manifest() == frozen_manifest
+    assert original.calls == 1
+    assert replacement.calls == 0
+    assert symbols == ["ORIGINAL"]
+    assert second.update.content_generation == first.update.content_generation
+
+    original.cache_key = "symbol-parser:mutated"
+    with pytest.raises(RuntimeError, match="frozen parser changed its cache identity"):
+        service.scan(repository)
+
+
+def test_component_changes_invalidate_only_their_minimal_scope(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    initial_service = _service(repository, isolated_user_dirs)
+    initial = initial_service.scan(repository)
+
+    scan_scanner = RepositoryScanner()
+    scan_scanner.fingerprints = replace(
+        scan_scanner.fingerprints,
+        scan=stable_fingerprint("scan-test", {"version": 2}),
+    )
+    scan_only = _service(repository, isolated_user_dirs, scan_scanner).scan(repository)
+    assert scan_only.result.stats.content_reads == 1
+    assert scan_only.result.stats.parsed_files == 0
+    assert scan_only.update.content_generation == initial.update.content_generation
+
+    term_scanner = RepositoryScanner()
+    term_scanner.fingerprints = replace(
+        scan_scanner.fingerprints,
+        term_index=stable_fingerprint("term-test", {"version": 2}),
+    )
+    term_only = _service(repository, isolated_user_dirs, term_scanner).scan(repository)
+    assert term_only.result.stats.content_reads == 0
+    assert term_only.result.stats.parsed_files == 0
+    assert term_only.update.content_generation == scan_only.update.content_generation + 1
+
+    retrieval_scanner = RepositoryScanner()
+    retrieval_scanner.fingerprints = replace(
+        term_scanner.fingerprints,
+        retrieval=stable_fingerprint("retrieval-test", {"version": 2}),
+    )
+
+    def unexpected_term_rebuild(_index: RepositoryIndex) -> None:
+        raise AssertionError("retrieval-only changes must not rebuild term facts")
+
+    monkeypatch.setattr(RepositoryIndex, "_rebuild_chunk_terms", unexpected_term_rebuild)
+    retrieval_only = _service(repository, isolated_user_dirs, retrieval_scanner).scan(repository)
+    assert retrieval_only.result.stats.content_reads == 0
+    assert retrieval_only.result.stats.parsed_files == 0
+    assert retrieval_only.update.content_generation == term_only.update.content_generation

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -440,6 +440,7 @@ def test_empty_directory_deadline_is_checked_after_enumeration(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from repolocus.scanner import budget as scanner_budget
     from repolocus.scanner import repository as scanner_repository
 
     now = [0.0]
@@ -457,7 +458,7 @@ def test_empty_directory_deadline_is_checked_after_enumeration(
             now[0] = 2.0
             return result
 
-    monkeypatch.setattr(scanner_repository, "monotonic", lambda: now[0])
+    monkeypatch.setattr(scanner_budget, "monotonic", lambda: now[0])
     monkeypatch.setattr(scanner_repository.os, "scandir", TimedScandir)
 
     result = RepositoryScanner(max_scan_seconds=1).scan(tmp_path)
@@ -479,6 +480,8 @@ def test_directory_rollback_preserves_a_global_budget_diagnostic(
 
     class ChangeAfterSecondParse:
         languages = frozenset({"python"})
+        cache_key = "test-change-after-parse:v1"
+        priority = 0
 
         def __init__(self) -> None:
             self.calls = 0
@@ -764,6 +767,8 @@ def test_invalid_gitignore_fails_closed_without_scanning_siblings(tmp_path: Path
 def test_parse_plugin_failure_isolated_to_one_file(tmp_path: Path) -> None:
     class BrokenParser:
         languages = frozenset({"python"})
+        cache_key = "test-broken:v1"
+        priority = 0
 
         def parse(self, *args: object, **kwargs: object) -> ParseResult:
             raise RuntimeError("repository content must not escape through errors")
@@ -783,6 +788,8 @@ def test_parse_plugin_failure_isolated_to_one_file(tmp_path: Path) -> None:
 def test_parser_cannot_fabricate_source_ranges_or_content(tmp_path: Path) -> None:
     class FabricatingParser:
         languages = frozenset({"python"})
+        cache_key = "test-fabricating:v1"
+        priority = 0
 
         def parse(self, *args: object, **kwargs: object) -> ParseResult:
             return ParseResult(chunks=(Chunk("one.py", 99, 100, "fabricated", "python"),))
@@ -800,6 +807,8 @@ def test_parser_cannot_fabricate_source_ranges_or_content(tmp_path: Path) -> Non
 def test_unchanged_files_reuse_versioned_parser_results(tmp_path: Path) -> None:
     class CountingParser:
         languages = frozenset({"python"})
+        cache_key = "test-counting:v1"
+        priority = 0
 
         def __init__(self) -> None:
             self.calls = 0
@@ -925,11 +934,11 @@ def test_scan_wall_clock_deadline_marks_the_repository_incomplete(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from repolocus.scanner import repository as scanner_repository
+    from repolocus.scanner import budget as scanner_budget
 
     _write(tmp_path, "one.py", "VALUE = 1\n")
     readings = iter((10.0, 12.0))
-    monkeypatch.setattr(scanner_repository, "monotonic", lambda: next(readings))
+    monkeypatch.setattr(scanner_budget, "monotonic", lambda: next(readings))
 
     result = RepositoryScanner(max_scan_seconds=1).scan(tmp_path)
 
@@ -941,6 +950,8 @@ def test_scan_wall_clock_deadline_marks_the_repository_incomplete(
 def test_stale_cached_file_is_never_reused(tmp_path: Path) -> None:
     class CountingParser:
         languages = frozenset({"python"})
+        cache_key = "test-counting-stale:v1"
+        priority = 0
 
         def __init__(self) -> None:
             self.calls = 0

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24,6 +24,8 @@ class RecordingScanner(RepositoryScanner):
     def __init__(self, *, analysis_version: str = "service-test") -> None:
         super().__init__(analysis_version=analysis_version)
         self.calls: list[tuple[int | None, tuple[str, ...]]] = []
+        self.scan_revisions: list[int | None] = []
+        self.refresh_modes: list[str] = []
 
     def scan(
         self,
@@ -32,13 +34,19 @@ class RecordingScanner(RepositoryScanner):
         cached_files: Mapping[str, ScannedFile] | None = None,
         trusted_cache: bool = False,
         base_generation: int | None = None,
+        base_scan_revision: int | None = None,
+        refresh_mode: str = "auto",
     ) -> ScanResult:
         self.calls.append((base_generation, tuple(sorted((cached_files or {}).keys()))))
+        self.scan_revisions.append(base_scan_revision)
+        self.refresh_modes.append(refresh_mode)
         return super().scan(
             root,
             cached_files=cached_files,
             trusted_cache=trusted_cache,
             base_generation=base_generation,
+            base_scan_revision=base_scan_revision,
+            refresh_mode=refresh_mode,
         )
 
 
@@ -137,7 +145,9 @@ def test_scan_seeds_cache_and_cas_from_one_index_snapshot(
     assert scanner.calls[0] == (0, ())
     assert scanner.calls[1][0] == first.update.generation
     assert "src/demo/config.py" in scanner.calls[1][1]
-    assert second.update.generation == first.update.generation + 1
+    assert scanner.scan_revisions == [0, first.update.scan_revision]
+    assert second.update.generation == first.update.generation
+    assert second.update.scan_revision == first.update.scan_revision
     assert second.update.unchanged == first.result.stats.indexed_files
 
 
@@ -170,7 +180,101 @@ def test_scan_retries_an_unpinned_stale_generation(
     assert len(scanner.calls) == 2
     assert scanner.calls[0][0] == 0
     assert scanner.calls[1][0] == 1
-    assert operation.update.generation == 2
+    assert scanner.scan_revisions == [0, 1]
+    assert operation.update.generation == 1
+    assert operation.update.scan_revision == 1
+
+
+def test_pinned_scan_retries_scan_revision_only_conflicts(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = RecordingScanner()
+    service = RepoLocusService(
+        Settings(model="local"),
+        scanner=scanner,
+        privacy=PrivacyStore(isolated_user_dirs / "privacy.json"),
+    )
+    initial = service.scan(sample_repo)
+    original_update = RepositoryIndex.update
+    first_call = True
+
+    def commit_then_report_stale(index: RepositoryIndex, result: ScanResult):
+        nonlocal first_call
+        update = original_update(index, result)
+        if first_call:
+            first_call = False
+            raise StaleScanError("simulated scan-revision-only conflict")
+        return update
+
+    monkeypatch.setattr(RepositoryIndex, "update", commit_then_report_stale)
+
+    operation = service.scan(
+        sample_repo,
+        refresh="always",
+        expected_generation=initial.update.content_generation,
+    )
+
+    assert len(scanner.calls) == 3
+    assert operation.update.content_generation == initial.update.content_generation
+    assert operation.update.scan_revision == initial.update.scan_revision + 2
+
+
+def test_pinned_scan_does_not_retry_when_content_generation_changes(
+    tmp_path: Path,
+    isolated_user_dirs: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    source = repository / "value.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    scanner = RecordingScanner()
+    service = RepoLocusService(
+        Settings(model="local"),
+        scanner=scanner,
+        privacy=PrivacyStore(isolated_user_dirs / "privacy.json"),
+    )
+    initial = service.scan(repository)
+    original_update = RepositoryIndex.update
+    first_call = True
+
+    def commit_changed_content_then_report_stale(
+        index: RepositoryIndex,
+        result: ScanResult,
+    ):
+        nonlocal first_call
+        if not first_call:
+            return original_update(index, result)
+        first_call = False
+        source.write_text("VALUE = 2\n", encoding="utf-8")
+        snapshot = index.snapshot()
+        competing = RepositoryScanner().scan(
+            repository,
+            cached_files={file.path: file for file in snapshot.files},
+            trusted_cache=False,
+            base_generation=snapshot.content_generation,
+            base_scan_revision=snapshot.scan_revision,
+            refresh_mode="always",
+        )
+        original_update(index, competing)
+        raise StaleScanError("simulated content-generation conflict")
+
+    monkeypatch.setattr(
+        RepositoryIndex,
+        "update",
+        commit_changed_content_then_report_stale,
+    )
+
+    with pytest.raises(StaleScanError, match="expected index generation"):
+        service.scan(
+            repository,
+            refresh="always",
+            expected_generation=initial.update.content_generation,
+        )
+
+    assert len(scanner.calls) == 2
 
 
 def test_refresh_modes_are_shared_by_generation_and_question_workflows(
@@ -189,6 +293,7 @@ def test_refresh_modes_are_shared_by_generation_and_question_workflows(
 
     _project_map, auto = service.map(sample_repo, refresh="auto")
     generation = auto.update.generation
+    scan_revision = auto.update.scan_revision
     assert len(scanner.calls) == 1
 
     service.diagram(sample_repo, refresh="never", expected_generation=generation)
@@ -220,15 +325,18 @@ def test_refresh_modes_are_shared_by_generation_and_question_workflows(
 
     _refreshed_map, refreshed = service.map(sample_repo, refresh="always")
     assert len(scanner.calls) == 2
-    assert refreshed.update.generation == generation + 1
+    assert scanner.refresh_modes[-1] == "always"
+    assert refreshed.update.generation == generation
+    assert refreshed.update.scan_revision == scan_revision + 1
 
+    service.ask(
+        "Where is load_config defined?",
+        sample_repo,
+        refresh="never",
+        expected_generation=generation,
+    )
     with pytest.raises(StaleScanError, match="expected index generation"):
-        service.ask(
-            "Where is load_config defined?",
-            sample_repo,
-            refresh="never",
-            expected_generation=generation,
-        )
+        service.ask("question", sample_repo, refresh="never", expected_generation=generation + 1)
     with pytest.raises(ValueError, match="refresh must be one of"):
         service.map(sample_repo, refresh="sometimes")  # type: ignore[arg-type]
 
@@ -341,7 +449,9 @@ def test_auto_refresh_scans_even_when_committed_snapshot_is_empty(
     _document, cached = service.map(repository, refresh="auto")
 
     assert len(scanner.calls) == 2
-    assert cached.update.generation == first.update.generation + 1
+    assert first.update.generation == 0
+    assert cached.update.generation == first.update.generation
+    assert cached.update.scan_revision == first.update.scan_revision
 
 
 def test_auto_refresh_observes_edits_while_never_is_explicit_snapshot_reuse(
@@ -479,7 +589,7 @@ def test_cloud_send_uses_the_exact_evidence_shown_in_preview(
 
     monkeypatch.setattr(
         "repolocus.core.service.create_provider",
-        lambda model, settings: FakeProvider(),
+        lambda model, settings, **_kwargs: FakeProvider(),
     )
     service = _service(sample_repo, isolated_user_dirs, model="openai/test-model")
     config = sample_repo / "src" / "demo" / "config.py"

--- a/tests/test_skill_adapter.py
+++ b/tests/test_skill_adapter.py
@@ -312,7 +312,7 @@ def test_runtime_probe_validates_module_origin_and_compatible_version(
         "run",
         lambda *args, **kwargs: SimpleNamespace(
             returncode=0,
-            stdout=json.dumps({"origin": str(origin), "version": "0.1.4"}),
+            stdout=json.dumps({"origin": str(origin), "version": "0.1.5"}),
             stderr="",
         ),
     )
@@ -327,11 +327,11 @@ def test_runtime_probe_validates_module_origin_and_compatible_version(
     )
 
     assert runtime.origin == origin.resolve()
-    assert runtime.version == "0.1.4"
+    assert runtime.version == "0.1.5"
     assert runtime.prefix[-2:] == ("-m", "repolocus")
 
 
-@pytest.mark.parametrize("version", ["0.1.1", "0.1.2", "0.1.3", "0.2.0", "not-a-version"])
+@pytest.mark.parametrize("version", ["0.1.1", "0.1.2", "0.1.3", "0.1.4", "0.2.0", "not-a-version"])
 def test_runtime_probe_rejects_incompatible_versions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: str
 ) -> None:
@@ -350,7 +350,7 @@ def test_runtime_probe_rejects_incompatible_versions(
         ),
     )
 
-    with pytest.raises(adapter.AdapterError, match=r"requires >=0\.1\.4,<0\.2\.0"):
+    with pytest.raises(adapter.AdapterError, match=r"requires >=0\.1\.5,<0\.2\.0"):
         adapter._probe_runtime(
             [str(tmp_path / "python"), "-I"],
             environment={},

--- a/tests/test_toml_standard.py
+++ b/tests/test_toml_standard.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from repolocus import config as config_module
+from repolocus.config import Settings
+
+
+def test_standard_toml_parser_handles_strings_arrays_dates_comments_and_nested_tables(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "standard.toml"
+    parsed = config_module._parse_config(
+        b"""
+title = "hash # stays in string" # real comment
+values = [1, 2, 3]
+created = 2026-08-06
+
+[outer.inner]
+enabled = true
+names = ["alpha", "beta"]
+""",
+        path,
+        source="user",
+    )
+
+    assert parsed["title"] == "hash # stays in string"
+    assert parsed["values"] == [1, 2, 3]
+    assert parsed["created"] == date(2026, 8, 6)
+    assert parsed["outer"] == {"inner": {"enabled": True, "names": ["alpha", "beta"]}}
+
+
+def test_standard_nested_toml_table_feeds_query_synonyms_consistently(tmp_path: Path) -> None:
+    user_config = tmp_path / "config.toml"
+    user_config.write_text(
+        """
+[query_synonyms]
+build = ["compile", "link"] # standard TOML array
+""",
+        encoding="utf-8",
+    )
+
+    settings = Settings.load(user_config_path=user_config, environ={})
+
+    assert settings.query_synonym_map == {"build": ("compile", "link")}
+
+
+def test_pyproject_accepts_standard_quoted_table_keys(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool."repolocus"]\nmax_file_bytes = 123456\n',
+        encoding="utf-8",
+    )
+
+    settings = Settings.load(
+        tmp_path,
+        environ={},
+        user_config_path=tmp_path / "missing.toml",
+    )
+
+    assert settings.max_file_bytes == 123_456

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ACTION = re.compile(r"^\s*(?:-\s*)?uses:\s*([^#\s]+)(?:\s+#\s+(\S+))?\s*$", re.MULTILINE)
+_FULL_SHA = re.compile(r"[0-9a-f]{40}")
+_READABLE_VERSION = re.compile(r"v\d+(?:\.\d+){0,2}")
+_UV_VERSION = "0.9.18"
+
+
+def _repository() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workflow(name: str) -> str:
+    return (_repository() / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def test_third_party_actions_are_pinned_with_readable_versions() -> None:
+    for name in ("ci.yml", "release.yml"):
+        references = _ACTION.findall(_workflow(name))
+        assert references
+        for reference, readable_version in references:
+            if reference.startswith("./"):
+                continue
+            action, separator, revision = reference.rpartition("@")
+            assert action and separator
+            assert _FULL_SHA.fullmatch(revision), reference
+            assert _READABLE_VERSION.fullmatch(readable_version), reference
+
+
+def test_ci_and_release_use_the_same_exact_uv_version() -> None:
+    workflows = [_workflow("ci.yml"), _workflow("release.yml")]
+    setup_count = sum(workflow.count("uses: astral-sh/setup-uv@") for workflow in workflows)
+    pinned_version_count = sum(
+        workflow.count(f'version: "{_UV_VERSION}"') for workflow in workflows
+    )
+
+    assert setup_count > 0
+    assert pinned_version_count == setup_count
+
+
+def test_external_evaluation_blocks_packaging() -> None:
+    workflow = _workflow("ci.yml")
+
+    assert "external-evaluation:" in workflow
+    assert "scripts/evaluate_external_repositories.py evaluation" in workflow
+    assert "--minimum-citation-recall 1.0" in workflow
+    assert "needs: [test, coverage, security, external-evaluation]" in workflow
+    assert "if: ${{ always() }}" in workflow
+    assert "EVALUATION_RESULT: ${{ needs.external-evaluation.result }}" in workflow
+    assert 'if [[ "$result" != "success" ]]' in workflow
+    assert 'python-version: ["3.10", "3.12", "3.14"]' in workflow
+
+
+def test_release_attests_and_verifies_every_asset_before_publish() -> None:
+    workflow = _workflow("release.yml")
+
+    assert "scripts/evaluate_external_repositories.py evaluation" in workflow
+    assert "--minimum-citation-recall 1.0" in workflow
+    assert "repolocus-${PROJECT_VERSION}.external-evaluation.json" in workflow
+    assert "attestations: write" in workflow
+    assert "subject-path: release-assets/*" in workflow
+    assert "verify-provenance:" in workflow
+    assert "sha256sum -c SHA256SUMS" in workflow
+    assert 'gh attestation verify "$asset" --repo "$GITHUB_REPOSITORY"' in workflow
+    assert "needs: [build, verify-provenance]" in workflow
+    assert "repolocus doctor --security --json" in workflow
+
+
+def test_dependabot_updates_github_actions() -> None:
+    configuration = (_repository() / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+
+    assert "version: 2" in configuration
+    assert "package-ecosystem: github-actions" in configuration
+    assert "interval: weekly" in configuration
+
+
+def test_build_backend_is_exactly_pinned() -> None:
+    configuration = (_repository() / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'requires = ["hatchling==1.31.0"]' in configuration

--- a/uv.lock
+++ b/uv.lock
@@ -233,6 +233,79 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.165.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/73/fc3743243603dc49911a1ec073a3a524ea8e1c7d48218d3c2a3faa9a8709/hypothesis-6.165.2.tar.gz", hash = "sha256:680a1adf523ac792b46064f425b112ce6c08a7a8f50e65d08e029de6aa11df95", size = 502277, upload-time = "2026-08-05T21:32:43.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/63/46c9908fe7bd5ffa5002fa88fe289dfe6d3cea3fad1ab8942fe11f1c8a2b/hypothesis-6.165.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:33a7303566e660664f3f02ea1df85f7b966cd6723165c696996cfd8630913b3a", size = 781704, upload-time = "2026-08-05T21:32:03.548Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/7f/fdce62542a514f6b33c4fc0a760e6d17bb57602b28cb079b78e55b8ea32d/hypothesis-6.165.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:06d8fe4c82a935f67e610c99848360f5caeb04f547c7d7a830a5c74fb96f053a", size = 777243, upload-time = "2026-08-05T21:32:17.546Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c8/39cd922bf3e1ec84977b768d4e8be31ae051e3a6b400b4fdd7ebcddb1eed/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de2e3f6a6f75c876be481138c6c0802ebe10deef9f13ce1cdd6e0ed21d8e1e28", size = 1106492, upload-time = "2026-08-05T21:31:47.844Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/91/7bb502379a8dcc43f2538530c05cf16fd4e386afa587d65cc289484425cf/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:21668cb5a8a694d45ff4c43f20a8fc577a47467b5102c680a43638b027136368", size = 1135105, upload-time = "2026-08-05T21:31:49.453Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/04/4ce8ae1bf78d09d7543ab7037a3beedc7f3d963c7aa04e82842415284689/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea4ab5cfdd6c6a23a60777559ea06c34868234fff6542ff6125c0250429348e", size = 1156034, upload-time = "2026-08-05T21:31:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/49/de/b074d899f4a04fa8b99a5bbd66f209c1c02bc21f9f87404539b28b99aff0/hypothesis-6.165.2-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:0a6add02d9b3b73b59f4d69f5b15abbc07113cd335cc140815cec2877e6b496c", size = 1111344, upload-time = "2026-08-05T21:32:27.211Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/38/5a8514683a181f82a8ad9f6d084b704fea7a97c9814033939fc493b55fca/hypothesis-6.165.2-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:11013896b6a2ed497079558cb9f89e8b3b564f8859782b38f72cfc1dbeca66ad", size = 1148115, upload-time = "2026-08-05T21:31:01.009Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c7/08cf7930d8bec7f1df971c948af2ccb5a402d5b8b19b306af655a603b180/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ceabc69a95e761f381663c6452537fde12a2a6e0275e095b6822c0e0f3b1364", size = 1280321, upload-time = "2026-08-05T21:31:14.843Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/91/c9ebb7da3b6e06c47aecceb959cf7df6af75025663af543373c5692f97ac/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:11e1ce261765ffa6acbaf540358426519ca4a5e46b825cf39b429c77c1895689", size = 1408134, upload-time = "2026-08-05T21:31:27.383Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/24/13c2fd9f253ba3a92d4aaa61ae45a8b130df57ab5bd6fc481e2aae520e36/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b0250099b2e55d72872319918aacc501110a182938a3d56bcae4a999bee5db08", size = 1280884, upload-time = "2026-08-05T21:32:00.188Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fa/2820bdbe0660394544b9e120b03ea7020702d7fa5c76236166de6ababc9d/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:96d02928d1a0b7d59e39fd8ada75f0b7d0377ff29f91c94109f92fc2dab9af74", size = 1322998, upload-time = "2026-08-05T21:31:24.373Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/24/38752794eb821f5c77da08523602003c344f3498fce09f20741cd5b5e29c/hypothesis-6.165.2-cp310-abi3-win32.whl", hash = "sha256:0f2044093c8244d73893e755a7fa53154b7eca57b37e1427d9b0d9948f6c2b3e", size = 667506, upload-time = "2026-08-05T21:32:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/71/b28f714a127017750e450d152aa4fbff51bd144c6840090d28b529b408d3/hypothesis-6.165.2-cp310-abi3-win_amd64.whl", hash = "sha256:2aa30716066e5ee7750e56b8f90cefaf4ed28c12b4b1d66cef40014fd3f95196", size = 673650, upload-time = "2026-08-05T21:31:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a3/73083b49b3a58746ece612b338965502a25b37c6ec827db3a6c69281594d/hypothesis-6.165.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:5cc5c019d9b4f6acc5f55b1a6f8e6472f70e6a5891deee4d4581263bb0f9f8ca", size = 782416, upload-time = "2026-08-05T21:32:25.269Z" },
+    { url = "https://files.pythonhosted.org/packages/80/15/1a623f0119477df8d7f7ccbf8a6046f9d5cb2b73744ebc534f20f8e63de5/hypothesis-6.165.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fff6ff4d566570e2169911deb0b0c90a69e5407a1f6d6e075d618fff5f143807", size = 778151, upload-time = "2026-08-05T21:31:03.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/45/dc65446c62fef1f3d28772965aecdb5b6ef8c8b1a5725fbc1ea6656d024d/hypothesis-6.165.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5610a61bd1bdb1324f706e130febfdde22ade385583582364e5b6ce7e42263b", size = 1107016, upload-time = "2026-08-05T21:31:07.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/65/0b3a098f41e684422d89d0c1f3bd9674283e48b65fd3bc7d22bb2377af70/hypothesis-6.165.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e43bf234fd9b3c9f0e364e16048902c47b0e93e69e5f7bc4e05fd6c4da01d6ed", size = 1156537, upload-time = "2026-08-05T21:31:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d3/dff6ba121b4f2cd36f796bbbf1eb89fa76977e8c859d14aaeae7420e80ee/hypothesis-6.165.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b68184d0a9398a36758750f750212a143fca3a8887377ce793cdfb68428bf357", size = 1280965, upload-time = "2026-08-05T21:31:16.257Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f2/a9740494900837a49f14849f68062a553a50fdaf76326f4c8f6acb07fb87/hypothesis-6.165.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:232a481e1b4311bc35ff76d48617db6745ea4ae882ac73145b5bc7d76c20bbfd", size = 1323309, upload-time = "2026-08-05T21:32:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d1/6f8fbc556d684faed9c1eb5b843c3756ab9e4b430d93e0a7b74b266c5d53/hypothesis-6.165.2-cp310-cp310-win_amd64.whl", hash = "sha256:d58de7af449bcd38b35eef8084ea73b37848951f34b7e15345739554af58ceb1", size = 673531, upload-time = "2026-08-05T21:31:34.27Z" },
+    { url = "https://files.pythonhosted.org/packages/67/43/ba4e9140480326c517e46f6d16fb2efd423a579f4f50ff79d0326226c563/hypothesis-6.165.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a49889d19484ccfe1977f448a9c0ad27078232a707fa9f9c8667e9d7ffbe792d", size = 782176, upload-time = "2026-08-05T21:32:08.821Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/10/f0ed8d6906a959f015bb6140413e5be7965ff50f965478316cc3a7469254/hypothesis-6.165.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:67560ca111bcad4e07dc8390a499d9b5c6b5488bab0b3c801a4c31a02238e199", size = 777969, upload-time = "2026-08-05T21:32:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1e/137cc1cc254c4b00eb41ddebccf0a33cc2ad99f6bb531e68525c2561c475/hypothesis-6.165.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54e5afbdf7c973ced6984265a7ffbcdd3b072349c6e9f9d92af889a5af8d2a08", size = 1106856, upload-time = "2026-08-05T21:30:59.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/16/52e37b42dfa7579176aa9c8ada2f94eadcd27659b71c85fb477df0d57ad8/hypothesis-6.165.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3aed6b889f493d75b7f734e931d10dc003d7277af63956f8d2f131326aaf297", size = 1156324, upload-time = "2026-08-05T21:31:51.917Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/467ccd787de1cd77c9a23b963580bbe0ec00e8163ee0df224b3bfcbc2c94/hypothesis-6.165.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:929e47581a4a20b81a67deecd48f6589151fada7c23a418d8505c4595de14577", size = 1280680, upload-time = "2026-08-05T21:31:32.452Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9b/6edfb53334df96a0889978374a115fbc1569ffdef7786fe256ed71aa72a1/hypothesis-6.165.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:020a889e548e81514132fe215cca664ee3961a8d1343262c2aa6ea7e5f31370a", size = 1323331, upload-time = "2026-08-05T21:31:13.393Z" },
+    { url = "https://files.pythonhosted.org/packages/67/83/92a460ee8811360b5f95cc547d6f43e632457be0bd1a28e497c84e46fa7a/hypothesis-6.165.2-cp311-cp311-win_amd64.whl", hash = "sha256:1bd8955bd5dd72bb9bd6f7243cef8a2bf8a264e23edbd29eecebe41de9348eb9", size = 673376, upload-time = "2026-08-05T21:31:22.637Z" },
+    { url = "https://files.pythonhosted.org/packages/98/81/a9039e7eee38523e2ad13e9e4e70c508f25d4205fb4c6ceb98632547ca82/hypothesis-6.165.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b24f1b238deb97fda828a939931de3210f5cef21e87fe0b941fafbeb55ead676", size = 783294, upload-time = "2026-08-05T21:31:56.881Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e5/120642320291d8d117a83491d93527149ddbd15e56399274741fc4bd3a9a/hypothesis-6.165.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306763ce7186e08ee30dba409b320873d1afc54adf76b44c6bf83b5867d17359", size = 774867, upload-time = "2026-08-05T21:32:05.489Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ef/251607eb2446fb44e8faa83e30aa1b6cc281b6eca5d0ecaabe7527e3395d/hypothesis-6.165.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f878ebc5c33e4e8e8a90bd3d7ccc3f3a7370847aa22243536e673047f0f4c37", size = 1105307, upload-time = "2026-08-05T21:31:53.719Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f1/de30869d83f00137a664319a4acb0ba8b1a9e2c879afdc12abb1b4c703f7/hypothesis-6.165.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d726513b32cc6407667ac0812fa3517408f933b89b16b6b84f296335eec18432", size = 1155348, upload-time = "2026-08-05T21:31:58.536Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2c/8925c2bddf6e105d947a04511cd5d536eabc8d4ed926518a0d1672ede007/hypothesis-6.165.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a700c0e193707e3b6f1b23f1d5f534896dd9f79bb2a2340582579bad5f5b59a4", size = 1278124, upload-time = "2026-08-05T21:32:14.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/00/e285e7987e96d74e229fcb94c58dd8e85290966fc2040fbac4b081fc49c9/hypothesis-6.165.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:50d50e313dfff2e79c754b92a4c88c479dd9e102a56c60caa5b3d6263caa1b02", size = 1322340, upload-time = "2026-08-05T21:31:11.671Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7a/990e802222b3a88a284a872fc41339e39d8b619e5266aae45ef1c5da231a/hypothesis-6.165.2-cp312-cp312-win_amd64.whl", hash = "sha256:e2493b71a6e75dbd9ab33f8ab3920a6850a7965de55baf9725738a227ef3bfd2", size = 670805, upload-time = "2026-08-05T21:32:19.278Z" },
+    { url = "https://files.pythonhosted.org/packages/22/01/add18f19d5e5f084a59709f0dcebf3cb1edeca475ce8a31573dc33891e66/hypothesis-6.165.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e2bf15d05264ec9da8d55c3843902f906ced5e84fb3da924eafe165697ab4638", size = 783183, upload-time = "2026-08-05T21:31:55.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4b/df2e4c24d208518a6a3dab7acabad7f5ec6c5bb0f4d0bf1701d2fb7206ce/hypothesis-6.165.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3748153d4f64d347f8c988dd41fbef3513b66819e73e9209b1c501bf0d716a13", size = 774829, upload-time = "2026-08-05T21:32:01.891Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a0/b75a001efbde704ff2188924a4d4bb3cdf7a22924dc51c155115af64858c/hypothesis-6.165.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f689976e0eb578afbe8ce37669cb637f00f7c545ad303412947ee4abe2f29ce6", size = 1105224, upload-time = "2026-08-05T21:32:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f2/4942f510c6441b5d60dc7f0d8d2af74fe444b62d3af565bdf42d9b6b803d/hypothesis-6.165.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7c68a5684b2e2ad3c33500198a6073b3d04493fd7b1ef34937645ad092b797d", size = 1155166, upload-time = "2026-08-05T21:31:46.408Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/405ebff50c6949518d34f487017412d5b8f8ee9239e50ecdfdd99a745f4b/hypothesis-6.165.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b40db922ccb53fb77c68d944748a3eb5b945402967b64093d9ba970d028cf1af", size = 1278170, upload-time = "2026-08-05T21:31:43.116Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ff/93ad0f4b55100876604d2c316a8c6e0ee037cb0da925caaa478709e504b0/hypothesis-6.165.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d2fd48ec969b2dbe1c8e25dc86d199c6820b9222846469449b997f5546383378", size = 1322061, upload-time = "2026-08-05T21:32:07.217Z" },
+    { url = "https://files.pythonhosted.org/packages/14/37/14b655c664a957e44c7f59d9498e53d79b55f1b752a1bb38fee9da403e9c/hypothesis-6.165.2-cp313-cp313-win_amd64.whl", hash = "sha256:9cf13225121280036ea5a8ff8babb82ec27a4736aea669bbe0bc9839d254575f", size = 670824, upload-time = "2026-08-05T21:32:21.25Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ce/a2de75f1a12b6670edfca890794daab685a63ab1a2e36f28dc2c4d8e831d/hypothesis-6.165.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:66be9b848bdcb29132b18de6f574b89b392024c7de442acb393edaa1540cb548", size = 783398, upload-time = "2026-08-05T21:31:37.916Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/bf01b5f356f64a8af28be2718674e23ff7c0a4dbc5f476295be624b1a5ad/hypothesis-6.165.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e51742efe8466cf89e26cb94843db8854bd0673a6d80da7e3d1ff6bd9dc006db", size = 774963, upload-time = "2026-08-05T21:31:10.053Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4b/9ad06c5a5613b6d175a7fd1a518a9732bcc4772c0cb24f6d7e5fd63f7fed/hypothesis-6.165.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c648ee54cd734261e1615d80c2ebbd679d6dfbba6ef5aa672354c6ca62b6f446", size = 1105721, upload-time = "2026-08-05T21:32:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f1/04c8ebe621c8b832106859f9425f91d049a96ccf99c3501f2905f3e1291a/hypothesis-6.165.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:032292cbffc0743b2fe4337a30c21ea9703a70a0021d39bf0c3e68bce7baab18", size = 1155349, upload-time = "2026-08-05T21:31:39.636Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/23/41fe5e805638dcb6a1b70c147e909d254d9f09db5ade7a3e790c94ec926e/hypothesis-6.165.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5dc64171b06472f0b6c2e54bdc25687987e560e15133cf52f55d9ef4c747ebe1", size = 1278502, upload-time = "2026-08-05T21:32:23.405Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/54fdfc954314980d2b0eabbe57ef2960d85f3b1acb95f3326ff931ed349f/hypothesis-6.165.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e5a823ba918641af8177c121f122964d471db2ab1d07c1fe229c77b3a5ab7e8", size = 1322379, upload-time = "2026-08-05T21:31:05.39Z" },
+    { url = "https://files.pythonhosted.org/packages/68/db/3667633b31b2b423b320fec4b7ac154e74d6b4a122fadd8e06f9d9afbef1/hypothesis-6.165.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:70966ab7dbe0ea9644eaed8324e037f05ac6a8141646b977da9e77813dac6ed7", size = 614909, upload-time = "2026-08-05T21:31:41.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d9/0168c0d6ea32c195225b0673ee8cb7b61de6841d62c87d614d26add35770/hypothesis-6.165.2-cp314-cp314-win_amd64.whl", hash = "sha256:a5b913acd896f4f80597dd38966cd13984a1cfd45512498e8cf054aa7c92ffb9", size = 670684, upload-time = "2026-08-05T21:32:37.076Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e4/61cea938488b6958f07b8249bf37fcfb2802367e2a6af65afe82b05ca18c/hypothesis-6.165.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:6fa46589088966083ce653f908560cdd3330274cfafaaa65d1fb29b5f6681644", size = 781982, upload-time = "2026-08-05T21:32:15.899Z" },
+    { url = "https://files.pythonhosted.org/packages/15/73/b4f9ba3e4b988b567d887b0857962e841b227a81a02ea83ae520e2001c31/hypothesis-6.165.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6b5b922603879b4788447583928eb1cf2e1aafb9ce27f3a7234b7a4557d089a8", size = 773430, upload-time = "2026-08-05T21:31:28.913Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e2/6fb4a2edbc7775dfa4d3950e3537239c6d957eeb6c571275edfd79a2b981/hypothesis-6.165.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ab3a6b5bb3302f7dcd65b07dcdc0ca353c8c151567dffeda826977e765caaf9", size = 1104317, upload-time = "2026-08-05T21:30:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/06/9479b2acc58996ae18300becbaf910d7c542b5054a47ba05c28bdacd08f1/hypothesis-6.165.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09f1c626023b68968d2cc5fe1e31548109f4406d81a2c3017b3de9fdd3a02e7d", size = 1154232, upload-time = "2026-08-05T21:31:30.368Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9b/5b5cfce5445a807d042ca5a1a470606613835842d99488a199d994584cae/hypothesis-6.165.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5c95808ab851498513192268e25f40bccd1c3719384c91535bbec3eedea39760", size = 1276739, upload-time = "2026-08-05T21:32:12.324Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/aa/6a731776ccaee13dba0624a73f01935fa174f39647ad463a495dcb2206a8/hypothesis-6.165.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a1c8bec789f21dc10620ce99e15fcd4f7737b9b4cfa571cdd93e01a17b7b06b", size = 1321119, upload-time = "2026-08-05T21:31:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a1/5d2c7c1346a0089908a3974c9e40ce223c22dd291dfe5df69a8c8cc64b98/hypothesis-6.165.2-cp314-cp314t-win_amd64.whl", hash = "sha256:458c891dfc00133bc4ce2e6c9716838f80f2fd96caf306f5eef42ad02aa4d972", size = 670831, upload-time = "2026-08-05T21:31:17.998Z" },
+    { url = "https://files.pythonhosted.org/packages/35/51/745695dde335122e447dd8f762ee1c2f44d5f73dd3268a6df7f5d4339c1d/hypothesis-6.165.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:210955bdb78ce0e3279fd7ed47fa77fdd9f6004368a099c933c456f4c6ea358f", size = 783104, upload-time = "2026-08-05T21:31:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/8a/26f37eb2265ec3d6d59fcac7d93d554231ad2db7cef4e9e78113fa39ac36/hypothesis-6.165.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:024ddf78d150825210b4e41169ad1f3d40f8819bee0304890b851904d9f97541", size = 778956, upload-time = "2026-08-05T21:31:08.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ef/72d586c2c5094410569a4e62792f0069dc0b6113979dd7754e80d03a800b/hypothesis-6.165.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49e9aa39b21589e64b25ed8a452014fb546f2533cd5dbc0be16c35f94a4a9f6c", size = 1107828, upload-time = "2026-08-05T21:31:19.457Z" },
+    { url = "https://files.pythonhosted.org/packages/38/1b/292fd8f7552d624ed29abab7f17935009cae3de14e50991951a73cff2a25/hypothesis-6.165.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:568038c8c9de3b22087fe1536d8d512e23c5a5eca3aa4c692e8fa46592afa267", size = 1157603, upload-time = "2026-08-05T21:32:39.041Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/005eff3fba214bac14df88fdb78502d4990a135b128837dc826b215aa746/hypothesis-6.165.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:5a9c92f193b14bb0e69038cb4b31f3c0c7497cd3f2f43be5bb8a8fb6a036362d", size = 674478, upload-time = "2026-08-05T21:32:41.203Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -481,13 +554,14 @@ wheels = [
 
 [[package]]
 name = "repolocus"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typer" },
 ]
 
@@ -499,6 +573,7 @@ api = [
 dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -510,12 +585,14 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115,<1" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<1" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.112,<7" },
     { name = "pathspec", specifier = ">=0.12,<1" },
     { name = "platformdirs", specifier = ">=4.2,<5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5,<7" },
     { name = "rich", specifier = ">=13.7,<15" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6,<1" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2,<3" },
     { name = "typer", specifier = ">=0.12,<1" },
     { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.30,<1" },
 ]
@@ -566,6 +643,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- separate retrieval-visible `content_generation` from diagnostic `scan_revision`, and implement distinct `auto`, `always`, `never`, and `rebuild` refresh modes
- replace the manual analysis version with component fingerprints and parser cache identities
- normalize and budget parser facts, including bounded dependency output
- add descriptor-relative/handle-validated atomic generated-file writes with fail-closed race recovery
- make HTTP proxy transport explicit and bind the credential-free route to consent
- add Windows cross-process PrivacyStore locking and standard TOML parsing on Python 3.10
- add a six-repository/18-qrel synthetic retrieval release gate
- pin Actions/tooling and attest release assets with SLSA provenance

## Why

v0.1.5 closes the remaining refresh/cache semantics and generated-output/transport/parser boundaries before the v0.2 scalable evidence-index work begins.

## Verification

- [x] Local full suite: `481 passed, 3 skipped`.
- [x] Coverage: `85.21%` (minimum `85%`).
- [x] External retrieval gate: hit rate `1.0`, macro recall `1.0`, MRR `0.916667`, citation recall `1.0`, no-answer F1 `1.0`, must-not-return violation rate `0.0`.
- [x] Security doctor, Ruff, compileall, locked dependency check, wheel/sdist build, Twine, and actionlint pass locally.
- [x] GitHub CI run 31143652563 passes Linux, macOS, and native Windows 3.10/3.12/3.14, coverage, security, external evaluation, package install, and container build.
- [x] User-facing docs are updated.
- [x] No new read, write, execution, telemetry, or network permission is hidden.
- [x] Every commit includes a DCO sign-off.

The external implementation-plan Markdown remains outside the repository and is not part of this PR.