### PR TITLE
fix: make PR context artifacts portable

### DIFF
--- a/scripts/pr_context.py
+++ b/scripts/pr_context.py
@@ -192,7 +192,6 @@ def _snapshot_metadata(snapshot: Any) -> dict[str, object]:
     return {
         "format_version": snapshot.format_version,
         "schema_version": snapshot.schema_version,
-        "repository_identity": snapshot.repository_identity,
         "content_generation": snapshot.generation,
         "fingerprints": _fingerprints(snapshot),
         "dependency_resolver_fingerprint": snapshot.dependency_resolver_fingerprint,

--- a/tests/test_pr_context.py
+++ b/tests/test_pr_context.py
@@ -64,7 +64,9 @@ def test_context_artifacts_are_deterministic_and_record_revisions(
     base = _snapshot(identity="a" * 64, generation=7, digest="b" * 64)
     head = _snapshot(identity="c" * 64, generation=11, digest="d" * 64)
 
-    snapshots = iter((base, head, base, head))
+    relocated_base = _snapshot(identity="e" * 64, generation=7, digest="b" * 64)
+    relocated_head = _snapshot(identity="f" * 64, generation=11, digest="d" * 64)
+    snapshots = iter((base, head, relocated_base, relocated_head))
     monkeypatch.setattr(module, "_capture_snapshot", lambda _root: next(snapshots))
     arguments = {
         "base_root": base_root,
@@ -82,6 +84,7 @@ def test_context_artifacts_are_deterministic_and_record_revisions(
     assert first_payload["head"]["revision"] == "2" * 40
     assert first_payload["generated_by"] == {"name": "RepoLocus", "version": __version__}
     assert first_payload["base"]["snapshot"]["fingerprints"]["parser"] == "2" * 64
+    assert "repository_identity" not in first_payload["base"]["snapshot"]
     assert first_payload["diff"] == module.diff_to_dict(compare_snapshots(base, head))
     assert "# RepoLocus PR Context" in first_markdown
     assert f"RepoLocus version: `{__version__}`" in first_markdown


### PR DESCRIPTION
## Summary

- omit host-specific cache identity from PR-context snapshot metadata
- preserve stable repository and full base/head revision identities already present in the artifact
- prove that distinct filesystem identities produce byte-equivalent payloads and Markdown

## Invariant

For identical repository contents, full revisions, and analysis fingerprints, PR Context artifacts do not depend on runner device/inode identity.

## Validation

- `uv run pytest -q tests/test_pr_context.py` (10 passed)
- Ruff check/format
