### PR TITLE
feat: add evidence-backed architecture diff

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -31,8 +31,11 @@ Mermaid diagram, symbol query, dependency-neighbor query, and fused retrieval. E
 is isolated in a fresh worker with an operation-level timeout and records wall time, CPU time,
 process peak RSS, application-issued SQLite statement count, database bytes, and WAL bytes.
 Absolute ceilings and relative SQLite-query regression limits live in the versioned manifest
-rather than being selected by the current CI run. Each checked-in baseline records the benchmark
-script hash and a deterministic digest of the measured RepoLocus implementation.
+rather than being selected by the current CI run. The checked-in manifests preserve the measured
+v0.2.0 reference baseline, including its benchmark-script hash and deterministic implementation
+digest. Every current CI/release run records its own version and implementation digest and compares
+its measurements with that historical reference; old measurements are never relabeled as a new
+baseline.
 
 ```bash
 uv run python benchmarks/benchmark_v020.py --manifest benchmarks/v0.2-gates.json

--- a/src/repolocus/cli.py
+++ b/src/repolocus/cli.py
@@ -26,6 +26,15 @@ from rich.text import Text
 from repolocus import __version__
 from repolocus.config import Settings
 from repolocus.core import PrivacyRequiredError, RepoLocusService
+from repolocus.diff import (
+    RepositorySnapshot,
+    compare_snapshots,
+    dumps_diff,
+    load_snapshot,
+    render_diff_markdown,
+    save_snapshot,
+    snapshot_from_index,
+)
 from repolocus.index import RepositoryIndex, cache_root, index_path_for
 from repolocus.models import Evidence
 from repolocus.security import (
@@ -57,6 +66,17 @@ RepoArgument = Annotated[
         help="Repository directory.",
         exists=True,
         file_okay=False,
+        dir_okay=True,
+        resolve_path=False,
+    ),
+]
+
+DiffArgument = Annotated[
+    Path,
+    typer.Argument(
+        help="Repository directory or immutable RepoLocus snapshot JSON.",
+        exists=True,
+        file_okay=True,
         dir_okay=True,
         resolve_path=False,
     ),
@@ -329,6 +349,121 @@ def status(
         str(data["scan_revision_detail"]),
     )
     console.print(table)
+
+
+def _require_refresh_mode(refresh: str, *, allow_never: bool) -> None:
+    modes = (
+        ("auto", "always", "never", "rebuild")
+        if allow_never
+        else (
+            "auto",
+            "always",
+            "rebuild",
+        )
+    )
+    if refresh not in modes:
+        supported = ", ".join(modes)
+        raise ValueError(f"refresh must be one of: {supported}")
+
+
+def _scan_snapshot(path: Path, refresh: str) -> RepositorySnapshot:
+    operation = _service(path).scan(path, refresh=refresh)  # type: ignore[arg-type]
+    with RepositoryIndex.open(path) as index:
+        return snapshot_from_index(
+            index,
+            expected_generation=operation.update.content_generation,
+        )
+
+
+def _existing_index_snapshot(path: Path) -> RepositorySnapshot:
+    database = index_path_for(path)
+    if database.is_symlink() or not database.is_file():
+        raise ValueError("no RepoLocus index exists for this repository")
+    with RepositoryIndex.open(path) as index:
+        return snapshot_from_index(index)
+
+
+@app.command("snapshot")
+def snapshot_command(
+    path: RepoArgument,
+    output: Annotated[
+        Path,
+        typer.Argument(
+            help="Destination for the immutable canonical snapshot JSON.",
+            resolve_path=False,
+        ),
+    ],
+    refresh: Annotated[
+        str,
+        typer.Option(
+            "--refresh",
+            help="Index refresh mode: auto, always, or rebuild.",
+        ),
+    ] = "auto",
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Replace an existing regular snapshot file."),
+    ] = False,
+) -> None:
+    """Capture one generation-pinned architecture snapshot without source text."""
+
+    try:
+        if path.is_symlink():
+            raise ValueError("repository path must not be a symbolic link")
+        root = path.resolve(strict=True)
+        _require_refresh_mode(refresh, allow_never=False)
+        snapshot = _scan_snapshot(root, refresh)
+        destination = save_snapshot(snapshot, output, overwrite=force)
+    except (OSError, ValueError, RuntimeError) as exc:
+        _fail(exc)
+    console.print(
+        f"Saved immutable snapshot to {escape_untrusted_display(str(destination))}.",
+        markup=False,
+        highlight=False,
+    )
+
+
+def _diff_snapshot(path: Path, refresh: str) -> RepositorySnapshot:
+    if path.is_symlink():
+        raise ValueError("diff input must not be a symbolic link")
+    candidate = path.resolve(strict=True)
+    if candidate.is_file():
+        return load_snapshot(candidate)
+    if not candidate.is_dir():
+        raise ValueError(f"diff input is neither a repository directory nor snapshot: {candidate}")
+    if refresh == "never":
+        return _existing_index_snapshot(candidate)
+    return _scan_snapshot(candidate, refresh)
+
+
+@app.command("diff")
+def diff_command(
+    old: DiffArgument,
+    new: DiffArgument,
+    json_output: Annotated[
+        bool, typer.Option("--json", help="Emit canonical machine-readable JSON.")
+    ] = False,
+    refresh: Annotated[
+        str,
+        typer.Option(
+            "--refresh",
+            help="Directory index refresh mode: auto, always, never, or rebuild.",
+        ),
+    ] = "auto",
+) -> None:
+    """Compare two repositories or immutable architecture snapshots without running Git."""
+
+    try:
+        _require_refresh_mode(refresh, allow_never=True)
+        old_snapshot = _diff_snapshot(old, refresh)
+        new_snapshot = _diff_snapshot(new, refresh)
+        difference = compare_snapshots(old_snapshot, new_snapshot)
+    except (OSError, ValueError, RuntimeError) as exc:
+        _fail(exc)
+    if json_output:
+        sys.stdout.write(dumps_diff(difference))
+        return
+    sys.stdout.write(render_diff_markdown(difference, str(old), str(new)))
 
 
 @app.command("map")

--- a/src/repolocus/diff/__init__.py
+++ b/src/repolocus/diff/__init__.py
@@ -1,0 +1,59 @@
+"""Pure, generation-aware Repository Architecture Diff."""
+
+from .engine import compare_snapshots, snapshot_from_index, snapshot_from_view
+from .formatting import render_diff_markdown
+from .models import (
+    SNAPSHOT_FORMAT_VERSION,
+    EntryPointIdentity,
+    FileChange,
+    FileDigest,
+    FileMove,
+    FingerprintCompatibility,
+    RepositoryDiff,
+    RepositoryFacts,
+    RepositorySnapshot,
+    ResolvedDependencyIdentity,
+    ReviewItem,
+    SourceEvidence,
+    SymbolIdentity,
+    SymbolMove,
+)
+from .serialization import (
+    diff_to_dict,
+    dumps_diff,
+    dumps_snapshot,
+    load_snapshot,
+    loads_snapshot,
+    save_snapshot,
+    snapshot_from_dict,
+    snapshot_to_dict,
+)
+
+__all__ = [
+    "SNAPSHOT_FORMAT_VERSION",
+    "EntryPointIdentity",
+    "FileChange",
+    "FileDigest",
+    "FileMove",
+    "FingerprintCompatibility",
+    "RepositoryDiff",
+    "RepositoryFacts",
+    "RepositorySnapshot",
+    "ResolvedDependencyIdentity",
+    "ReviewItem",
+    "SourceEvidence",
+    "SymbolIdentity",
+    "SymbolMove",
+    "compare_snapshots",
+    "diff_to_dict",
+    "dumps_diff",
+    "dumps_snapshot",
+    "load_snapshot",
+    "loads_snapshot",
+    "render_diff_markdown",
+    "save_snapshot",
+    "snapshot_from_dict",
+    "snapshot_from_index",
+    "snapshot_from_view",
+    "snapshot_to_dict",
+]

--- a/src/repolocus/diff/engine.py
+++ b/src/repolocus/diff/engine.py
@@ -1,0 +1,575 @@
+"""Projection-only snapshot capture and pure architecture comparison."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from pathlib import PurePosixPath
+from typing import TypeVar
+
+from repolocus.index.view import RepositoryView
+from repolocus.scanner.filters import CONFIG_FILENAMES
+
+from .models import (
+    EntryPointIdentity,
+    FileChange,
+    FileDigest,
+    FileMove,
+    FingerprintCompatibility,
+    RepositoryDiff,
+    RepositoryFacts,
+    RepositorySnapshot,
+    ResolvedDependencyIdentity,
+    ReviewItem,
+    SourceEvidence,
+    SymbolIdentity,
+    SymbolMove,
+)
+
+_T = TypeVar("_T")
+
+
+def snapshot_from_view(view: RepositoryView) -> RepositorySnapshot:
+    """Capture compact facts from one active, generation-pinned view.
+
+    The adapter uses only metadata, symbols, resolved dependencies, and entry
+    points.  It never asks the view for a text prefix or materializes chunks.
+    """
+
+    generation = view.generation
+    files = {
+        file.path: FileDigest(
+            path=file.path,
+            sha256=file.sha256,
+            language=file.language,
+            size_bytes=file.size_bytes,
+            line_count=file.line_count,
+            evidence=SourceEvidence(file.path, 1, max(1, file.line_count), generation),
+        )
+        for file in view.file_manifest()
+    }
+    symbols = frozenset(
+        SymbolIdentity(
+            name=symbol.name,
+            kind=symbol.kind,
+            signature=symbol.signature,
+            evidence=SourceEvidence(
+                symbol.path,
+                symbol.start_line,
+                symbol.end_line,
+                generation,
+            ),
+        )
+        for symbol in view.symbols()
+        if symbol.path in files
+    )
+    dependencies = frozenset(
+        ResolvedDependencyIdentity(
+            raw_target=dependency.raw_target,
+            target_path=dependency.target_path,
+            target_symbol=dependency.target_symbol,
+            kind=dependency.kind,
+            confidence=dependency.confidence,
+            candidates=tuple(sorted(set(dependency.candidates))),
+            evidence=SourceEvidence(
+                dependency.source_path,
+                dependency.line,
+                dependency.line,
+                generation,
+            ),
+        )
+        for dependency in view.dependencies()
+        if dependency.source_path in files
+    )
+    entry_points = frozenset(
+        EntryPointIdentity(SourceEvidence(entry.path, entry.line, entry.line, generation))
+        for entry in view.entry_points()
+        if entry.path in files
+    )
+    return RepositorySnapshot(
+        schema_version=view.schema_version,
+        repository_identity=view.repository_identity,
+        generation=generation,
+        fingerprints=view.fingerprints,
+        dependency_resolver_fingerprint=view.dependency_resolver_fingerprint,
+        facts=RepositoryFacts(
+            files=files,
+            symbols=symbols,
+            dependencies=dependencies,
+            entry_points=entry_points,
+        ),
+    )
+
+
+def snapshot_from_index(
+    index: object, *, expected_generation: int | None = None
+) -> RepositorySnapshot:
+    """Open one public RepositoryView and capture an immutable snapshot."""
+
+    repository_view = getattr(index, "repository_view", None)
+    if not callable(repository_view):
+        raise TypeError("index must provide repository_view()")
+    with repository_view(expected_generation=expected_generation) as view:
+        return snapshot_from_view(view)
+
+
+def _component_compatibility(
+    old: RepositorySnapshot,
+    new: RepositorySnapshot,
+) -> FingerprintCompatibility:
+    reasons: list[str] = []
+    schema = old.schema_version == new.schema_version
+    if not schema:
+        reasons.append(
+            f"schema version differs ({old.schema_version} != {new.schema_version}); "
+            "rebuild snapshots"
+        )
+
+    names = ("scan", "parser", "term_index", "retrieval")
+    component_matches: dict[str, bool] = {}
+    if old.fingerprints is None or new.fingerprints is None:
+        for name in names:
+            component_matches[name] = False
+        reasons.append("component fingerprints are missing; comparison is degraded")
+    else:
+        for name in names:
+            matches = getattr(old.fingerprints, name) == getattr(new.fingerprints, name)
+            component_matches[name] = matches
+            if not matches:
+                reasons.append(
+                    f"{name} fingerprint differs; rebuild with one analysis configuration"
+                )
+
+    dependency_resolver = (
+        old.dependency_resolver_fingerprint is not None
+        and old.dependency_resolver_fingerprint == new.dependency_resolver_fingerprint
+    )
+    if not dependency_resolver:
+        reasons.append(
+            "dependency resolver fingerprint is missing or differs; edge diff is degraded"
+        )
+    return FingerprintCompatibility(
+        schema=schema,
+        scan=component_matches["scan"],
+        parser=component_matches["parser"],
+        term_index=component_matches["term_index"],
+        retrieval=component_matches["retrieval"],
+        dependency_resolver=dependency_resolver,
+        degraded=bool(reasons),
+        reasons=tuple(reasons),
+    )
+
+
+def _sort_file(file: FileDigest) -> tuple[str]:
+    return (file.path,)
+
+
+def _sort_symbol(symbol: SymbolIdentity) -> tuple[str, int, int, str, str, str]:
+    return (
+        symbol.evidence.path,
+        symbol.evidence.start_line,
+        symbol.evidence.end_line,
+        symbol.name,
+        symbol.kind,
+        symbol.signature,
+    )
+
+
+def _sort_dependency(
+    dependency: ResolvedDependencyIdentity,
+) -> tuple[str, int, str, str, str, tuple[str, ...]]:
+    return (
+        dependency.evidence.path,
+        dependency.evidence.start_line,
+        dependency.raw_target,
+        dependency.kind,
+        dependency.confidence,
+        dependency.candidates,
+    )
+
+
+def _sort_entry(entry: EntryPointIdentity) -> tuple[str, int]:
+    return (entry.evidence.path, entry.evidence.start_line)
+
+
+def _partition_by_key(
+    old_items: Iterable[_T],
+    new_items: Iterable[_T],
+    key: Callable[[_T], object],
+) -> tuple[list[_T], list[_T]]:
+    old_by_key: dict[object, _T] = {}
+    new_by_key: dict[object, _T] = {}
+    for side, items, destination in (
+        ("old", old_items, old_by_key),
+        ("new", new_items, new_by_key),
+    ):
+        for item in items:
+            item_key = key(item)
+            if item_key in destination:
+                raise ValueError(f"{side} snapshot contains a comparison-key collision")
+            destination[item_key] = item
+    return (
+        [old_by_key[item_key] for item_key in old_by_key.keys() - new_by_key.keys()],
+        [new_by_key[item_key] for item_key in new_by_key.keys() - old_by_key.keys()],
+    )
+
+
+def _file_moves(
+    removed: list[FileDigest],
+    added: list[FileDigest],
+    old_files: Iterable[FileDigest],
+    new_files: Iterable[FileDigest],
+) -> tuple[list[FileMove], list[FileDigest], list[FileDigest]]:
+    old_by_digest: dict[str, list[FileDigest]] = defaultdict(list)
+    new_by_digest: dict[str, list[FileDigest]] = defaultdict(list)
+    for file in removed:
+        old_by_digest[file.sha256].append(file)
+    for file in added:
+        new_by_digest[file.sha256].append(file)
+    old_digest_counts: dict[str, int] = defaultdict(int)
+    new_digest_counts: dict[str, int] = defaultdict(int)
+    for file in old_files:
+        old_digest_counts[file.sha256] += 1
+    for file in new_files:
+        new_digest_counts[file.sha256] += 1
+    moves: list[FileMove] = []
+    moved_old: set[str] = set()
+    moved_new: set[str] = set()
+    for digest in sorted(old_by_digest.keys() & new_by_digest.keys()):
+        old_candidates = old_by_digest[digest]
+        new_candidates = new_by_digest[digest]
+        if (
+            len(old_candidates) != 1
+            or len(new_candidates) != 1
+            or old_digest_counts[digest] != 1
+            or new_digest_counts[digest] != 1
+        ):
+            continue
+        old_file, new_file = old_candidates[0], new_candidates[0]
+        moves.append(FileMove(old_file, new_file))
+        moved_old.add(old_file.path)
+        moved_new.add(new_file.path)
+    return (
+        moves,
+        [file for file in removed if file.path not in moved_old],
+        [file for file in added if file.path not in moved_new],
+    )
+
+
+def _symbol_moves(
+    removed: list[SymbolIdentity],
+    added: list[SymbolIdentity],
+    file_moves: Iterable[FileMove],
+) -> tuple[list[SymbolMove], list[SymbolIdentity], list[SymbolIdentity]]:
+    """Promote symbols only when a unique digest-identical file move proves the path move."""
+
+    path_moves = {move.old.path: move.new.path for move in file_moves}
+    old_groups: dict[tuple[str, tuple[str, str, str]], list[SymbolIdentity]] = defaultdict(list)
+    new_groups: dict[tuple[str, tuple[str, str, str]], list[SymbolIdentity]] = defaultdict(list)
+    for symbol in removed:
+        old_groups[(symbol.evidence.path, symbol.semantic_key)].append(symbol)
+    for symbol in added:
+        new_groups[(symbol.evidence.path, symbol.semantic_key)].append(symbol)
+    moves: list[SymbolMove] = []
+    moved_old: set[tuple[str, str, str, str, int, int]] = set()
+    moved_new: set[tuple[str, str, str, str, int, int]] = set()
+    for (old_path, semantic_key), old_candidates in sorted(old_groups.items()):
+        new_path = path_moves.get(old_path)
+        if new_path is None:
+            continue
+        new_candidates = new_groups.get((new_path, semantic_key), [])
+        if len(old_candidates) != 1 or len(new_candidates) != 1:
+            continue
+        old_symbol, new_symbol = old_candidates[0], new_candidates[0]
+        moves.append(SymbolMove(old_symbol, new_symbol))
+        moved_old.add(old_symbol.comparison_key)
+        moved_new.add(new_symbol.comparison_key)
+    return (
+        moves,
+        [symbol for symbol in removed if symbol.comparison_key not in moved_old],
+        [symbol for symbol in added if symbol.comparison_key not in moved_new],
+    )
+
+
+def _is_config(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    name = candidate.name.casefold()
+    return (
+        name in CONFIG_FILENAMES
+        or name.startswith(("requirements", ".env.example"))
+        or candidate.suffix.casefold()
+        in {
+            ".cfg",
+            ".conf",
+            ".config",
+            ".gradle",
+            ".ini",
+            ".json",
+            ".toml",
+            ".xml",
+            ".yaml",
+            ".yml",
+        }
+    )
+
+
+def _is_security_boundary(path: str) -> bool:
+    parts = tuple(part.casefold() for part in PurePosixPath(path).parts)
+    name = parts[-1]
+    security_parts = {
+        "auth",
+        "authentication",
+        "authorization",
+        "crypto",
+        "permissions",
+        "privacy",
+        "secrets",
+        "security",
+        "tls",
+    }
+    return (
+        any(part in security_parts for part in parts)
+        or name in {"codeowners", "security.md", "dependabot.yml"}
+        or parts[:2] == (".github", "workflows")
+    )
+
+
+def _is_test(path: str) -> bool:
+    candidate = PurePosixPath(path.casefold())
+    name = candidate.name
+    return (
+        any(part in {"__tests__", "spec", "specs", "test", "tests"} for part in candidate.parts)
+        or name.startswith("test_")
+        or name.endswith(("_test.py", ".spec.js", ".spec.ts", ".test.js", ".test.ts"))
+    )
+
+
+def _as_changes(
+    added: Iterable[FileDigest],
+    removed: Iterable[FileDigest],
+    changed: Iterable[FileChange],
+    moved: Iterable[FileMove],
+) -> tuple[FileChange, ...]:
+    return (
+        *(FileChange(None, file) for file in added),
+        *(FileChange(file, None) for file in removed),
+        *changed,
+        *(FileChange(move.old, move.new) for move in moved),
+    )
+
+
+def _change_sort(change: FileChange) -> tuple[str, str, str]:
+    old_path = change.old.path if change.old is not None else ""
+    new_path = change.new.path if change.new is not None else ""
+    return (new_path or old_path, old_path, change.kind)
+
+
+def _classified_changes(
+    changes: Iterable[FileChange], predicate: Callable[[str], bool]
+) -> tuple[FileChange, ...]:
+    return tuple(
+        sorted(
+            (
+                change
+                for change in changes
+                if (change.old is not None and predicate(change.old.path))
+                or (change.new is not None and predicate(change.new.path))
+            ),
+            key=_change_sort,
+        )
+    )
+
+
+def _review_order(
+    changes: tuple[FileChange, ...],
+    added_entries: Iterable[EntryPointIdentity],
+    removed_entries: Iterable[EntryPointIdentity],
+    added_dependencies: Iterable[ResolvedDependencyIdentity],
+    removed_dependencies: Iterable[ResolvedDependencyIdentity],
+    added_symbols: Iterable[SymbolIdentity],
+    removed_symbols: Iterable[SymbolIdentity],
+    moved_symbols: Iterable[SymbolMove],
+) -> tuple[ReviewItem, ...]:
+    review: list[ReviewItem] = []
+    for change in changes:
+        old_evidence = change.old.evidence if change.old is not None else None
+        new_evidence = change.new.evidence if change.new is not None else None
+        path = new_evidence.path if new_evidence is not None else old_evidence.path  # type: ignore[union-attr]
+        if _is_security_boundary(path):
+            priority, area = 0, "security boundary"
+        elif _is_config(path):
+            priority, area = 1, "configuration"
+        elif _is_test(path):
+            priority, area = 4, "test area"
+        else:
+            priority, area = 5, "source"
+        review.append(
+            ReviewItem(
+                priority,
+                area,
+                path,
+                f"{change.kind} file",
+                old_evidence,
+                new_evidence,
+            )
+        )
+    for entry, old_side in (
+        *((entry, False) for entry in added_entries),
+        *((entry, True) for entry in removed_entries),
+    ):
+        review.append(
+            ReviewItem(
+                2,
+                "entry point",
+                entry.evidence.path,
+                f"{'removed' if old_side else 'added'} entry point",
+                entry.evidence if old_side else None,
+                None if old_side else entry.evidence,
+            )
+        )
+    for dependency, old_side in (
+        *((item, False) for item in added_dependencies),
+        *((item, True) for item in removed_dependencies),
+    ):
+        review.append(
+            ReviewItem(
+                3,
+                "dependency edge",
+                dependency.evidence.path,
+                f"{'removed' if old_side else 'added'} {dependency.confidence} edge to "
+                f"{dependency.raw_target}",
+                dependency.evidence if old_side else None,
+                None if old_side else dependency.evidence,
+            )
+        )
+    for symbol, old_side in (
+        *((item, False) for item in added_symbols),
+        *((item, True) for item in removed_symbols),
+    ):
+        review.append(
+            ReviewItem(
+                4,
+                "symbol",
+                symbol.evidence.path,
+                f"{'removed' if old_side else 'added'} {symbol.kind} {symbol.name}",
+                symbol.evidence if old_side else None,
+                None if old_side else symbol.evidence,
+            )
+        )
+    for move in moved_symbols:
+        review.append(
+            ReviewItem(
+                4,
+                "symbol",
+                move.new.evidence.path,
+                f"moved {move.new.kind} {move.new.name} with exact file-digest evidence",
+                move.old.evidence,
+                move.new.evidence,
+            )
+        )
+    return tuple(
+        sorted(
+            review,
+            key=lambda item: (
+                item.priority,
+                item.path,
+                item.reason,
+                item.old.start_line if item.old is not None else 0,
+                item.new.start_line if item.new is not None else 0,
+            ),
+        )
+    )
+
+
+def compare_snapshots(old: RepositorySnapshot, new: RepositorySnapshot) -> RepositoryDiff:
+    """Return a deterministic, side-effect-free architecture comparison."""
+
+    if not isinstance(old, RepositorySnapshot) or not isinstance(new, RepositorySnapshot):
+        raise TypeError("old and new must be RepositorySnapshot values")
+    compatibility = _component_compatibility(old, new)
+
+    old_paths = set(old.facts.files)
+    new_paths = set(new.facts.files)
+    removed_files = [old.facts.files[path] for path in sorted(old_paths - new_paths)]
+    added_files = [new.facts.files[path] for path in sorted(new_paths - old_paths)]
+    changed_files = [
+        FileChange(old.facts.files[path], new.facts.files[path])
+        for path in sorted(old_paths & new_paths)
+        if old.facts.files[path].comparison_key != new.facts.files[path].comparison_key
+    ]
+    moved_files, removed_files, added_files = _file_moves(
+        removed_files,
+        added_files,
+        old.facts.files.values(),
+        new.facts.files.values(),
+    )
+
+    removed_symbols, added_symbols = _partition_by_key(
+        old.facts.symbols,
+        new.facts.symbols,
+        lambda item: item.comparison_key,
+    )
+    moved_symbols, removed_symbols, added_symbols = _symbol_moves(
+        removed_symbols,
+        added_symbols,
+        moved_files,
+    )
+    removed_dependencies, added_dependencies = _partition_by_key(
+        old.facts.dependencies,
+        new.facts.dependencies,
+        lambda item: item.comparison_key,
+    )
+    removed_entries, added_entries = _partition_by_key(
+        old.facts.entry_points,
+        new.facts.entry_points,
+        lambda item: item.comparison_key,
+    )
+
+    added_files_tuple = tuple(sorted(added_files, key=_sort_file))
+    removed_files_tuple = tuple(sorted(removed_files, key=_sort_file))
+    changed_files_tuple = tuple(sorted(changed_files, key=_change_sort))
+    moved_files_tuple = tuple(sorted(moved_files, key=lambda move: (move.old.path, move.new.path)))
+    added_symbols_tuple = tuple(sorted(added_symbols, key=_sort_symbol))
+    removed_symbols_tuple = tuple(sorted(removed_symbols, key=_sort_symbol))
+    moved_symbols_tuple = tuple(
+        sorted(moved_symbols, key=lambda move: (_sort_symbol(move.old), _sort_symbol(move.new)))
+    )
+    added_entries_tuple = tuple(sorted(added_entries, key=_sort_entry))
+    removed_entries_tuple = tuple(sorted(removed_entries, key=_sort_entry))
+    added_dependencies_tuple = tuple(sorted(added_dependencies, key=_sort_dependency))
+    removed_dependencies_tuple = tuple(sorted(removed_dependencies, key=_sort_dependency))
+    all_file_changes = _as_changes(
+        added_files_tuple,
+        removed_files_tuple,
+        changed_files_tuple,
+        moved_files_tuple,
+    )
+    return RepositoryDiff(
+        old_generation=old.generation,
+        new_generation=new.generation,
+        compatibility=compatibility,
+        added_files=added_files_tuple,
+        removed_files=removed_files_tuple,
+        changed_files=changed_files_tuple,
+        moved_files=moved_files_tuple,
+        added_symbols=added_symbols_tuple,
+        removed_symbols=removed_symbols_tuple,
+        moved_symbols=moved_symbols_tuple,
+        added_entry_points=added_entries_tuple,
+        removed_entry_points=removed_entries_tuple,
+        added_dependencies=added_dependencies_tuple,
+        removed_dependencies=removed_dependencies_tuple,
+        configuration_changes=_classified_changes(all_file_changes, _is_config),
+        security_boundary_changes=_classified_changes(all_file_changes, _is_security_boundary),
+        test_area_changes=_classified_changes(all_file_changes, _is_test),
+        review_order=_review_order(
+            all_file_changes,
+            added_entries_tuple,
+            removed_entries_tuple,
+            added_dependencies_tuple,
+            removed_dependencies_tuple,
+            added_symbols_tuple,
+            removed_symbols_tuple,
+            moved_symbols_tuple,
+        ),
+    )

--- a/src/repolocus/diff/formatting.py
+++ b/src/repolocus/diff/formatting.py
@@ -1,0 +1,148 @@
+"""Deterministic, untrusted-text-safe Architecture Diff Markdown."""
+
+from __future__ import annotations
+
+from html import escape as html_escape
+
+from repolocus.security.display import escape_untrusted_display
+
+from .models import RepositoryDiff, SourceEvidence
+
+
+def _visible(value: str) -> str:
+    escaped = html_escape(escape_untrusted_display(value), quote=False)
+    for marker in ("\\", "`", "*", "_", "[", "]", "<", ">", "|"):
+        escaped = escaped.replace(marker, f"\\{marker}")
+    return escaped.replace("@", "&#64;")
+
+
+def _code(value: str) -> str:
+    safe = _visible(value).replace("`", "'")
+    return f"`{safe}`"
+
+
+def _citation(evidence: SourceEvidence | None) -> str:
+    return "-" if evidence is None else _code(evidence.citation)
+
+
+def _section(lines: list[str], title: str, items: list[str]) -> None:
+    lines.extend([f"## {title}", ""])
+    lines.extend(items or ["None."])
+    lines.append("")
+
+
+def render_diff_markdown(
+    diff: RepositoryDiff,
+    old_label: str = "old",
+    new_label: str = "new",
+) -> str:
+    """Render a shared CLI/Action report without links or raw untrusted markup."""
+
+    if not isinstance(diff, RepositoryDiff):
+        raise TypeError("diff must be a RepositoryDiff")
+    if not isinstance(old_label, str) or not old_label:
+        raise ValueError("old_label must not be empty")
+    if not isinstance(new_label, str) or not new_label:
+        raise ValueError("new_label must not be empty")
+    status = "degraded" if diff.compatibility.degraded else "compatible"
+    lines = [
+        f"# Architecture Diff: {_visible(old_label)} to {_visible(new_label)}",
+        "",
+        f"- Generations: {_code(str(diff.old_generation))} to {_code(str(diff.new_generation))}",
+        f"- Comparison: **{status}**",
+        f"- Empty: {_code(str(diff.is_empty).lower())}",
+        "",
+    ]
+    if diff.compatibility.reasons:
+        lines.extend(["## Compatibility notes", ""])
+        lines.extend(f"- {_visible(reason)}" for reason in diff.compatibility.reasons)
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Summary",
+            "",
+            "| Area | Added | Removed | Changed or moved |",
+            "|---|---:|---:|---:|",
+            f"| Files | {len(diff.added_files)} | {len(diff.removed_files)} | "
+            f"{len(diff.changed_files) + len(diff.moved_files)} |",
+            f"| Symbols | {len(diff.added_symbols)} | {len(diff.removed_symbols)} | "
+            f"{len(diff.moved_symbols)} |",
+            f"| Entry points | {len(diff.added_entry_points)} | "
+            f"{len(diff.removed_entry_points)} | 0 |",
+            f"| Dependency edges | {len(diff.added_dependencies)} | "
+            f"{len(diff.removed_dependencies)} | 0 |",
+            "",
+        ]
+    )
+
+    file_items = [f"- Added {_citation(item.evidence)}" for item in diff.added_files] + [
+        f"- Removed {_citation(item.evidence)}" for item in diff.removed_files
+    ]
+    file_items.extend(
+        f"- Changed {_citation(item.old.evidence)} to {_citation(item.new.evidence)}"
+        for item in diff.changed_files
+        if item.old is not None and item.new is not None
+    )
+    file_items.extend(
+        f"- Moved {_citation(item.old.evidence)} to {_citation(item.new.evidence)} "
+        f"({_code(item.confidence)})"
+        for item in diff.moved_files
+    )
+    _section(lines, "Files", file_items)
+
+    symbol_items = [
+        f"- Added {_code(item.kind)} {_code(item.name)} at {_citation(item.evidence)}"
+        for item in diff.added_symbols
+    ] + [
+        f"- Removed {_code(item.kind)} {_code(item.name)} at {_citation(item.evidence)}"
+        for item in diff.removed_symbols
+    ]
+    symbol_items.extend(
+        f"- Moved {_code(item.old.kind)} {_code(item.old.name)} from "
+        f"{_citation(item.old.evidence)} to {_citation(item.new.evidence)} "
+        f"({_code(item.confidence)})"
+        for item in diff.moved_symbols
+    )
+    _section(lines, "Symbols", symbol_items)
+
+    entry_items = [f"- Added {_citation(item.evidence)}" for item in diff.added_entry_points] + [
+        f"- Removed {_citation(item.evidence)}" for item in diff.removed_entry_points
+    ]
+    _section(lines, "Entry points", entry_items)
+
+    dependency_items: list[str] = []
+    for prefix, dependencies in (
+        ("Added", diff.added_dependencies),
+        ("Removed", diff.removed_dependencies),
+    ):
+        for dependency in dependencies:
+            target = dependency.target_path or dependency.raw_target
+            candidates = (
+                " candidates=" + ", ".join(_code(candidate) for candidate in dependency.candidates)
+                if dependency.candidates
+                else ""
+            )
+            dependency_items.append(
+                f"- {prefix} {_code(dependency.kind)} edge {_citation(dependency.evidence)} "
+                f"to {_code(target)} ({_code(dependency.confidence)}){candidates}"
+            )
+    _section(lines, "Dependency edges", dependency_items)
+
+    lines.extend(
+        [
+            "## Classified file changes",
+            "",
+            f"- Configuration: {len(diff.configuration_changes)}",
+            f"- Security boundary: {len(diff.security_boundary_changes)}",
+            f"- Test area: {len(diff.test_area_changes)}",
+            "",
+        ]
+    )
+    review_items = [
+        f"{number}. P{item.priority} {_code(item.area)}: {_visible(item.reason)}; "
+        f"old={_citation(item.old)}, new={_citation(item.new)}"
+        for number, item in enumerate(diff.review_order, 1)
+    ]
+    _section(lines, "Suggested review order", review_items)
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/repolocus/diff/models.py
+++ b/src/repolocus/diff/models.py
@@ -1,0 +1,458 @@
+"""Immutable, source-addressable facts for architecture comparisons."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from types import MappingProxyType
+from typing import Literal
+
+from repolocus.analysis import AnalysisFingerprints
+
+SNAPSHOT_FORMAT_VERSION = 1
+DependencyConfidence = Literal["exact", "probable", "ambiguous", "unresolved"]
+MoveConfidence = Literal["exact"]
+
+
+def _require_non_negative(value: int, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _require_positive(value: int, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+
+
+def _require_text(value: str, name: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must not be empty")
+
+
+def _require_digest(value: str, name: str) -> None:
+    if not isinstance(value, str) or len(value) != 64 or value != value.lower():
+        raise ValueError(f"{name} must be a lowercase SHA-256 hex digest")
+    try:
+        bytes.fromhex(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a lowercase SHA-256 hex digest") from exc
+
+
+def _require_path(value: str, name: str = "path") -> None:
+    _require_text(value, name)
+    candidate = PurePosixPath(value)
+    if (
+        "\\" in value
+        or candidate.is_absolute()
+        or ".." in candidate.parts
+        or candidate.as_posix() != value
+        or value == "."
+    ):
+        raise ValueError(f"{name} must be normalized and repository-relative")
+
+
+@dataclass(frozen=True, slots=True)
+class SourceEvidence:
+    """A location in exactly one content generation, without source text."""
+
+    path: str
+    start_line: int
+    end_line: int
+    generation: int
+
+    def __post_init__(self) -> None:
+        _require_path(self.path)
+        _require_positive(self.start_line, "start_line")
+        _require_positive(self.end_line, "end_line")
+        if self.end_line < self.start_line:
+            raise ValueError("end_line must be greater than or equal to start_line")
+        _require_non_negative(self.generation, "generation")
+
+    @property
+    def citation(self) -> str:
+        end = f"-{self.end_line}" if self.end_line != self.start_line else ""
+        return f"{self.path}:{self.start_line}{end}@{self.generation}"
+
+
+@dataclass(frozen=True, slots=True)
+class FileDigest:
+    """Content identity and bounded metadata for one indexed source file."""
+
+    path: str
+    sha256: str
+    language: str
+    size_bytes: int
+    line_count: int
+    evidence: SourceEvidence
+
+    def __post_init__(self) -> None:
+        _require_path(self.path)
+        _require_digest(self.sha256, "sha256")
+        _require_text(self.language, "language")
+        _require_non_negative(self.size_bytes, "size_bytes")
+        _require_non_negative(self.line_count, "line_count")
+        if self.evidence.path != self.path:
+            raise ValueError("file evidence path must match file path")
+        if self.evidence.start_line != 1 or self.evidence.end_line != max(1, self.line_count):
+            raise ValueError("file evidence must cover the indexed line range")
+
+    @property
+    def comparison_key(self) -> tuple[str, str, int, int]:
+        return (self.sha256, self.language, self.size_bytes, self.line_count)
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolIdentity:
+    """A parser-derived symbol with a precise generation-pinned location."""
+
+    name: str
+    kind: str
+    signature: str
+    evidence: SourceEvidence
+
+    def __post_init__(self) -> None:
+        _require_text(self.name, "symbol name")
+        _require_text(self.kind, "symbol kind")
+        if not isinstance(self.signature, str):
+            raise ValueError("symbol signature must be text")
+
+    @property
+    def semantic_key(self) -> tuple[str, str, str]:
+        """Identity used only to nominate unique move candidates."""
+
+        return (self.name, self.kind, self.signature)
+
+    @property
+    def comparison_key(self) -> tuple[str, str, str, str, int, int]:
+        return (
+            self.evidence.path,
+            self.name,
+            self.kind,
+            self.signature,
+            self.evidence.start_line,
+            self.evidence.end_line,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedDependencyIdentity:
+    """One persisted resolver result, preserving ambiguous candidates."""
+
+    raw_target: str
+    target_path: str | None
+    target_symbol: str | None
+    kind: str
+    confidence: DependencyConfidence
+    candidates: tuple[str, ...]
+    evidence: SourceEvidence
+
+    def __post_init__(self) -> None:
+        _require_text(self.raw_target, "raw_target")
+        _require_text(self.kind, "dependency kind")
+        if self.target_path is not None:
+            _require_path(self.target_path, "target_path")
+        if self.target_symbol is not None and not isinstance(self.target_symbol, str):
+            raise ValueError("target_symbol must be text or None")
+        if self.confidence not in {"exact", "probable", "ambiguous", "unresolved"}:
+            raise ValueError("dependency confidence is invalid")
+        if not isinstance(self.candidates, tuple):
+            raise ValueError("dependency candidates must be a tuple")
+        for candidate in self.candidates:
+            _require_path(candidate, "dependency candidate")
+        if tuple(sorted(set(self.candidates))) != self.candidates:
+            raise ValueError("dependency candidates must be sorted and unique")
+        if self.confidence == "ambiguous" and len(self.candidates) < 2:
+            raise ValueError("ambiguous dependencies must preserve at least two candidates")
+
+    @property
+    def comparison_key(
+        self,
+    ) -> tuple[str, str, str | None, str | None, str, str, tuple[str, ...], int]:
+        return (
+            self.evidence.path,
+            self.raw_target,
+            self.target_path,
+            self.target_symbol,
+            self.kind,
+            self.confidence,
+            self.candidates,
+            self.evidence.start_line,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EntryPointIdentity:
+    """An executable entry point and its best source witness."""
+
+    evidence: SourceEvidence
+
+    @property
+    def comparison_key(self) -> tuple[str, int, int]:
+        return (self.evidence.path, self.evidence.start_line, self.evidence.end_line)
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryFacts:
+    """Compact architecture facts; source bodies and chunks are deliberately absent."""
+
+    files: Mapping[str, FileDigest]
+    symbols: frozenset[SymbolIdentity]
+    dependencies: frozenset[ResolvedDependencyIdentity]
+    entry_points: frozenset[EntryPointIdentity]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.files, Mapping):
+            raise ValueError("files must be a mapping")
+        normalized_files = dict(self.files)
+        if any(path != fact.path for path, fact in normalized_files.items()):
+            raise ValueError("file mapping keys must match file paths")
+        if any(not isinstance(fact, FileDigest) for fact in normalized_files.values()):
+            raise ValueError("files must contain FileDigest values")
+        object.__setattr__(self, "files", MappingProxyType(dict(sorted(normalized_files.items()))))
+        for name, value, expected in (
+            ("symbols", self.symbols, SymbolIdentity),
+            ("dependencies", self.dependencies, ResolvedDependencyIdentity),
+            ("entry_points", self.entry_points, EntryPointIdentity),
+        ):
+            if not isinstance(value, frozenset) or any(
+                not isinstance(item, expected) for item in value
+            ):
+                raise ValueError(f"{name} must be a frozenset of {expected.__name__} values")
+        paths = set(normalized_files)
+        for fact_kind, facts in (
+            ("symbol", self.symbols),
+            ("dependency", self.dependencies),
+            ("entry-point", self.entry_points),
+        ):
+            for fact in facts:
+                if fact.evidence.path not in paths:
+                    raise ValueError(f"{fact_kind} evidence must reference a snapshot file")
+                file = normalized_files[fact.evidence.path]
+                if fact.evidence.end_line > max(1, file.line_count):
+                    raise ValueError(f"{fact_kind} evidence exceeds the indexed file range")
+        for dependency in self.dependencies:
+            if dependency.target_path is not None and dependency.target_path not in paths:
+                raise ValueError("dependency target_path must reference a snapshot file")
+            if any(candidate not in paths for candidate in dependency.candidates):
+                raise ValueError("dependency candidates must reference snapshot files")
+
+
+@dataclass(frozen=True, slots=True)
+class RepositorySnapshot:
+    """An immutable, portable architecture snapshot."""
+
+    schema_version: int
+    repository_identity: str
+    generation: int
+    fingerprints: AnalysisFingerprints | None
+    dependency_resolver_fingerprint: str | None
+    facts: RepositoryFacts
+    format_version: int = SNAPSHOT_FORMAT_VERSION
+
+    def __post_init__(self) -> None:
+        _require_positive(self.schema_version, "schema_version")
+        _require_digest(self.repository_identity, "repository_identity")
+        _require_non_negative(self.generation, "generation")
+        if self.fingerprints is not None and not isinstance(
+            self.fingerprints, AnalysisFingerprints
+        ):
+            raise ValueError("fingerprints must be AnalysisFingerprints or None")
+        if self.dependency_resolver_fingerprint is not None:
+            _require_digest(
+                self.dependency_resolver_fingerprint,
+                "dependency_resolver_fingerprint",
+            )
+        if not isinstance(self.facts, RepositoryFacts):
+            raise ValueError("facts must be RepositoryFacts")
+        if self.format_version != SNAPSHOT_FORMAT_VERSION:
+            raise ValueError(
+                f"unsupported snapshot format {self.format_version}; "
+                f"expected {SNAPSHOT_FORMAT_VERSION}"
+            )
+        for fact in (
+            *self.facts.files.values(),
+            *self.facts.symbols,
+            *self.facts.dependencies,
+            *self.facts.entry_points,
+        ):
+            if fact.evidence.generation != self.generation:
+                raise ValueError("all snapshot evidence must use the snapshot generation")
+
+
+@dataclass(frozen=True, slots=True)
+class FingerprintCompatibility:
+    """Explicit comparability of every recorded analysis component."""
+
+    schema: bool
+    scan: bool
+    parser: bool
+    term_index: bool
+    retrieval: bool
+    dependency_resolver: bool
+    degraded: bool
+    reasons: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        for name in (
+            "schema",
+            "scan",
+            "parser",
+            "term_index",
+            "retrieval",
+            "dependency_resolver",
+            "degraded",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise ValueError(f"compatibility {name} must be true or false")
+        if not isinstance(self.reasons, tuple) or any(
+            not isinstance(reason, str) or not reason for reason in self.reasons
+        ):
+            raise ValueError("compatibility reasons must be a tuple of non-empty text")
+        if tuple(sorted(set(self.reasons))) != tuple(sorted(self.reasons)):
+            raise ValueError("compatibility reasons must be unique")
+        if self.degraded != bool(self.reasons):
+            raise ValueError("degraded must reflect whether compatibility reasons exist")
+
+
+@dataclass(frozen=True, slots=True)
+class FileChange:
+    old: FileDigest | None
+    new: FileDigest | None
+
+    def __post_init__(self) -> None:
+        if self.old is None and self.new is None:
+            raise ValueError("a file change must include old or new evidence")
+
+    @property
+    def kind(self) -> Literal["added", "removed", "changed", "moved"]:
+        if self.old is None:
+            return "added"
+        if self.new is None:
+            return "removed"
+        return "changed" if self.old.path == self.new.path else "moved"
+
+
+@dataclass(frozen=True, slots=True)
+class FileMove:
+    old: FileDigest
+    new: FileDigest
+    confidence: MoveConfidence = "exact"
+
+    def __post_init__(self) -> None:
+        if self.old.path == self.new.path or self.old.sha256 != self.new.sha256:
+            raise ValueError("a file move requires different paths with the same digest")
+        if self.confidence != "exact":
+            raise ValueError("only exact unique file moves are supported")
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolMove:
+    old: SymbolIdentity
+    new: SymbolIdentity
+    confidence: MoveConfidence = "exact"
+
+    def __post_init__(self) -> None:
+        if self.old.evidence.path == self.new.evidence.path:
+            raise ValueError("a symbol move requires different paths")
+        if self.old.semantic_key != self.new.semantic_key:
+            raise ValueError("a symbol move requires the same semantic identity")
+        if self.confidence != "exact":
+            raise ValueError("only exact unique symbol moves are supported")
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewItem:
+    priority: int
+    area: str
+    path: str
+    reason: str
+    old: SourceEvidence | None
+    new: SourceEvidence | None
+
+    def __post_init__(self) -> None:
+        _require_non_negative(self.priority, "priority")
+        _require_text(self.area, "review area")
+        _require_path(self.path)
+        _require_text(self.reason, "review reason")
+        if self.old is None and self.new is None:
+            raise ValueError("review items require old or new evidence")
+        evidence_paths = {
+            evidence.path for evidence in (self.old, self.new) if evidence is not None
+        }
+        if self.path not in evidence_paths:
+            raise ValueError("review path must identify old or new evidence")
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryDiff:
+    """Deterministic architecture changes between two immutable snapshots."""
+
+    old_generation: int
+    new_generation: int
+    compatibility: FingerprintCompatibility
+    added_files: tuple[FileDigest, ...] = ()
+    removed_files: tuple[FileDigest, ...] = ()
+    changed_files: tuple[FileChange, ...] = ()
+    moved_files: tuple[FileMove, ...] = ()
+    added_symbols: tuple[SymbolIdentity, ...] = ()
+    removed_symbols: tuple[SymbolIdentity, ...] = ()
+    moved_symbols: tuple[SymbolMove, ...] = ()
+    added_entry_points: tuple[EntryPointIdentity, ...] = ()
+    removed_entry_points: tuple[EntryPointIdentity, ...] = ()
+    added_dependencies: tuple[ResolvedDependencyIdentity, ...] = ()
+    removed_dependencies: tuple[ResolvedDependencyIdentity, ...] = ()
+    configuration_changes: tuple[FileChange, ...] = ()
+    security_boundary_changes: tuple[FileChange, ...] = ()
+    test_area_changes: tuple[FileChange, ...] = ()
+    review_order: tuple[ReviewItem, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_non_negative(self.old_generation, "old_generation")
+        _require_non_negative(self.new_generation, "new_generation")
+        if not isinstance(self.compatibility, FingerprintCompatibility):
+            raise ValueError("compatibility must be FingerprintCompatibility")
+        expected_types = {
+            "added_files": FileDigest,
+            "removed_files": FileDigest,
+            "changed_files": FileChange,
+            "moved_files": FileMove,
+            "added_symbols": SymbolIdentity,
+            "removed_symbols": SymbolIdentity,
+            "moved_symbols": SymbolMove,
+            "added_entry_points": EntryPointIdentity,
+            "removed_entry_points": EntryPointIdentity,
+            "added_dependencies": ResolvedDependencyIdentity,
+            "removed_dependencies": ResolvedDependencyIdentity,
+            "configuration_changes": FileChange,
+            "security_boundary_changes": FileChange,
+            "test_area_changes": FileChange,
+            "review_order": ReviewItem,
+        }
+        for name, expected in expected_types.items():
+            value = getattr(self, name)
+            if not isinstance(value, tuple) or any(
+                not isinstance(item, expected) for item in value
+            ):
+                raise ValueError(f"{name} must be a tuple of {expected.__name__} values")
+
+    @property
+    def is_empty(self) -> bool:
+        return not any(
+            (
+                self.added_files,
+                self.removed_files,
+                self.changed_files,
+                self.moved_files,
+                self.added_symbols,
+                self.removed_symbols,
+                self.moved_symbols,
+                self.added_entry_points,
+                self.removed_entry_points,
+                self.added_dependencies,
+                self.removed_dependencies,
+                self.configuration_changes,
+                self.security_boundary_changes,
+                self.test_area_changes,
+            )
+        )

--- a/src/repolocus/diff/serialization.py
+++ b/src/repolocus/diff/serialization.py
@@ -1,0 +1,615 @@
+"""Strict canonical JSON for portable snapshots and diff results."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import os
+import stat
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, NoReturn
+
+from repolocus.analysis import AnalysisFingerprints
+from repolocus.security.atomic_write import (
+    AtomicWriteError,
+    _capture_fallback_descriptor_state,
+    _capture_fallback_state,
+    _same_fallback_state,
+)
+
+from .models import (
+    EntryPointIdentity,
+    FileChange,
+    FileDigest,
+    RepositoryDiff,
+    RepositoryFacts,
+    RepositorySnapshot,
+    ResolvedDependencyIdentity,
+    ReviewItem,
+    SourceEvidence,
+    SymbolIdentity,
+)
+
+_MAX_SNAPSHOT_BYTES = 256 * 1024 * 1024
+
+
+def _evidence_to_dict(evidence: SourceEvidence) -> dict[str, object]:
+    return {
+        "path": evidence.path,
+        "start_line": evidence.start_line,
+        "end_line": evidence.end_line,
+        "generation": evidence.generation,
+    }
+
+
+def _file_to_dict(file: FileDigest) -> dict[str, object]:
+    return {
+        "path": file.path,
+        "sha256": file.sha256,
+        "language": file.language,
+        "size_bytes": file.size_bytes,
+        "line_count": file.line_count,
+        "evidence": _evidence_to_dict(file.evidence),
+    }
+
+
+def _symbol_to_dict(symbol: SymbolIdentity) -> dict[str, object]:
+    return {
+        "name": symbol.name,
+        "kind": symbol.kind,
+        "signature": symbol.signature,
+        "evidence": _evidence_to_dict(symbol.evidence),
+    }
+
+
+def _dependency_to_dict(dependency: ResolvedDependencyIdentity) -> dict[str, object]:
+    return {
+        "raw_target": dependency.raw_target,
+        "target_path": dependency.target_path,
+        "target_symbol": dependency.target_symbol,
+        "kind": dependency.kind,
+        "confidence": dependency.confidence,
+        "candidates": list(dependency.candidates),
+        "evidence": _evidence_to_dict(dependency.evidence),
+    }
+
+
+def _entry_to_dict(entry: EntryPointIdentity) -> dict[str, object]:
+    return {"evidence": _evidence_to_dict(entry.evidence)}
+
+
+def snapshot_to_dict(snapshot: RepositorySnapshot) -> dict[str, object]:
+    """Return the stable JSON-compatible representation of one snapshot."""
+
+    if not isinstance(snapshot, RepositorySnapshot):
+        raise TypeError("snapshot must be a RepositorySnapshot")
+    fingerprints: dict[str, str] | None = None
+    if snapshot.fingerprints is not None:
+        fingerprints = {
+            "scan": snapshot.fingerprints.scan,
+            "parser": snapshot.fingerprints.parser,
+            "term_index": snapshot.fingerprints.term_index,
+            "retrieval": snapshot.fingerprints.retrieval,
+        }
+    payload: dict[str, object] = {
+        "format_version": snapshot.format_version,
+        "schema_version": snapshot.schema_version,
+        "repository_identity": snapshot.repository_identity,
+        "generation": snapshot.generation,
+        "fingerprints": fingerprints,
+        "dependency_resolver_fingerprint": snapshot.dependency_resolver_fingerprint,
+        "facts": {
+            "files": [
+                _file_to_dict(file)
+                for file in sorted(snapshot.facts.files.values(), key=lambda item: item.path)
+            ],
+            "symbols": [
+                _symbol_to_dict(symbol)
+                for symbol in sorted(
+                    snapshot.facts.symbols,
+                    key=lambda item: item.comparison_key,
+                )
+            ],
+            "dependencies": [
+                _dependency_to_dict(dependency)
+                for dependency in sorted(
+                    snapshot.facts.dependencies,
+                    key=lambda item: item.comparison_key,
+                )
+            ],
+            "entry_points": [
+                _entry_to_dict(entry)
+                for entry in sorted(
+                    snapshot.facts.entry_points,
+                    key=lambda item: item.comparison_key,
+                )
+            ],
+        },
+    }
+    payload["snapshot_sha256"] = hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+    return payload
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _expect_object(value: object, keys: set[str], context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{context} must be an object")
+    actual = set(value)
+    if actual != keys:
+        missing = ", ".join(sorted(keys - actual))
+        unknown = ", ".join(sorted(actual - keys))
+        details = []
+        if missing:
+            details.append(f"missing: {missing}")
+        if unknown:
+            details.append(f"unknown: {unknown}")
+        raise ValueError(f"{context} fields are invalid ({'; '.join(details)})")
+    return value
+
+
+def _expect_list(value: object, context: str) -> list[object]:
+    if not isinstance(value, list):
+        raise ValueError(f"{context} must be an array")
+    return value
+
+
+def _expect_string(value: object, context: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{context} must be text")
+    return value
+
+
+def _expect_optional_string(value: object, context: str) -> str | None:
+    if value is None:
+        return None
+    return _expect_string(value, context)
+
+
+def _expect_integer(value: object, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{context} must be an integer")
+    return value
+
+
+def _parse_evidence(value: object, context: str) -> SourceEvidence:
+    item = _expect_object(
+        value,
+        {"path", "start_line", "end_line", "generation"},
+        context,
+    )
+    return SourceEvidence(
+        path=_expect_string(item["path"], f"{context}.path"),
+        start_line=_expect_integer(item["start_line"], f"{context}.start_line"),
+        end_line=_expect_integer(item["end_line"], f"{context}.end_line"),
+        generation=_expect_integer(item["generation"], f"{context}.generation"),
+    )
+
+
+def _parse_file(value: object, context: str) -> FileDigest:
+    item = _expect_object(
+        value,
+        {"path", "sha256", "language", "size_bytes", "line_count", "evidence"},
+        context,
+    )
+    return FileDigest(
+        path=_expect_string(item["path"], f"{context}.path"),
+        sha256=_expect_string(item["sha256"], f"{context}.sha256"),
+        language=_expect_string(item["language"], f"{context}.language"),
+        size_bytes=_expect_integer(item["size_bytes"], f"{context}.size_bytes"),
+        line_count=_expect_integer(item["line_count"], f"{context}.line_count"),
+        evidence=_parse_evidence(item["evidence"], f"{context}.evidence"),
+    )
+
+
+def _parse_symbol(value: object, context: str) -> SymbolIdentity:
+    item = _expect_object(value, {"name", "kind", "signature", "evidence"}, context)
+    return SymbolIdentity(
+        name=_expect_string(item["name"], f"{context}.name"),
+        kind=_expect_string(item["kind"], f"{context}.kind"),
+        signature=_expect_string(item["signature"], f"{context}.signature"),
+        evidence=_parse_evidence(item["evidence"], f"{context}.evidence"),
+    )
+
+
+def _parse_dependency(value: object, context: str) -> ResolvedDependencyIdentity:
+    item = _expect_object(
+        value,
+        {
+            "raw_target",
+            "target_path",
+            "target_symbol",
+            "kind",
+            "confidence",
+            "candidates",
+            "evidence",
+        },
+        context,
+    )
+    candidates = tuple(
+        _expect_string(candidate, f"{context}.candidates[{index}]")
+        for index, candidate in enumerate(_expect_list(item["candidates"], f"{context}.candidates"))
+    )
+    confidence = _expect_string(item["confidence"], f"{context}.confidence")
+    return ResolvedDependencyIdentity(
+        raw_target=_expect_string(item["raw_target"], f"{context}.raw_target"),
+        target_path=_expect_optional_string(item["target_path"], f"{context}.target_path"),
+        target_symbol=_expect_optional_string(item["target_symbol"], f"{context}.target_symbol"),
+        kind=_expect_string(item["kind"], f"{context}.kind"),
+        confidence=confidence,  # type: ignore[arg-type]
+        candidates=candidates,
+        evidence=_parse_evidence(item["evidence"], f"{context}.evidence"),
+    )
+
+
+def _parse_entry(value: object, context: str) -> EntryPointIdentity:
+    item = _expect_object(value, {"evidence"}, context)
+    return EntryPointIdentity(_parse_evidence(item["evidence"], f"{context}.evidence"))
+
+
+def _unique_facts(items: list[Any], context: str) -> None:
+    if len(items) != len(set(items)):
+        raise ValueError(f"{context} contains duplicate facts")
+
+
+def snapshot_from_dict(value: object) -> RepositorySnapshot:
+    """Strictly validate and construct a snapshot from decoded JSON."""
+
+    item = _expect_object(
+        value,
+        {
+            "format_version",
+            "schema_version",
+            "repository_identity",
+            "generation",
+            "fingerprints",
+            "dependency_resolver_fingerprint",
+            "facts",
+            "snapshot_sha256",
+        },
+        "snapshot",
+    )
+    recorded_digest = _expect_string(item["snapshot_sha256"], "snapshot.snapshot_sha256")
+    if len(recorded_digest) != 64 or recorded_digest != recorded_digest.lower():
+        raise ValueError("snapshot.snapshot_sha256 must be a lowercase SHA-256 hex digest")
+    try:
+        bytes.fromhex(recorded_digest)
+    except ValueError as exc:
+        raise ValueError("snapshot.snapshot_sha256 must be a lowercase SHA-256 hex digest") from exc
+    unsigned = {key: field for key, field in item.items() if key != "snapshot_sha256"}
+    expected_digest = hashlib.sha256(_canonical_json_bytes(unsigned)).hexdigest()
+    if not hmac.compare_digest(recorded_digest, expected_digest):
+        raise ValueError("snapshot SHA-256 integrity check failed")
+    fingerprints_value = item["fingerprints"]
+    fingerprints: AnalysisFingerprints | None
+    if fingerprints_value is None:
+        fingerprints = None
+    else:
+        fingerprint_object = _expect_object(
+            fingerprints_value,
+            {"scan", "parser", "term_index", "retrieval"},
+            "snapshot.fingerprints",
+        )
+        fingerprints = AnalysisFingerprints(
+            scan=_expect_string(fingerprint_object["scan"], "snapshot.fingerprints.scan"),
+            parser=_expect_string(fingerprint_object["parser"], "snapshot.fingerprints.parser"),
+            term_index=_expect_string(
+                fingerprint_object["term_index"], "snapshot.fingerprints.term_index"
+            ),
+            retrieval=_expect_string(
+                fingerprint_object["retrieval"], "snapshot.fingerprints.retrieval"
+            ),
+        )
+    facts_value = _expect_object(
+        item["facts"],
+        {"files", "symbols", "dependencies", "entry_points"},
+        "snapshot.facts",
+    )
+    files = [
+        _parse_file(file, f"snapshot.facts.files[{index}]")
+        for index, file in enumerate(_expect_list(facts_value["files"], "snapshot.facts.files"))
+    ]
+    if len(files) != len({file.path for file in files}):
+        raise ValueError("snapshot.facts.files contains duplicate paths")
+    symbols = [
+        _parse_symbol(symbol, f"snapshot.facts.symbols[{index}]")
+        for index, symbol in enumerate(
+            _expect_list(facts_value["symbols"], "snapshot.facts.symbols")
+        )
+    ]
+    dependencies = [
+        _parse_dependency(dependency, f"snapshot.facts.dependencies[{index}]")
+        for index, dependency in enumerate(
+            _expect_list(facts_value["dependencies"], "snapshot.facts.dependencies")
+        )
+    ]
+    entries = [
+        _parse_entry(entry, f"snapshot.facts.entry_points[{index}]")
+        for index, entry in enumerate(
+            _expect_list(facts_value["entry_points"], "snapshot.facts.entry_points")
+        )
+    ]
+    _unique_facts(symbols, "snapshot.facts.symbols")
+    _unique_facts(dependencies, "snapshot.facts.dependencies")
+    _unique_facts(entries, "snapshot.facts.entry_points")
+    return RepositorySnapshot(
+        format_version=_expect_integer(item["format_version"], "snapshot.format_version"),
+        schema_version=_expect_integer(item["schema_version"], "snapshot.schema_version"),
+        repository_identity=_expect_string(
+            item["repository_identity"], "snapshot.repository_identity"
+        ),
+        generation=_expect_integer(item["generation"], "snapshot.generation"),
+        fingerprints=fingerprints,
+        dependency_resolver_fingerprint=_expect_optional_string(
+            item["dependency_resolver_fingerprint"],
+            "snapshot.dependency_resolver_fingerprint",
+        ),
+        facts=RepositoryFacts(
+            files={file.path: file for file in files},
+            symbols=frozenset(symbols),
+            dependencies=frozenset(dependencies),
+            entry_points=frozenset(entries),
+        ),
+    )
+
+
+def _reject_constant(value: str) -> NoReturn:
+    raise ValueError(f"non-finite JSON number is not allowed: {value}")
+
+
+def _reject_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("non-finite JSON numbers are not allowed")
+    return parsed
+
+
+def _object_without_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def dumps_snapshot(snapshot: RepositorySnapshot) -> str:
+    """Return deterministic compact JSON with one trailing newline."""
+
+    return _canonical_json_bytes(snapshot_to_dict(snapshot)).decode("ascii") + "\n"
+
+
+def loads_snapshot(payload: str | bytes | bytearray) -> RepositorySnapshot:
+    """Parse bounded JSON, rejecting duplicates, drift, and non-finite numbers."""
+
+    if not isinstance(payload, (str, bytes, bytearray)):
+        raise ValueError("snapshot payload must be text or bytes")
+    if len(payload) > _MAX_SNAPSHOT_BYTES:
+        raise ValueError("snapshot payload exceeds the 256 MiB limit")
+    try:
+        decoded = json.loads(
+            payload,
+            object_pairs_hook=_object_without_duplicate_keys,
+            parse_constant=_reject_constant,
+            parse_float=_reject_float,
+        )
+        return snapshot_from_dict(decoded)
+    except (json.JSONDecodeError, RecursionError, UnicodeDecodeError) as exc:
+        raise ValueError("snapshot JSON is invalid") from exc
+
+
+def load_snapshot(path: Path | str) -> RepositorySnapshot:
+    """Load one bounded snapshot file without executing repository code."""
+
+    source = Path(path)
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_BINARY", 0)
+    descriptor = -1
+    try:
+        before = _capture_fallback_state(source, directory=False)
+        descriptor = os.open(source, flags)
+        opened = _capture_fallback_descriptor_state(descriptor)
+        opened_metadata = os.fstat(descriptor)
+        if not _same_fallback_state(before, opened):
+            raise ValueError("snapshot file changed while it was opened")
+        if opened_metadata.st_size > _MAX_SNAPSHOT_BYTES:
+            raise ValueError("snapshot file exceeds the 256 MiB limit")
+        chunks: list[bytes] = []
+        remaining = opened_metadata.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 1024 * 1024))
+            if not chunk:
+                raise ValueError("snapshot file was truncated while reading")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if os.read(descriptor, 1):
+            raise ValueError("snapshot file grew while reading")
+        after_descriptor = _capture_fallback_descriptor_state(descriptor)
+        after_path = _capture_fallback_state(source, directory=False)
+        if not _same_fallback_state(opened, after_descriptor) or not _same_fallback_state(
+            opened, after_path
+        ):
+            raise ValueError("snapshot file changed while it was read")
+        payload = b"".join(chunks)
+    except AtomicWriteError as exc:
+        raise ValueError("snapshot path must be a non-symlink regular file") from exc
+    except ValueError:
+        raise
+    except OSError as exc:
+        raise ValueError(f"snapshot file cannot be read: {source}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return loads_snapshot(payload)
+
+
+def _safe_snapshot_parent(path: Path) -> Path:
+    parent = path.parent.expanduser()
+    absolute = Path(os.path.abspath(parent))
+    try:
+        resolved = parent.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(f"snapshot parent does not exist: {parent}") from exc
+    if os.path.normcase(str(absolute)) != os.path.normcase(str(resolved)):
+        raise ValueError("snapshot parent must not traverse symbolic links")
+    try:
+        metadata = resolved.lstat()
+    except OSError as exc:
+        raise ValueError(f"snapshot parent cannot be inspected: {resolved}") from exc
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise ValueError("snapshot parent must be a non-symlink directory")
+    return resolved
+
+
+def save_snapshot(
+    snapshot: RepositorySnapshot,
+    path: Path | str,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Publish canonical JSON via a same-directory temporary file."""
+
+    if not isinstance(overwrite, bool):
+        raise ValueError("overwrite must be true or false")
+    requested = Path(path)
+    if not requested.name or requested.name in {".", ".."}:
+        raise ValueError("snapshot path must name a file")
+    parent = _safe_snapshot_parent(requested)
+    destination = parent / requested.name
+    try:
+        existing = destination.lstat()
+    except FileNotFoundError:
+        existing = None
+    except OSError as exc:
+        raise ValueError(f"snapshot destination cannot be inspected: {destination}") from exc
+    if existing is not None:
+        if stat.S_ISLNK(existing.st_mode) or not stat.S_ISREG(existing.st_mode):
+            raise ValueError("snapshot destination must be a non-symlink regular file")
+        if not overwrite:
+            raise ValueError(f"snapshot already exists: {destination}")
+    payload = dumps_snapshot(snapshot).encode("utf-8")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            if hasattr(os, "fchmod"):
+                os.fchmod(stream.fileno(), 0o600)
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if overwrite:
+            os.replace(temporary, destination)
+        else:
+            try:
+                os.link(temporary, destination)
+            except FileExistsError as exc:
+                raise ValueError(f"snapshot already exists: {destination}") from exc
+            temporary.unlink()
+        if os.name != "nt":
+            directory_descriptor = os.open(
+                parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0),
+            )
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            temporary.unlink()
+        raise
+    return destination
+
+
+def _change_to_dict(change: FileChange) -> dict[str, object]:
+    return {
+        "kind": change.kind,
+        "old": _file_to_dict(change.old) if change.old is not None else None,
+        "new": _file_to_dict(change.new) if change.new is not None else None,
+    }
+
+
+def _review_to_dict(item: ReviewItem) -> dict[str, object]:
+    return {
+        "priority": item.priority,
+        "area": item.area,
+        "path": item.path,
+        "reason": item.reason,
+        "old": _evidence_to_dict(item.old) if item.old is not None else None,
+        "new": _evidence_to_dict(item.new) if item.new is not None else None,
+    }
+
+
+def diff_to_dict(diff: RepositoryDiff) -> dict[str, object]:
+    """Return stable JSON data for CLI, Action, and future MCP consumers."""
+
+    if not isinstance(diff, RepositoryDiff):
+        raise TypeError("diff must be a RepositoryDiff")
+    return {
+        "old_generation": diff.old_generation,
+        "new_generation": diff.new_generation,
+        "compatibility": {
+            "schema": diff.compatibility.schema,
+            "scan": diff.compatibility.scan,
+            "parser": diff.compatibility.parser,
+            "term_index": diff.compatibility.term_index,
+            "retrieval": diff.compatibility.retrieval,
+            "dependency_resolver": diff.compatibility.dependency_resolver,
+            "degraded": diff.compatibility.degraded,
+            "reasons": list(diff.compatibility.reasons),
+        },
+        "is_empty": diff.is_empty,
+        "added_files": [_file_to_dict(item) for item in diff.added_files],
+        "removed_files": [_file_to_dict(item) for item in diff.removed_files],
+        "changed_files": [_change_to_dict(item) for item in diff.changed_files],
+        "moved_files": [
+            {
+                "old": _file_to_dict(item.old),
+                "new": _file_to_dict(item.new),
+                "confidence": item.confidence,
+            }
+            for item in diff.moved_files
+        ],
+        "added_symbols": [_symbol_to_dict(item) for item in diff.added_symbols],
+        "removed_symbols": [_symbol_to_dict(item) for item in diff.removed_symbols],
+        "moved_symbols": [
+            {
+                "old": _symbol_to_dict(item.old),
+                "new": _symbol_to_dict(item.new),
+                "confidence": item.confidence,
+            }
+            for item in diff.moved_symbols
+        ],
+        "added_entry_points": [_entry_to_dict(item) for item in diff.added_entry_points],
+        "removed_entry_points": [_entry_to_dict(item) for item in diff.removed_entry_points],
+        "added_dependencies": [_dependency_to_dict(item) for item in diff.added_dependencies],
+        "removed_dependencies": [_dependency_to_dict(item) for item in diff.removed_dependencies],
+        "configuration_changes": [_change_to_dict(item) for item in diff.configuration_changes],
+        "security_boundary_changes": [
+            _change_to_dict(item) for item in diff.security_boundary_changes
+        ],
+        "test_area_changes": [_change_to_dict(item) for item in diff.test_area_changes],
+        "review_order": [_review_to_dict(item) for item in diff.review_order],
+    }
+
+
+def dumps_diff(diff: RepositoryDiff) -> str:
+    """Return canonical compact JSON for a diff result."""
+
+    return _canonical_json_bytes(diff_to_dict(diff)).decode("ascii") + "\n"

--- a/src/repolocus/index/view.py
+++ b/src/repolocus/index/view.py
@@ -12,8 +12,9 @@ from pathlib import Path, PurePosixPath
 from types import TracebackType
 from typing import Protocol
 
-from repolocus.analysis import DEPENDENCY_RESOLVER_FINGERPRINT
+from repolocus.analysis import DEPENDENCY_RESOLVER_FINGERPRINT, AnalysisFingerprints
 from repolocus.graph import ResolvedDependency
+from repolocus.models import ScannedFile, Symbol
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +55,14 @@ class RepositoryView(Protocol):
 
     generation: int
     root: Path
+    schema_version: int
+    repository_identity: str
+    fingerprints: AnalysisFingerprints | None
+    dependency_resolver_fingerprint: str | None
+
+    def file_manifest(self) -> Iterable[ScannedFile]: ...
+
+    def symbols(self) -> Iterable[Symbol]: ...
 
     def diagram_files(self) -> Iterable[DiagramFile]: ...
 
@@ -96,6 +105,10 @@ class SQLiteRepositoryView:
         self._file_summary_cache: tuple[FileSummary, ...] | None = None
         self.generation = 0
         self.root = Path(index.root)
+        self.schema_version = 0
+        self.repository_identity = ""
+        self.fingerprints: AnalysisFingerprints | None = None
+        self.dependency_resolver_fingerprint: str | None = None
 
     def __enter__(self) -> SQLiteRepositoryView:
         if self._active:
@@ -109,11 +122,23 @@ class SQLiteRepositoryView:
             self.generation = self._index._revision_in_transaction(
                 "content_generation", fallback="generation"
             )
-            resolver_row = self._index._connection.execute(
-                "SELECT value FROM meta WHERE key = 'dependency_resolver_fingerprint'"
-            ).fetchone()
-            resolver_fingerprint = str(resolver_row["value"]) if resolver_row is not None else None
-            if resolver_fingerprint != DEPENDENCY_RESOLVER_FINGERPRINT:
+            metadata = {
+                str(row["key"]): str(row["value"])
+                for row in self._index._connection.execute(
+                    "SELECT key, value FROM meta "
+                    "WHERE key IN ("
+                    "'schema_version', 'repository_identity', "
+                    "'scan_fingerprint', 'parser_fingerprint', "
+                    "'term_index_fingerprint', 'retrieval_fingerprint', "
+                    "'dependency_resolver_fingerprint'"
+                    ")"
+                )
+            }
+            self.schema_version = int(metadata.get("schema_version", "0"))
+            self.repository_identity = metadata.get("repository_identity", "")
+            self.fingerprints = AnalysisFingerprints.from_metadata(metadata)
+            self.dependency_resolver_fingerprint = metadata.get("dependency_resolver_fingerprint")
+            if self.dependency_resolver_fingerprint != DEPENDENCY_RESOLVER_FINGERPRINT:
                 from repolocus.index.store import StaleScanError
 
                 raise StaleScanError(
@@ -179,6 +204,62 @@ class SQLiteRepositoryView:
         ).fetchall()
         return tuple(
             DiagramFile(path=str(row["path"]), first_line=int(row["first_line"])) for row in rows
+        )
+
+    def file_manifest(self) -> tuple[ScannedFile, ...]:
+        """Return metadata-only files from this view's read transaction."""
+
+        self._ensure_active()
+        rows = self._index._connection.execute(
+            """
+            SELECT path, language, size_bytes, sha256, line_count, is_entry_point,
+                   mtime_ns, ctime_ns, provenance, stale
+            FROM files
+            WHERE provenance = 'source' AND stale = 0
+            ORDER BY path
+            """
+        ).fetchall()
+        return tuple(
+            ScannedFile(
+                path=str(row["path"]),
+                language=str(row["language"]),
+                size_bytes=int(row["size_bytes"]),
+                sha256=str(row["sha256"]),
+                line_count=int(row["line_count"]),
+                text="",
+                is_entry_point=bool(row["is_entry_point"]),
+                mtime_ns=int(row["mtime_ns"]),
+                ctime_ns=int(row["ctime_ns"]),
+                provenance="source",
+                stale=False,
+                facts_materialized=False,
+            )
+            for row in rows
+        )
+
+    def symbols(self) -> tuple[Symbol, ...]:
+        """Return source symbol locations without reading files or chunks."""
+
+        self._ensure_active()
+        rows = self._index._connection.execute(
+            """
+            SELECT s.name, s.kind, s.file_path, s.start_line, s.end_line, s.signature
+            FROM symbols AS s
+            JOIN files AS f ON f.path = s.file_path
+            WHERE f.provenance = 'source' AND f.stale = 0
+            ORDER BY s.file_path, s.start_line, s.end_line, s.name, s.kind, s.id
+            """
+        ).fetchall()
+        return tuple(
+            Symbol(
+                name=str(row["name"]),
+                kind=str(row["kind"]),
+                path=str(row["file_path"]),
+                start_line=int(row["start_line"]),
+                end_line=int(row["end_line"]),
+                signature=str(row["signature"]),
+            )
+            for row in rows
         )
 
     def file_summaries(self) -> tuple[FileSummary, ...]:
@@ -282,8 +363,10 @@ class SQLiteRepositoryView:
                        candidate.path AS candidate_path
                 FROM resolved_dependencies AS rd
                 JOIN dependencies AS d ON d.id = rd.dependency_id
+                JOIN files AS f ON f.path = rd.source_path
                 LEFT JOIN resolved_dependency_candidates AS candidate
                   ON candidate.dependency_id = rd.dependency_id
+                WHERE f.provenance = 'source' AND f.stale = 0
                 ORDER BY rd.source_path, rd.witness_line, d.target, d.kind,
                          rd.dependency_id, candidate.path
                 """

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -17,6 +17,9 @@ _METRICS = (
     "database_bytes",
     "wal_bytes",
 )
+_V020_BASELINE_IMPLEMENTATION_SHA256 = (
+    "c383815bf7f4b510d5d1fd29dd0c82303f44f180ef23c77488dbe6c1acb39f38"
+)
 
 
 def _benchmark_module() -> ModuleType:
@@ -79,7 +82,10 @@ def test_v020_versioned_manifests_fix_scale_and_baseline_provenance() -> None:
         assert manifest["minimum_source_bytes"] == source_bytes
         baseline = manifest["baseline"]
         assert baseline["benchmark_script_sha256"] == script_sha256
-        assert baseline["implementation_sha256"] == benchmark._implementation_sha256()
+        # The manifest is an immutable v0.2.0 reference measurement. Current
+        # runs record their own implementation digest in the benchmark report
+        # and are compared with, rather than relabeled as, this baseline.
+        assert baseline["implementation_sha256"] == _V020_BASELINE_IMPLEMENTATION_SHA256
         assert baseline["date"]
         assert baseline["python"]
         assert baseline["platform"]
@@ -316,6 +322,9 @@ def test_v020_benchmark_covers_every_versioned_operation(tmp_path: Path) -> None
     assert report["files"] == 60
     assert report["symbols"] == 300
     assert report["dependencies"] >= 59
+    assert report["implementation_sha256"] == benchmark._implementation_sha256()
+    assert report["benchmark_script_sha256"] == benchmark._script_sha256()
+    assert report["repolocus_version"] == benchmark.__version__
     assert report["gate"] == {"passed": True, "violations": []}
     assert set(report["operations"]) == set(benchmark._OPERATIONS)
     worker_pids = {measurement["worker_pid"] for measurement in report["operations"].values()}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from repolocus import __version__
 from repolocus.cli import _index_cache_permission_status, app
 from repolocus.config import Settings
 from repolocus.core import RepoLocusService
+from repolocus.index import index_path_for
 from repolocus.security import PrivacyStore
 
 runner = CliRunner()
@@ -46,6 +47,155 @@ def test_cli_scan_map_ask_and_diagram(sample_repo: Path, isolated_user_dirs: Pat
     assert ask_data["evidence"]
     assert diagram_result.exit_code == 0, diagram_result.output
     assert (sample_repo / "ARCHITECTURE.md").is_file()
+
+
+def test_cli_snapshot_is_reproducible_and_diffs_a_directory(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "baseline.json"
+
+    created = runner.invoke(app, ["snapshot", str(sample_repo), str(output)])
+
+    assert created.exit_code == 0, created.output
+    first = output.read_bytes()
+    first_text = first.decode("ascii")
+    first_data = json.loads(first_text)
+    assert first_text == (
+        json.dumps(
+            first_data,
+            ensure_ascii=True,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    repeated = runner.invoke(
+        app,
+        ["snapshot", str(sample_repo), str(output), "--force"],
+    )
+    assert repeated.exit_code == 0, repeated.output
+    assert output.read_bytes() == first
+
+    unicode_source = sample_repo / "src" / "demo" / "猫.py"
+    unicode_source.write_text("def meow() -> str:\n    return '喵'\n", encoding="utf-8")
+    difference = runner.invoke(
+        app,
+        [
+            "diff",
+            str(output),
+            str(sample_repo),
+            "--refresh",
+            "always",
+            "--json",
+        ],
+    )
+
+    assert difference.exit_code == 0, difference.output
+    difference.stdout.encode("ascii")
+    diff_data = json.loads(difference.stdout)
+    assert {item["path"] for item in diff_data["added_files"]} == {"src/demo/猫.py"}
+    assert "\\u732b" in difference.stdout
+
+
+def test_cli_diff_refresh_never_fails_closed_and_does_not_scan(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    monkeypatch,
+) -> None:
+    database = index_path_for(sample_repo)
+
+    missing = runner.invoke(
+        app,
+        ["diff", str(sample_repo), str(sample_repo), "--refresh", "never"],
+    )
+
+    assert missing.exit_code == 1
+    assert "no RepoLocus index exists" in missing.output
+    assert not database.exists()
+
+    scanned = runner.invoke(app, ["scan", str(sample_repo), "--json"])
+    assert scanned.exit_code == 0, scanned.output
+
+    def unexpected_scan(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("diff --refresh never must not scan the repository")
+
+    monkeypatch.setattr(RepoLocusService, "scan", unexpected_scan)
+    reused = runner.invoke(
+        app,
+        [
+            "diff",
+            str(sample_repo),
+            str(sample_repo),
+            "--refresh",
+            "never",
+            "--json",
+        ],
+    )
+
+    assert reused.exit_code == 0, reused.output
+    assert json.loads(reused.stdout)["is_empty"] is True
+
+
+def test_cli_snapshot_requires_force_and_rejects_symbolic_links(
+    sample_repo: Path,
+    isolated_user_dirs: Path,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "snapshot.json"
+    created = runner.invoke(app, ["snapshot", str(sample_repo), str(output)])
+    assert created.exit_code == 0, created.output
+    original = output.read_bytes()
+
+    readme = sample_repo / "README.md"
+    readme.write_text(readme.read_text(encoding="utf-8") + "\nChanged.\n", encoding="utf-8")
+    refused = runner.invoke(app, ["snapshot", str(sample_repo), str(output)])
+    assert refused.exit_code == 1
+    assert "snapshot already exists" in refused.output
+    assert output.read_bytes() == original
+
+    replaced = runner.invoke(
+        app,
+        ["snapshot", str(sample_repo), str(output), "--force"],
+    )
+    assert replaced.exit_code == 0, replaced.output
+    assert output.read_bytes() != original
+
+    never_output = tmp_path / "never.json"
+    never = runner.invoke(
+        app,
+        [
+            "snapshot",
+            str(sample_repo),
+            str(never_output),
+            "--refresh",
+            "never",
+        ],
+    )
+    assert never.exit_code == 1
+    assert "refresh must be one of" in never.output
+    assert not never_output.exists()
+
+    if os.name != "nt":
+        output_link = tmp_path / "snapshot-link.json"
+        output_link.symlink_to(output)
+        linked_output = runner.invoke(
+            app,
+            ["snapshot", str(sample_repo), str(output_link), "--force"],
+        )
+        assert linked_output.exit_code == 1
+        assert "non-symlink regular file" in linked_output.output
+
+        repository_link = tmp_path / "repository-link"
+        repository_link.symlink_to(sample_repo, target_is_directory=True)
+        linked_repository = runner.invoke(
+            app,
+            ["snapshot", str(repository_link), str(tmp_path / "linked-repo.json")],
+        )
+        assert linked_repository.exit_code == 1
+        assert "repository path must not be a symbolic link" in linked_repository.output
 
 
 def test_cli_cloud_without_consent_prints_preview(

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from repolocus.analysis import (
+    DEFAULT_ANALYSIS_FINGERPRINTS,
+    DEPENDENCY_RESOLVER_FINGERPRINT,
+    AnalysisFingerprints,
+)
+from repolocus.diff import (
+    EntryPointIdentity,
+    FileDigest,
+    RepositoryFacts,
+    RepositorySnapshot,
+    ResolvedDependencyIdentity,
+    SourceEvidence,
+    SymbolIdentity,
+    compare_snapshots,
+    dumps_diff,
+    dumps_snapshot,
+    load_snapshot,
+    loads_snapshot,
+    render_diff_markdown,
+    save_snapshot,
+    snapshot_from_index,
+)
+from repolocus.index import RepositoryIndex
+from repolocus.models import Chunk, Dependency, ScannedFile, ScanResult, ScanStats, Symbol
+
+
+def _sha(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _file(
+    path: str,
+    text: str,
+    *,
+    symbols: tuple[tuple[str, int, int], ...] = (),
+    dependencies: tuple[tuple[str, int], ...] = (),
+    entry_point: bool = False,
+) -> ScannedFile:
+    line_count = max(1, len(text.splitlines()))
+    return ScannedFile(
+        path=path,
+        language="python",
+        size_bytes=len(text.encode()),
+        sha256=_sha(text),
+        line_count=line_count,
+        text=text,
+        symbols=tuple(
+            Symbol(name, "function", path, start, end, f"def {name}()")
+            for name, start, end in symbols
+        ),
+        dependencies=tuple(
+            Dependency(path, target, "import", line) for target, line in dependencies
+        ),
+        chunks=(Chunk(path, 1, line_count, text, "python"),),
+        is_entry_point=entry_point,
+    )
+
+
+def _snapshot(
+    generation: int,
+    files: tuple[FileDigest, ...],
+    *,
+    symbols: tuple[SymbolIdentity, ...] = (),
+    dependencies: tuple[ResolvedDependencyIdentity, ...] = (),
+    entries: tuple[EntryPointIdentity, ...] = (),
+    fingerprints: AnalysisFingerprints | None = DEFAULT_ANALYSIS_FINGERPRINTS,
+    identity: str = "1" * 64,
+    schema: int = 6,
+) -> RepositorySnapshot:
+    return RepositorySnapshot(
+        schema_version=schema,
+        repository_identity=identity,
+        generation=generation,
+        fingerprints=fingerprints,
+        dependency_resolver_fingerprint=DEPENDENCY_RESOLVER_FINGERPRINT,
+        facts=RepositoryFacts(
+            files={file.path: file for file in files},
+            symbols=frozenset(symbols),
+            dependencies=frozenset(dependencies),
+            entry_points=frozenset(entries),
+        ),
+    )
+
+
+def _digest(path: str, content: str, generation: int, *, line_count: int = 1) -> FileDigest:
+    return FileDigest(
+        path,
+        _sha(content),
+        "python",
+        len(content.encode()),
+        line_count,
+        SourceEvidence(path, 1, line_count, generation),
+    )
+
+
+def _symbol(path: str, name: str, generation: int, line: int = 1) -> SymbolIdentity:
+    return SymbolIdentity(
+        name,
+        "function",
+        f"def {name}()",
+        SourceEvidence(path, line, line, generation),
+    )
+
+
+def test_same_snapshot_diff_is_empty_deterministic_and_identity_agnostic() -> None:
+    file = _digest("src/app.py", "same", 7)
+    first = _snapshot(7, (file,), symbols=(_symbol(file.path, "run", 7),))
+    identical_facts = replace(first, repository_identity="2" * 64)
+
+    first_diff = compare_snapshots(first, identical_facts)
+    second_diff = compare_snapshots(first, identical_facts)
+
+    assert first_diff.is_empty
+    assert first_diff == second_diff
+    assert dumps_diff(first_diff) == dumps_diff(second_diff)
+    assert first_diff.compatibility.degraded is False
+
+
+def test_diff_reports_files_symbols_exact_moves_entry_points_and_areas() -> None:
+    old_move = _digest("src/old.py", "move", 2)
+    new_move = _digest("src/new.py", "move", 5)
+    old_config = _digest("pyproject.toml", "version=1", 2)
+    new_config = _digest("pyproject.toml", "version=2", 5)
+    removed_security = _digest("src/security/auth.py", "allow", 2)
+    added_test = _digest("tests/test_new.py", "assert True", 5)
+    old = _snapshot(
+        2,
+        (old_move, old_config, removed_security),
+        symbols=(
+            _symbol(old_move.path, "run", 2),
+            _symbol(removed_security.path, "authorize", 2),
+        ),
+        entries=(EntryPointIdentity(SourceEvidence(old_move.path, 1, 1, 2)),),
+    )
+    new = _snapshot(
+        5,
+        (new_move, new_config, added_test),
+        symbols=(
+            _symbol(new_move.path, "run", 5),
+            _symbol(added_test.path, "test_new", 5),
+        ),
+        entries=(EntryPointIdentity(SourceEvidence(new_move.path, 1, 1, 5)),),
+    )
+
+    result = compare_snapshots(old, new)
+
+    assert [(move.old.path, move.new.path) for move in result.moved_files] == [
+        ("src/old.py", "src/new.py")
+    ]
+    assert [(move.old.name, move.new.name) for move in result.moved_symbols] == [("run", "run")]
+    assert [item.path for item in result.removed_files] == ["src/security/auth.py"]
+    assert [item.path for item in result.added_files] == ["tests/test_new.py"]
+    assert result.changed_files[0].old.evidence.generation == 2  # type: ignore[union-attr]
+    assert result.changed_files[0].new.evidence.generation == 5  # type: ignore[union-attr]
+    assert {item.new.path for item in result.configuration_changes if item.new} == {
+        "pyproject.toml"
+    }
+    assert result.security_boundary_changes[0].old == removed_security
+    assert result.test_area_changes[0].new == added_test
+    assert result.review_order[0].area == "security boundary"
+    assert any(item.area == "symbol" for item in result.review_order)
+
+
+def test_duplicate_file_digest_and_symbol_candidates_are_not_guessed_as_moves() -> None:
+    old_files = (
+        _digest("old/a.py", "duplicate", 1),
+        _digest("old/b.py", "duplicate", 1),
+    )
+    new_files = (
+        _digest("new/a.py", "duplicate", 2),
+        _digest("new/b.py", "duplicate", 2),
+    )
+    old = _snapshot(
+        1,
+        old_files,
+        symbols=tuple(_symbol(file.path, "same", 1) for file in old_files),
+    )
+    new = _snapshot(
+        2,
+        new_files,
+        symbols=tuple(_symbol(file.path, "same", 2) for file in new_files),
+    )
+
+    result = compare_snapshots(old, new)
+
+    assert result.moved_files == ()
+    assert result.moved_symbols == ()
+    assert len(result.removed_files) == len(result.added_files) == 2
+    assert len(result.removed_symbols) == len(result.added_symbols) == 2
+
+    unchanged_old = _digest("shared.py", "duplicate", 1)
+    unchanged_new = _digest("shared.py", "duplicate", 2)
+    result_with_unchanged_duplicate = compare_snapshots(
+        _snapshot(1, (old_files[0], unchanged_old)),
+        _snapshot(2, (new_files[0], unchanged_new)),
+    )
+    assert result_with_unchanged_duplicate.moved_files == ()
+
+
+def test_ambiguous_dependencies_remain_explicit_and_generation_pinned() -> None:
+    caller_old = _digest("src/caller.py", "import common", 1)
+    caller_new = _digest("src/caller.py", "import common", 2)
+    first_old = _digest("src/a/common.py", "a", 1)
+    second_old = _digest("src/b/common.py", "b", 1)
+    first_new = _digest("src/a/common.py", "a", 2)
+    second_new = _digest("src/b/common.py", "b", 2)
+    dependency_old = ResolvedDependencyIdentity(
+        "common",
+        None,
+        None,
+        "import",
+        "ambiguous",
+        ("src/a/common.py", "src/b/common.py"),
+        SourceEvidence(caller_old.path, 1, 1, 1),
+    )
+    dependency_new = replace(
+        dependency_old,
+        candidates=("src/a/common.py", "src/b/common.py", "src/c/common.py"),
+        evidence=SourceEvidence(caller_new.path, 1, 1, 2),
+    )
+    third_new = _digest("src/c/common.py", "c", 2)
+
+    result = compare_snapshots(
+        _snapshot(1, (caller_old, first_old, second_old), dependencies=(dependency_old,)),
+        _snapshot(
+            2,
+            (caller_new, first_new, second_new, third_new),
+            dependencies=(dependency_new,),
+        ),
+    )
+
+    assert result.removed_dependencies == (dependency_old,)
+    assert result.added_dependencies == (dependency_new,)
+    assert result.removed_dependencies[0].evidence.generation == 1
+    assert result.added_dependencies[0].evidence.generation == 2
+    assert result.added_dependencies[0].confidence == "ambiguous"
+
+
+def test_fingerprint_schema_mismatch_degrades_but_repository_identity_does_not() -> None:
+    file_old = _digest("app.py", "one", 1)
+    file_new = _digest("app.py", "one", 2)
+    changed_fingerprints = replace(DEFAULT_ANALYSIS_FINGERPRINTS, parser="a" * 64)
+
+    result = compare_snapshots(
+        _snapshot(1, (file_old,), identity="1" * 64),
+        _snapshot(
+            2,
+            (file_new,),
+            identity="2" * 64,
+            schema=7,
+            fingerprints=changed_fingerprints,
+        ),
+    )
+
+    assert result.compatibility.degraded
+    assert result.compatibility.schema is False
+    assert result.compatibility.parser is False
+    assert all("repository" not in reason for reason in result.compatibility.reasons)
+
+
+def test_snapshot_from_index_uses_projection_only_and_active_source_facts(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    caller = _file(
+        "src/caller.py",
+        "import common\ndef run():\n    return 1\n",
+        symbols=(("run", 2, 3),),
+        dependencies=(("common", 1),),
+        entry_point=True,
+    )
+    first = _file("src/a/common.py", "VALUE = 1\n")
+    second = _file("src/b/common.py", "VALUE = 2\n")
+    generated = replace(
+        _file("generated.py", "def hidden():\n    return 0\n", symbols=(("hidden", 1, 2),)),
+        provenance="generated",
+    )
+
+    with RepositoryIndex.open(repository, tmp_path / "cache") as index:
+        update = index.update(
+            ScanResult(repository, [caller, first, second, generated], ScanStats())
+        )
+        statements: list[str] = []
+        index._connection.set_trace_callback(statements.append)
+        try:
+            snapshot = snapshot_from_index(index, expected_generation=update.content_generation)
+        finally:
+            index._connection.set_trace_callback(None)
+
+    assert set(snapshot.facts.files) == {caller.path, first.path, second.path}
+    assert {symbol.name for symbol in snapshot.facts.symbols} == {"run"}
+    dependency = next(iter(snapshot.facts.dependencies))
+    assert dependency.confidence == "ambiguous"
+    assert dependency.candidates == (first.path, second.path)
+    assert snapshot.facts.entry_points == frozenset(
+        {EntryPointIdentity(SourceEvidence(caller.path, 1, 1, snapshot.generation))}
+    )
+    assert all("SELECT * FROM files" not in statement for statement in statements)
+    assert all("SELECT * FROM chunks" not in statement for statement in statements)
+    assert all("substr(text" not in statement.casefold() for statement in statements)
+    assert all(" f.text" not in statement.casefold() for statement in statements)
+
+
+def test_snapshot_json_is_canonical_integrity_checked_and_strict(tmp_path: Path) -> None:
+    snapshot = _snapshot(3, (_digest("app.py", "content", 3),))
+    payload = dumps_snapshot(snapshot)
+    destination = save_snapshot(snapshot, tmp_path / "snapshot.json")
+
+    if os.name != "nt":
+        assert destination.stat().st_mode & 0o077 == 0
+    assert load_snapshot(destination) == snapshot
+    assert loads_snapshot(payload) == snapshot
+    assert dumps_snapshot(loads_snapshot(payload)) == payload
+
+    tampered = json.loads(payload)
+    tampered["generation"] = 4
+    with pytest.raises(ValueError, match="integrity"):
+        loads_snapshot(json.dumps(tampered))
+
+    duplicate_key = payload.replace(
+        '{"dependency_resolver_fingerprint"', '{"generation":3,"dependency_resolver_fingerprint"', 1
+    )
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        loads_snapshot(duplicate_key)
+
+    unknown = json.loads(payload)
+    unsigned = {key: value for key, value in unknown.items() if key != "snapshot_sha256"}
+    unsigned["unexpected"] = True
+    unsigned["snapshot_sha256"] = hashlib.sha256(
+        json.dumps(
+            {key: value for key, value in unsigned.items() if key != "snapshot_sha256"},
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    with pytest.raises(ValueError, match="unknown"):
+        loads_snapshot(json.dumps(unsigned))
+
+    with pytest.raises(ValueError, match="non-finite"):
+        loads_snapshot(payload.replace('"generation":3', '"generation":NaN'))
+    if os.name != "nt":
+        symlink = tmp_path / "link.json"
+        symlink.symlink_to(destination)
+        with pytest.raises(ValueError, match="non-symlink"):
+            load_snapshot(symlink)
+
+
+def test_markdown_renderer_neutralizes_repository_controlled_markup_and_mentions() -> None:
+    path = "src/<img src=x onerror=alert(1)>@team|[x].py"
+    old_file = _digest(path, "old", 1)
+    new_file = _digest(path, "new", 2)
+    old = _snapshot(1, (old_file,), symbols=(_symbol(path, "@all<script>", 1),))
+    new = _snapshot(2, (new_file,))
+
+    rendered = render_diff_markdown(compare_snapshots(old, new), "@old<script>", "new|label")
+
+    assert "<script>" not in rendered
+    assert "<img " not in rendered
+    assert "@old" not in rendered
+    assert "@all" not in rendered
+    assert "&#64;old" in rendered
+    assert "&#64;all" in rendered
+    assert "http://" not in rendered
+    assert "https://" not in rendered
+
+
+def test_large_snapshot_diff_is_deterministic_without_source_text() -> None:
+    count = 4_000
+    old_files = tuple(
+        _digest(f"src/module_{index:05d}.py", f"value={index}", 10) for index in range(count)
+    )
+    new_files = tuple(
+        _digest(
+            f"src/module_{index:05d}.py",
+            f"value={index + 1}" if index % 1_000 == 0 else f"value={index}",
+            11,
+        )
+        for index in reversed(range(count))
+    )
+    old_symbols = tuple(
+        _symbol(file.path, f"symbol_{index}", 10) for index, file in enumerate(old_files)
+    )
+    new_symbols = tuple(
+        _symbol(file.path, f"symbol_{index}", 11) for index, file in enumerate(reversed(new_files))
+    )
+
+    old = _snapshot(10, old_files, symbols=old_symbols)
+    new = _snapshot(11, new_files, symbols=new_symbols)
+    first = compare_snapshots(old, new)
+    second = compare_snapshots(old, new)
+
+    assert len(first.changed_files) == 4
+    assert first == second
+    assert dumps_diff(first) == dumps_diff(second)
+    assert "content" not in dumps_snapshot(old)


### PR DESCRIPTION
## Summary

- add canonical, integrity-checked architecture snapshots without source bodies
- add a pure old/new diff for files, symbols, entry points, dependency edges, configuration, security boundaries, and tests
- expose `repolocus snapshot` and `repolocus diff`, including fail-closed existing-index reuse with `--refresh never`
- preserve historical v0.2.0 performance baselines while current runs record their own implementation digest

## Safety boundaries

- does not invoke Git, hooks, builds, tests, or target-repository commands
- rejects symlink snapshot inputs/outputs and validates generation plus component fingerprints
- emits canonical ASCII JSON and untrusted-text-safe Markdown

## Validation

- isolated committed-tree validation: 54 passed (`test_diff`, `test_cli`, `test_benchmarks`)
- broader core suite before commit: 623 passed, 11 skipped
- Ruff and `git diff --check` passed

Part of the v0.2.1 maintainer-workflow release; kept separate so this PR carries one reviewable invariant.