### PR TITLE
feat: add secure PR context action

### DIFF
--- a/.github/actions/pr-context/action.yml
+++ b/.github/actions/pr-context/action.yml
@@ -1,0 +1,170 @@
+name: RepoLocus PR Context
+description: Produce read-only architecture context artifacts for one pull request.
+
+inputs:
+  base-ref:
+    description: Full base commit SHA from github.event.pull_request.base.sha.
+    required: true
+  head-ref:
+    description: Full head commit SHA from github.event.pull_request.head.sha.
+    required: true
+  artifact-name:
+    description: Name for the uploaded Markdown and JSON artifact.
+    required: false
+    default: repolocus-pr-context
+  comment:
+    description: Explicitly opt in to a same-repository pull-request comment.
+    required: false
+    default: "false"
+  github-token:
+    description: Token used only when comment is true for a non-fork pull request.
+    required: false
+    default: ""
+
+outputs:
+  markdown-path:
+    description: Absolute path to the generated Markdown artifact.
+    value: ${{ steps.context.outputs.markdown-path }}
+  json-path:
+    description: Absolute path to the generated JSON artifact.
+    value: ${{ steps.context.outputs.json-path }}
+  comment-posted:
+    description: Whether the opt-in same-repository comment was posted.
+    value: ${{ steps.comment.outputs.posted || steps.validate.outputs.comment-posted }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate immutable PR inputs
+      id: validate
+      shell: bash
+      env:
+        ACTION_REF: ${{ github.action_ref }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        BASE_REF: ${{ inputs.base-ref }}
+        BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+        COMMENT: ${{ inputs.comment }}
+        EVENT_BASE_REF: ${{ github.event.pull_request.base.sha }}
+        EVENT_HEAD_REF: ${{ github.event.pull_request.head.sha }}
+        EVENT_NAME: ${{ github.event_name }}
+        HEAD_REF: ${{ inputs.head-ref }}
+        HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+      run: |
+        set -euo pipefail
+        if [[ ! "$ACTION_REF" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "RepoLocus PR Context must be referenced by a full lowercase commit SHA." >&2
+          exit 1
+        fi
+        if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          echo "RepoLocus PR Context only accepts the pull_request event." >&2
+          exit 1
+        fi
+        for revision in "$BASE_REF" "$HEAD_REF"; do
+          if [[ ! "$revision" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Base and head refs must be full lowercase commit SHAs." >&2
+            exit 1
+          fi
+        done
+        if [[ "$BASE_REF" != "$EVENT_BASE_REF" || "$HEAD_REF" != "$EVENT_HEAD_REF" ]]; then
+          echo "Base and head refs must exactly match the pull-request event revisions." >&2
+          exit 1
+        fi
+        for repository in "$BASE_REPOSITORY" "$HEAD_REPOSITORY"; do
+          if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "Pull-request repository identity is missing or invalid." >&2
+            exit 1
+          fi
+        done
+        if [[ ! "$ARTIFACT_NAME" =~ ^[A-Za-z0-9._-]{1,64}$ ]]; then
+          echo "artifact-name must contain only letters, digits, dot, underscore, or hyphen." >&2
+          exit 1
+        fi
+        if [[ "$COMMENT" != "true" && "$COMMENT" != "false" ]]; then
+          echo "comment must be exactly true or false." >&2
+          exit 1
+        fi
+        comment_eligible=false
+        if [[ "$COMMENT" == "true" && "$BASE_REPOSITORY" == "$HEAD_REPOSITORY" ]]; then
+          comment_eligible=true
+        elif [[ "$COMMENT" == "true" ]]; then
+          echo "::warning::PR comments are disabled for fork pull requests; artifacts will still be produced."
+        fi
+        echo "comment-eligible=$comment_eligible" >> "$GITHUB_OUTPUT"
+        echo "comment-posted=false" >> "$GITHUB_OUTPUT"
+
+    - name: Check out base revision
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: ${{ github.event.pull_request.base.repo.full_name }}
+        ref: ${{ inputs.base-ref }}
+        path: .repolocus-pr-context-${{ github.run_id }}-${{ github.run_attempt }}/base
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Check out head revision
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ inputs.head-ref }}
+        path: .repolocus-pr-context-${{ github.run_id }}-${{ github.run_attempt }}/head
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Install pinned uv
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        version: "0.9.18"
+        enable-cache: false
+
+    - name: Scan revisions and build PR context
+      id: context
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref }}
+        HEAD_REF: ${{ inputs.head-ref }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        trusted_root="$(cd "$GITHUB_ACTION_PATH/../../.." && pwd -P)"
+        if [[ "$trusted_root" == "$GITHUB_WORKSPACE" || "$trusted_root" == "$GITHUB_WORKSPACE/"* ]]; then
+          echo "Refusing to execute Action code from the analyzed checkout; use a full remote SHA." >&2
+          exit 1
+        fi
+        output_dir="$RUNNER_TEMP/repolocus-pr-context-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+        export UV_PROJECT_ENVIRONMENT="$RUNNER_TEMP/repolocus-pr-context-venv"
+        export XDG_CACHE_HOME="$RUNNER_TEMP/repolocus-pr-context-cache"
+        cd "$RUNNER_TEMP"
+        uv run --project "$trusted_root" --frozen --no-dev \
+          python -I "$trusted_root/scripts/pr_context.py" \
+          --base "$GITHUB_WORKSPACE/.repolocus-pr-context-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT/base" \
+          --head "$GITHUB_WORKSPACE/.repolocus-pr-context-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT/head" \
+          --base-revision "$BASE_REF" \
+          --head-revision "$HEAD_REF" \
+          --repository "$REPOSITORY" \
+          --output-dir "$output_dir"
+        echo "markdown-path=$output_dir/pr-context.md" >> "$GITHUB_OUTPUT"
+        echo "json-path=$output_dir/pr-context.json" >> "$GITHUB_OUTPUT"
+
+    - name: Upload PR context artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          ${{ steps.context.outputs.markdown-path }}
+          ${{ steps.context.outputs.json-path }}
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Publish explicitly requested same-repository comment
+      id: comment
+      if: ${{ steps.validate.outputs.comment-eligible == 'true' }}
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref }}
+        COMMENT_TOKEN: ${{ inputs.github-token }}
+        HEAD_REF: ${{ inputs.head-ref }}
+        MARKDOWN_PATH: ${{ steps.context.outputs.markdown-path }}
+      run: |
+        set -euo pipefail
+        node "$GITHUB_ACTION_PATH/post-comment.js"
+        echo "posted=true" >> "$GITHUB_OUTPUT"

--- a/.github/actions/pr-context/post-comment.js
+++ b/.github/actions/pr-context/post-comment.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const fs = require("fs");
+
+const marker = "<!-- repolocus-pr-context -->";
+const maxBodyLength = 60_000;
+
+function fail(message) {
+  throw new Error(`RepoLocus PR comment refused: ${message}`);
+}
+
+function required(name) {
+  const value = process.env[name] || "";
+  if (!value) fail(`${name} is required`);
+  return value;
+}
+
+async function request(url, token, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 500);
+    fail(`GitHub API returned ${response.status}: ${detail}`);
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+async function main() {
+  if (required("GITHUB_EVENT_NAME") !== "pull_request") {
+    fail("only pull_request events may publish comments");
+  }
+  const event = JSON.parse(fs.readFileSync(required("GITHUB_EVENT_PATH"), "utf8"));
+  const pullRequest = event.pull_request;
+  if (!pullRequest || !Number.isSafeInteger(pullRequest.number) || pullRequest.number < 1) {
+    fail("pull-request metadata is missing");
+  }
+  const baseRepository = pullRequest.base?.repo?.full_name;
+  const headRepository = pullRequest.head?.repo?.full_name;
+  if (!baseRepository || baseRepository !== headRepository || baseRepository !== required("GITHUB_REPOSITORY")) {
+    fail("fork or repository-mismatched pull requests cannot publish comments");
+  }
+  if (pullRequest.base.sha !== required("BASE_REF") || pullRequest.head.sha !== required("HEAD_REF")) {
+    fail("artifact revisions do not match the event revisions");
+  }
+
+  const token = required("COMMENT_TOKEN");
+  let body = fs.readFileSync(required("MARKDOWN_PATH"), "utf8");
+  if (body.length > maxBodyLength) {
+    body = `${body.slice(0, maxBodyLength)}\n\n_Context truncated; download the JSON artifact for the complete diff._\n`;
+  }
+  body = `${marker}\n${body}`;
+
+  const api = required("GITHUB_API_URL").replace(/\/$/, "");
+  const [owner, repository] = baseRepository.split("/");
+  const commentsUrl = `${api}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}` +
+    `/issues/${pullRequest.number}/comments`;
+  const comments = await request(`${commentsUrl}?per_page=100`, token);
+  const existing = comments.find(
+    (comment) => comment.user?.login === "github-actions[bot]" &&
+      typeof comment.body === "string" && comment.body.startsWith(marker),
+  );
+  if (existing) {
+    await request(`${api}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}` +
+      `/issues/comments/${existing.id}`, token, { method: "PATCH", body: JSON.stringify({ body }) });
+  } else {
+    await request(commentsUrl, token, { method: "POST", body: JSON.stringify({ body }) });
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/scripts/pr_context.py
+++ b/scripts/pr_context.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Build deterministic PR-context artifacts from two checked-out repositories.
+
+Git checkout and optional comment publication deliberately stay outside this
+wrapper.  The repositories are treated as untrusted input: RepoLocus scans
+their files, but never imports them or executes their commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from repolocus import __version__
+from repolocus.config import Settings
+from repolocus.core import RepoLocusService
+from repolocus.diff import (
+    compare_snapshots,
+    diff_to_dict,
+    render_diff_markdown,
+    snapshot_from_index,
+)
+from repolocus.index import RepositoryIndex
+
+_REVISION = re.compile(r"[0-9a-f]{40}")
+_REPOSITORY = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_FORMAT_VERSION = 1
+_JSON_NAME = "pr-context.json"
+_MARKDOWN_NAME = "pr-context.md"
+_ACTIVE_SCHEME = re.compile(r"(?i)(?<![A-Za-z0-9+.-])(https?|javascript|mailto):")
+
+
+def _safe_markdown(document: str) -> str:
+    """Neutralize active HTML and mentions in core-rendered Markdown."""
+
+    escaped = (
+        document.replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("@", "&#64;")
+        .replace("[", r"\[")
+        .replace("]", r"\]")
+    )
+    return _ACTIVE_SCHEME.sub(lambda match: match.group(1) + "&#58;", escaped)
+
+
+def _revision(value: str, field: str) -> str:
+    if not _REVISION.fullmatch(value):
+        raise ValueError(f"{field} must be a full lowercase 40-character Git commit SHA")
+    return value
+
+
+def _repository_name(value: str) -> str:
+    if not _REPOSITORY.fullmatch(value):
+        raise ValueError("repository must use the owner/name form")
+    return value
+
+
+def _repository_path(value: Path, field: str) -> Path:
+    candidate = Path(value).expanduser()
+    try:
+        metadata = candidate.lstat()
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(f"{field} repository does not exist: {candidate}") from exc
+    resolved_metadata = resolved.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or (metadata.st_dev, metadata.st_ino)
+        != (resolved_metadata.st_dev, resolved_metadata.st_ino)
+    ):
+        raise ValueError(f"{field} repository must be a stable, non-symlink directory")
+    return resolved
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _output_directory(value: Path, repositories: tuple[Path, Path]) -> Path:
+    candidate = Path(value).expanduser()
+    if candidate.exists() and candidate.is_symlink():
+        raise ValueError("output directory must not be a symlink")
+    resolved = candidate.resolve(strict=False)
+    if any(_is_within(resolved, repository) for repository in repositories):
+        raise ValueError("PR-context artifacts must be written outside analyzed repositories")
+    if resolved.exists() and any(resolved.iterdir()):
+        raise ValueError("output directory must be empty")
+    resolved.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if resolved.is_symlink() or not resolved.is_dir():
+        raise ValueError("output directory must be a stable, non-symlink directory")
+    if os.name != "nt":
+        resolved.chmod(0o700)
+    return resolved
+
+
+def _open_output_directory(path: Path) -> tuple[int, os.stat_result]:
+    """Pin the Action's output directory across the potentially long scans."""
+
+    if os.name == "nt":  # pragma: no cover - the composite Action is Linux-only
+        raise ValueError("descriptor-bound PR-context output requires a POSIX runner")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    before = path.lstat()
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino)
+        ):
+            raise ValueError("output directory changed while it was opened")
+        return descriptor, opened
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _write_new_at(directory: int, name: str, payload: bytes) -> None:
+    """Create one private artifact relative to a pinned directory descriptor."""
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_BINARY", 0)
+    descriptor = os.open(name, flags, 0o600, dir_fd=directory)
+    try:
+        try:
+            view = memoryview(payload)
+            offset = 0
+            while offset < len(view):
+                written = os.write(descriptor, view[offset:])
+                if written <= 0:
+                    raise OSError("short write while creating PR-context artifact")
+                offset += written
+            if hasattr(os, "fchmod"):
+                os.fchmod(descriptor, 0o600)
+            os.fsync(descriptor)
+        except BaseException:
+            with suppress(OSError):
+                os.unlink(name, dir_fd=directory)
+            raise
+    finally:
+        os.close(descriptor)
+
+
+def _attest_output_directory(path: Path, opened: os.stat_result) -> None:
+    try:
+        current = path.lstat()
+    except OSError as exc:
+        raise ValueError("output directory changed while artifacts were generated") from exc
+    if (
+        not stat.S_ISDIR(current.st_mode)
+        or stat.S_ISLNK(current.st_mode)
+        or (current.st_dev, current.st_ino) != (opened.st_dev, opened.st_ino)
+    ):
+        raise ValueError("output directory changed while artifacts were generated")
+
+
+def _capture_snapshot(root: Path):
+    """Scan one checkout and capture its committed projection-only facts."""
+
+    operation = RepoLocusService(Settings()).scan(root, refresh="rebuild")
+    with RepositoryIndex.open(root) as index:
+        return snapshot_from_index(index, expected_generation=operation.update.content_generation)
+
+
+def _fingerprints(snapshot: Any) -> dict[str, str] | None:
+    value = snapshot.fingerprints
+    if value is None:
+        return None
+    return {
+        "scan": value.scan,
+        "parser": value.parser,
+        "term_index": value.term_index,
+        "retrieval": value.retrieval,
+    }
+
+
+def _snapshot_metadata(snapshot: Any) -> dict[str, object]:
+    facts = snapshot.facts
+    return {
+        "format_version": snapshot.format_version,
+        "schema_version": snapshot.schema_version,
+        "repository_identity": snapshot.repository_identity,
+        "content_generation": snapshot.generation,
+        "fingerprints": _fingerprints(snapshot),
+        "dependency_resolver_fingerprint": snapshot.dependency_resolver_fingerprint,
+        "fact_counts": {
+            "files": len(facts.files),
+            "symbols": len(facts.symbols),
+            "dependencies": len(facts.dependencies),
+            "entry_points": len(facts.entry_points),
+        },
+    }
+
+
+def build_context(
+    *,
+    base_root: Path,
+    head_root: Path,
+    base_revision: str,
+    head_revision: str,
+    repository: str,
+) -> tuple[dict[str, object], str]:
+    """Scan both checkouts, run the pure diff, and render portable artifacts."""
+
+    base = _repository_path(base_root, "base")
+    head = _repository_path(head_root, "head")
+    if base == head:
+        raise ValueError("base and head must be separate checkout directories")
+    base_sha = _revision(base_revision, "base revision")
+    head_sha = _revision(head_revision, "head revision")
+    repository_name = _repository_name(repository)
+
+    base_snapshot = _capture_snapshot(base)
+    head_snapshot = _capture_snapshot(head)
+    difference = compare_snapshots(base_snapshot, head_snapshot)
+    payload: dict[str, object] = {
+        "format_version": _FORMAT_VERSION,
+        "kind": "repolocus-pr-context",
+        "repository": repository_name,
+        "generated_by": {"name": "RepoLocus", "version": __version__},
+        "base": {
+            "revision": base_sha,
+            "snapshot": _snapshot_metadata(base_snapshot),
+        },
+        "head": {
+            "revision": head_sha,
+            "snapshot": _snapshot_metadata(head_snapshot),
+        },
+        "diff": diff_to_dict(difference),
+    }
+    markdown = "\n".join(
+        (
+            "# RepoLocus PR Context",
+            "",
+            f"- Repository: `{repository_name}`",
+            f"- Base revision: `{base_sha}`",
+            f"- Head revision: `{head_sha}`",
+            f"- RepoLocus version: `{__version__}`",
+            "",
+            _safe_markdown(render_diff_markdown(difference).rstrip()),
+            "",
+        )
+    )
+    return payload, markdown
+
+
+def write_context(
+    *,
+    base_root: Path,
+    head_root: Path,
+    base_revision: str,
+    head_revision: str,
+    repository: str,
+    output_dir: Path,
+) -> tuple[Path, Path]:
+    base = _repository_path(base_root, "base")
+    head = _repository_path(head_root, "head")
+    output = _output_directory(output_dir, (base, head))
+    directory, opened = _open_output_directory(output)
+    created: list[str] = []
+    try:
+        payload, markdown = build_context(
+            base_root=base,
+            head_root=head,
+            base_revision=base_revision,
+            head_revision=head_revision,
+            repository=repository,
+        )
+        _attest_output_directory(output, opened)
+        encoded_json = (
+            json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n"
+        ).encode("ascii")
+        for name, content in (
+            (_JSON_NAME, encoded_json),
+            (_MARKDOWN_NAME, markdown.encode("utf-8")),
+        ):
+            _write_new_at(directory, name, content)
+            created.append(name)
+        os.fsync(directory)
+        _attest_output_directory(output, opened)
+    except BaseException:
+        for name in created:
+            with suppress(OSError):
+                os.unlink(name, dir_fd=directory)
+        raise
+    finally:
+        os.close(directory)
+    json_path = output / _JSON_NAME
+    markdown_path = output / _MARKDOWN_NAME
+    return markdown_path, json_path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, type=Path)
+    parser.add_argument("--head", required=True, type=Path)
+    parser.add_argument("--base-revision", required=True)
+    parser.add_argument("--head-revision", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    markdown_path, json_path = write_context(
+        base_root=arguments.base,
+        head_root=arguments.head,
+        base_revision=arguments.base_revision,
+        head_revision=arguments.head_revision,
+        repository=arguments.repository,
+        output_dir=arguments.output_dir,
+    )
+    print(
+        json.dumps(
+            {"markdown_path": str(markdown_path), "json_path": str(json_path)},
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_context.py
+++ b/tests/test_pr_context.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from repolocus import __version__
+from repolocus.analysis import AnalysisFingerprints
+from repolocus.diff.engine import compare_snapshots
+from repolocus.diff.models import (
+    FileDigest,
+    RepositoryFacts,
+    RepositorySnapshot,
+    SourceEvidence,
+)
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _ROOT / "scripts" / "pr_context.py"
+_ACTION_PATH = _ROOT / ".github" / "actions" / "pr-context" / "action.yml"
+_COMMENT_PATH = _ROOT / ".github" / "actions" / "pr-context" / "post-comment.js"
+
+
+def _load_script():
+    specification = importlib.util.spec_from_file_location("repolocus_pr_context", _SCRIPT_PATH)
+    assert specification is not None and specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def _snapshot(*, identity: str, generation: int, digest: str) -> RepositorySnapshot:
+    fingerprints = AnalysisFingerprints("1" * 64, "2" * 64, "3" * 64, "4" * 64)
+    evidence = SourceEvidence("src/app.py", 1, 2, generation)
+    file = FileDigest("src/app.py", digest, "python", 24, 2, evidence)
+    return RepositorySnapshot(
+        schema_version=6,
+        repository_identity=identity,
+        generation=generation,
+        fingerprints=fingerprints,
+        dependency_resolver_fingerprint="5" * 64,
+        facts=RepositoryFacts(
+            files={file.path: file},
+            symbols=frozenset(),
+            dependencies=frozenset(),
+            entry_points=frozenset(),
+        ),
+    )
+
+
+def test_context_artifacts_are_deterministic_and_record_revisions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    module = _load_script()
+    base_root = tmp_path / "base"
+    head_root = tmp_path / "head"
+    base_root.mkdir()
+    head_root.mkdir()
+    base = _snapshot(identity="a" * 64, generation=7, digest="b" * 64)
+    head = _snapshot(identity="c" * 64, generation=11, digest="d" * 64)
+
+    snapshots = iter((base, head, base, head))
+    monkeypatch.setattr(module, "_capture_snapshot", lambda _root: next(snapshots))
+    arguments = {
+        "base_root": base_root,
+        "head_root": head_root,
+        "base_revision": "1" * 40,
+        "head_revision": "2" * 40,
+        "repository": "owner/project",
+    }
+    first_payload, first_markdown = module.build_context(**arguments)
+    second_payload, second_markdown = module.build_context(**arguments)
+
+    assert first_payload == second_payload
+    assert first_markdown == second_markdown
+    assert first_payload["base"]["revision"] == "1" * 40
+    assert first_payload["head"]["revision"] == "2" * 40
+    assert first_payload["generated_by"] == {"name": "RepoLocus", "version": __version__}
+    assert first_payload["base"]["snapshot"]["fingerprints"]["parser"] == "2" * 64
+    assert first_payload["diff"] == module.diff_to_dict(compare_snapshots(base, head))
+    assert "# RepoLocus PR Context" in first_markdown
+    assert f"RepoLocus version: `{__version__}`" in first_markdown
+
+
+def test_write_context_emits_only_external_markdown_and_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    if os.name == "nt":
+        pytest.skip("the composite Action uses a POSIX runner")
+    module = _load_script()
+    base_root = tmp_path / "base"
+    head_root = tmp_path / "head"
+    output = tmp_path / "artifacts"
+    base_root.mkdir()
+    head_root.mkdir()
+    snapshots = iter(
+        (
+            _snapshot(identity="a" * 64, generation=1, digest="b" * 64),
+            _snapshot(identity="c" * 64, generation=2, digest="d" * 64),
+        )
+    )
+    monkeypatch.setattr(module, "_capture_snapshot", lambda _root: next(snapshots))
+
+    markdown_path, json_path = module.write_context(
+        base_root=base_root,
+        head_root=head_root,
+        base_revision="1" * 40,
+        head_revision="2" * 40,
+        repository="owner/project",
+        output_dir=output,
+    )
+
+    assert {path.name for path in output.iterdir()} == {"pr-context.md", "pr-context.json"}
+    assert markdown_path.read_text(encoding="utf-8").startswith("# RepoLocus PR Context\n")
+    document = json.loads(json_path.read_text(encoding="utf-8"))
+    assert document["kind"] == "repolocus-pr-context"
+    assert document["base"]["snapshot"]["content_generation"] == 1
+    if os.name != "nt":
+        assert json_path.stat().st_mode & 0o077 == 0
+        assert markdown_path.stat().st_mode & 0o077 == 0
+
+
+def test_write_context_rejects_output_directory_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    if os.name == "nt":
+        pytest.skip("the composite Action uses a POSIX runner")
+    module = _load_script()
+    base_root = tmp_path / "base"
+    head_root = tmp_path / "head"
+    output = tmp_path / "artifacts"
+    victim = tmp_path / "victim"
+    displaced = tmp_path / "displaced"
+    base_root.mkdir()
+    head_root.mkdir()
+    victim.mkdir()
+    (victim / "pr-context.json").write_text("keep\n", encoding="utf-8")
+
+    snapshots = iter(
+        (
+            _snapshot(identity="a" * 64, generation=1, digest="b" * 64),
+            _snapshot(identity="c" * 64, generation=2, digest="d" * 64),
+        )
+    )
+
+    def replace_after_first_scan(_root: Path):  # type: ignore[no-untyped-def]
+        snapshot = next(snapshots)
+        if output.exists() and not displaced.exists():
+            output.rename(displaced)
+            output.symlink_to(victim, target_is_directory=True)
+        return snapshot
+
+    monkeypatch.setattr(module, "_capture_snapshot", replace_after_first_scan)
+
+    with pytest.raises(ValueError, match="output directory changed"):
+        module.write_context(
+            base_root=base_root,
+            head_root=head_root,
+            base_revision="1" * 40,
+            head_revision="2" * 40,
+            repository="owner/project",
+            output_dir=output,
+        )
+
+    assert (victim / "pr-context.json").read_text(encoding="utf-8") == "keep\n"
+    assert not (victim / "pr-context.md").exists()
+
+
+def test_build_context_scans_real_checkouts_without_running_repository_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    module = _load_script()
+    base_root = tmp_path / "base"
+    head_root = tmp_path / "head"
+    base_root.mkdir()
+    head_root.mkdir()
+    (base_root / "app.py").write_text(
+        "def run():\n    return 'base'\n",
+        encoding="utf-8",
+    )
+    (head_root / "app.py").write_text(
+        "def run():\n    return 'head'\n",
+        encoding="utf-8",
+    )
+    # A scanner input named like an executable remains inert repository text.
+    marker = tmp_path / "executed"
+    (head_root / "danger.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).touch()\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    payload, markdown = module.build_context(
+        base_root=base_root,
+        head_root=head_root,
+        base_revision="1" * 40,
+        head_revision="2" * 40,
+        repository="owner/project",
+    )
+
+    assert payload["diff"]["is_empty"] is False
+    assert payload["base"]["snapshot"]["fact_counts"]["files"] == 1
+    assert payload["head"]["snapshot"]["fact_counts"]["files"] == 2
+    assert "Changed" in markdown
+    assert not marker.exists()
+
+
+def test_context_rejects_mutable_revisions_and_repository_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    module = _load_script()
+    base_root = tmp_path / "base"
+    head_root = tmp_path / "head"
+    base_root.mkdir()
+    head_root.mkdir()
+    monkeypatch.setattr(
+        module,
+        "_capture_snapshot",
+        lambda _root: pytest.fail("invalid input must fail before scanning"),
+    )
+
+    with pytest.raises(ValueError, match="full lowercase"):
+        module.build_context(
+            base_root=base_root,
+            head_root=head_root,
+            base_revision="main",
+            head_revision="2" * 40,
+            repository="owner/project",
+        )
+    with pytest.raises(ValueError, match="outside analyzed repositories"):
+        module._output_directory(base_root / "artifacts", (base_root, head_root))
+
+
+def test_wrapper_never_imports_process_or_git_execution_apis() -> None:
+    tree = ast.parse(_SCRIPT_PATH.read_text(encoding="utf-8"))
+    imported = {
+        alias.name.split(".", 1)[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert imported.isdisjoint({"subprocess", "shlex", "git"})
+    assert "os.system" not in _SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def test_composite_action_is_read_only_by_default_and_fork_safe() -> None:
+    action = _ACTION_PATH.read_text(encoding="utf-8")
+
+    assert 'default: "false"' in action
+    assert action.count("persist-credentials: false") == 2
+    assert "pull_request_target" not in action
+    assert 'if [[ "$EVENT_NAME" != "pull_request" ]]' in action
+    assert "ACTION_REF: ${{ github.action_ref }}" in action
+    assert '[[ ! "$ACTION_REF" =~ ^[0-9a-f]{40}$ ]]' in action
+    assert "EVENT_BASE_REF: ${{ github.event.pull_request.base.sha }}" in action
+    assert "EVENT_HEAD_REF: ${{ github.event.pull_request.head.sha }}" in action
+    assert '"$BASE_REF" != "$EVENT_BASE_REF"' in action
+    assert '"$HEAD_REF" != "$EVENT_HEAD_REF"' in action
+    assert '"$BASE_REPOSITORY" == "$HEAD_REPOSITORY"' in action
+    assert "comments are disabled for fork pull requests" in action
+    assert "steps.validate.outputs.comment-eligible == 'true'" in action
+    assert "COMMENT_TOKEN: ${{ inputs.github-token }}" in action
+    assert "permissions:" not in action
+    assert "secrets." not in action
+
+
+def test_composite_action_executes_only_pinned_trusted_tooling() -> None:
+    action = _ACTION_PATH.read_text(encoding="utf-8")
+    references = re.findall(r"^\s*uses:\s*([^#\s]+)", action, re.MULTILINE)
+    assert references
+    assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", reference) for reference in references)
+    assert 'trusted_root="$(cd "$GITHUB_ACTION_PATH/../../.." && pwd -P)"' in action
+    assert "Refusing to execute Action code from the analyzed checkout" in action
+    assert 'uv run --project "$trusted_root" --frozen --no-dev' in action
+    assert 'python -I "$trusted_root/scripts/pr_context.py"' in action
+    assert ".repolocus-pr-context-${{ github.run_id }}-${{ github.run_attempt }}/base" in action
+    assert ".repolocus-pr-context-${{ github.run_id }}-${{ github.run_attempt }}/head" in action
+    assert "actions/upload-artifact@" in action
+
+
+def test_markdown_defense_neutralizes_html_and_mentions() -> None:
+    module = _load_script()
+    hostile = "<img src=x onerror=alert(1)> @maintainers [safe-looking](javascript:alert(1))"
+
+    rendered = module._safe_markdown(hostile)
+
+    assert "<img" not in rendered
+    assert "@maintainers" not in rendered
+    assert "[safe-looking](" not in rendered
+    assert "javascript:" not in rendered
+    assert "&lt;img" in rendered
+    assert "&#64;maintainers" in rendered
+    assert r"\[safe-looking\](javascript&#58;alert(1))" in rendered
+
+
+def test_comment_publisher_has_valid_javascript_and_revision_guards() -> None:
+    result = subprocess.run(
+        ["node", "--check", str(_COMMENT_PATH)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    publisher = _COMMENT_PATH.read_text(encoding="utf-8")
+    assert 'required("GITHUB_EVENT_NAME") !== "pull_request"' in publisher
+    assert "baseRepository !== headRepository" in publisher
+    assert 'pullRequest.base.sha !== required("BASE_REF")' in publisher
+    assert 'pullRequest.head.sha !== required("HEAD_REF")' in publisher
+    assert "maxBodyLength = 60_000" in publisher
+    assert 'comment.user?.login === "github-actions[bot]"' in publisher


### PR DESCRIPTION
## Summary

- add a reusable PR Context composite Action pinned to exact base/head event SHAs
- keep artifact-only output as the default and refuse comment mode for fork PRs
- pin output-directory identity across analysis and use create-only, no-follow writes
- neutralize untrusted Markdown while preserving evidence citations

## Invariant

The action analyzes only the two explicitly event-bound checkouts, executes no target-repository code, and cannot overwrite pre-existing or redirected output files.

## Validation

- `uv run pytest -q tests/test_pr_context.py` (10 passed)
- Ruff check/format
- Node syntax check
- full suite on the combined v0.2.1 tree: 729 passed, 11 skipped
