### PR TITLE
release: prepare v0.2.1 public benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,60 @@ jobs:
           path: v0.2-benchmark.json
           if-no-files-found: error
 
+  public-benchmark:
+    needs: [external-evaluation, performance-benchmark]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          version: "0.9.18"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: external-evaluation
+          path: public-inputs/evaluation
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: v0.2-benchmark
+          path: public-inputs/performance
+      - run: uv sync --all-extras --locked
+      - name: Build the provenance-pinned public regression report
+        run: >-
+          uv run python scripts/public_benchmark_report.py
+          --manifest benchmarks/public-benchmark-manifest.json
+          --evaluation-report public-inputs/evaluation/external-evaluation.json
+          --performance-report public-inputs/performance/v0.2-benchmark.json
+          --json-output benchmarks/results/public-report.json
+          --markdown-output benchmarks/results/public-report.md
+      - name: Verify the public report is byte-reproducible
+        run: >-
+          uv run python scripts/public_benchmark_report.py
+          --manifest benchmarks/public-benchmark-manifest.json
+          --evaluation-report public-inputs/evaluation/external-evaluation.json
+          --performance-report public-inputs/performance/v0.2-benchmark.json
+          --json-output benchmarks/results/public-report.json
+          --markdown-output benchmarks/results/public-report.md
+          --check
+      - name: Upload the public report and its reproduction inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-benchmark
+          path: |
+            benchmarks/results/public-report.json
+            benchmarks/results/public-report.md
+            public-inputs/evaluation/external-evaluation.json
+            public-inputs/performance/v0.2-benchmark.json
+            benchmarks/public-benchmark-manifest.json
+            benchmarks/public-benchmark-report.schema.json
+          if-no-files-found: error
+
   package:
-    needs: [test, coverage, security, external-evaluation, performance-benchmark]
+    needs: [test, coverage, security, external-evaluation, performance-benchmark, public-benchmark]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -149,12 +201,13 @@ jobs:
           COVERAGE_RESULT: ${{ needs.coverage.result }}
           EVALUATION_RESULT: ${{ needs.external-evaluation.result }}
           PERFORMANCE_RESULT: ${{ needs.performance-benchmark.result }}
+          PUBLIC_BENCHMARK_RESULT: ${{ needs.public-benchmark.result }}
           SECURITY_RESULT: ${{ needs.security.result }}
           TEST_RESULT: ${{ needs.test.result }}
         run: |
           for result in \
             "$TEST_RESULT" "$COVERAGE_RESULT" "$SECURITY_RESULT" \
-            "$EVALUATION_RESULT" "$PERFORMANCE_RESULT"; do
+            "$EVALUATION_RESULT" "$PERFORMANCE_RESULT" "$PUBLIC_BENCHMARK_RESULT"; do
             if [[ "$result" != "success" ]]; then
               echo "Required CI gate did not succeed: $result" >&2
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,51 @@ jobs:
           --manifest benchmarks/v0.2-scale-gates.json
           --output
           "release-assets/repolocus-${PROJECT_VERSION}.scale-benchmark.json"
+      - name: Run the public-protocol 1k performance fixture
+        env:
+          PROJECT_VERSION: ${{ steps.version.outputs.version }}
+        run: >-
+          uv run python benchmarks/benchmark_v020.py
+          --manifest benchmarks/v0.2-gates.json
+          --output
+          "release-assets/repolocus-${PROJECT_VERSION}.public-performance.json"
+      - name: Build the provenance-pinned public regression report
+        env:
+          PROJECT_VERSION: ${{ steps.version.outputs.version }}
+        run: >-
+          uv run python scripts/public_benchmark_report.py
+          --manifest benchmarks/public-benchmark-manifest.json
+          --evaluation-report
+          "release-assets/repolocus-${PROJECT_VERSION}.external-evaluation.json"
+          --performance-report
+          "release-assets/repolocus-${PROJECT_VERSION}.public-performance.json"
+          --json-output
+          "release-assets/repolocus-${PROJECT_VERSION}.public-benchmark.json"
+          --markdown-output
+          "release-assets/repolocus-${PROJECT_VERSION}.public-benchmark.md"
+      - name: Verify the public report is byte-reproducible
+        env:
+          PROJECT_VERSION: ${{ steps.version.outputs.version }}
+        run: >-
+          uv run python scripts/public_benchmark_report.py
+          --manifest benchmarks/public-benchmark-manifest.json
+          --evaluation-report
+          "release-assets/repolocus-${PROJECT_VERSION}.external-evaluation.json"
+          --performance-report
+          "release-assets/repolocus-${PROJECT_VERSION}.public-performance.json"
+          --json-output
+          "release-assets/repolocus-${PROJECT_VERSION}.public-benchmark.json"
+          --markdown-output
+          "release-assets/repolocus-${PROJECT_VERSION}.public-benchmark.md"
+          --check
+      - name: Include the public benchmark protocol
+        env:
+          PROJECT_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cp benchmarks/public-benchmark-manifest.json \
+            "release-assets/repolocus-${PROJECT_VERSION}.public-benchmark-manifest.json"
+          cp benchmarks/public-benchmark-report.schema.json \
+            "release-assets/repolocus-${PROJECT_VERSION}.public-benchmark-report.schema.json"
       - name: Build and check Python distributions
         run: |
           mkdir -p release-assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Semantic Versioning while the project is in alpha.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-08-13
+
+### Added
+
+- Added deterministic architecture diffs between scanned repositories or immutable snapshot
+  files, with old/new evidence for file, symbol, entry-point, dependency, configuration,
+  security-boundary, and test-area changes.
+- Added portable, integrity-checked architecture snapshots containing repository identity,
+  schema and component fingerprints, content generation, and bounded fact projections without
+  source bodies.
+- Added an opt-in PR-context GitHub Action that checks out explicit base and head revisions and
+  publishes JSON and Markdown review artifacts. PR comments remain an explicit, trusted-context
+  option.
+- Added a provenance-pinned public regression package and report covering answer quality,
+  no-answer behavior, query latency, peak memory, and index cost on six openly published,
+  project-authored fixtures, explicitly labeled as a reproducible smoke suite rather than an
+  independent cross-project benchmark.
+
+### Changed
+
+- Architecture comparison reports incompatible analysis fingerprints as a degraded comparison
+  instead of presenting analysis-policy drift as a repository code change.
+- Suggested review order is now a deterministic projection of the changed security boundaries,
+  configuration, entry points, dependencies, symbols, tests, and files.
+
+### Security
+
+- Architecture diffing remains a pure read-only core operation: it does not invoke Git, hooks,
+  builds, tests, or target-repository commands, and it never stores source bodies in snapshots.
+- The PR-context Action is artifact-only by default, documents a caller job with only
+  `contents: read`, disables checkout credential persistence, never exposes secrets to fork code,
+  and cannot comment unless the caller explicitly grants that trusted-context mode.
+
+## [0.2.0] - 2026-08-13
+
 ### Added
 
 - Added a schema-v6 evidence index with normalized `symbol_terms`, persistent path aliases,
@@ -15,8 +50,8 @@ Semantic Versioning while the project is in alpha.
   cache identities and deterministic heuristic fallback.
 - Added structured query intent, reciprocal-rank fusion diagnostics, content/range deduplication,
   path diversity, and explicit no-answer reason codes.
-- Expanded the pinned external suite to 102 reviewed qrels with enforced query-type and
-  answerable/no-answer/citation coverage.
+- Expanded the six pinned, RepoLocus-authored external-repository fixtures to 102 reviewed qrels
+  with enforced query-type and answerable/no-answer/citation coverage.
 - Added a versioned benchmark gate for scan, map, diagram, symbol/dependency queries, and fused
   retrieval, recording wall/CPU time, peak RSS, SQLite statements, database size, and WAL bytes.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ executing repository commands, builds a local SQLite/FTS index, writes a stable
 It works without an LLM; Ollama and explicitly approved cloud providers can add a narrative
 answer on top of the same evidence.
 
-> **Alpha:** this repository implements the CLI-first v0.2 baseline. Static dependency and
+> **Alpha:** this repository implements the CLI-first v0.2.1 baseline. Static dependency and
 > call relationships are approximations, and the hosted public-repository Web Demo described
 > in the roadmap is not part of this release.
 
@@ -89,6 +89,26 @@ intentionally ignored after upgrade.
 validated AST-like subset, not accepted directly from a model. The evidence tables keep a
 representative source for each node and one concrete import witness for every rendered edge.
 
+`repolocus diff OLD NEW` compares two repository directories or immutable architecture snapshot
+files. It reports file, symbol, entry-point, dependency, configuration, security-boundary, and
+test-area changes with old/new path-and-line evidence and a deterministic suggested review order.
+The comparison never invokes Git or repository commands. Analyzer fingerprint drift is reported
+as a degraded comparison instead of being presented as a source change.
+
+Capture generation-pinned canonical JSON snapshots without source text, then compare those
+immutable inputs in Markdown or machine-readable JSON:
+
+```bash
+repolocus snapshot /path/to/old-checkout old.snapshot.json
+repolocus snapshot /path/to/new-checkout new.snapshot.json
+repolocus diff old.snapshot.json new.snapshot.json
+repolocus diff old.snapshot.json new.snapshot.json --json > architecture-diff.json
+```
+
+`snapshot` refuses to replace an existing destination unless `--force` is explicit. `diff` also
+accepts repository directories directly; use `--refresh never` only to require an already-present
+external index state without scanning either directory.
+
 On POSIX, replacing an existing output preserves its previous contents in a reported hidden
 `.rollback` file. Remove that recovery file manually only when other repository writers are
 quiescent. New documents use atomic create-if-absent publication and do not leave a recovery file.
@@ -114,6 +134,8 @@ supports the claim. A model answer that passes these checks is still labeled `ne
 | `repolocus map [PATH]` | Generate `PROJECT_MAP.md` or print it with `--stdout` |
 | `repolocus ask QUESTION [PATH]` | Retrieve source-backed evidence and optionally use a model |
 | `repolocus diagram [PATH]` | Generate validated Mermaid in `ARCHITECTURE.md` |
+| `repolocus snapshot PATH OUTPUT` | Save a generation-pinned architecture snapshot without source text |
+| `repolocus diff OLD NEW` | Compare repository directories or immutable snapshots with evidence |
 | `repolocus privacy status` | Show remembered per-repository/provider/endpoint consent |
 | `repolocus privacy preview QUESTION` | Show fragments a question would send |
 | `repolocus privacy revoke` | Forget cloud-provider consent |
@@ -140,6 +162,62 @@ ends it. The first answer pins the content generation, and every follow-up uses 
 generation with refresh disabled. The session fails closed if retrieval-visible facts change, but
 a diagnostics-only scan revision does not invalidate the evidence snapshot.
 Follow-up context is never written to the repository or consent state.
+
+## PR Context Action
+
+The opt-in PR Context Action uses `actions/checkout` to materialize the exact base and head
+revisions in separate directories, then uploads `pr-context.md` and `pr-context.json` in the
+`repolocus-pr-context` artifact. After checkout, the RepoLocus analysis core treats both trees as
+untrusted data: it does not call Git or execute target-repository code, hooks, builds, or tests.
+The default is artifact-only and needs only `contents: read`:
+
+```yaml
+name: RepoLocus PR context
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Henry-Yolky/RepoLocus/.github/actions/pr-context@<FULL_40_CHARACTER_COMMIT_SHA>
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.sha }}
+```
+
+Replace the placeholder with the Action's complete 40-character lowercase commit SHA. Branches,
+tags, abbreviated SHAs, and a local `./.github/actions/pr-context` reference are rejected: the
+analyzer must come from immutable trusted Action code, not the checkout being analyzed.
+
+PR comments are disabled unless `comment: "true"` and `github-token` are both supplied. Put that
+opt-in in a separate job restricted to a trusted same-repository head, and grant
+`pull-requests: write` only to that job:
+
+```yaml
+  trusted-comment:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Henry-Yolky/RepoLocus/.github/actions/pr-context@<FULL_40_CHARACTER_COMMIT_SHA>
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.sha }}
+          comment: "true"
+          github-token: ${{ github.token }}
+```
+
+The Action accepts the `pull_request` event, not `pull_request_target`. With the job boundary
+above, fork PRs are never dispatched to a job that receives the comment token. As a second
+defense, if comment mode is requested for a fork elsewhere, the Action skips the comment and
+still produces the artifacts.
 
 ## Agent Skill
 
@@ -309,9 +387,13 @@ The repository includes reproducible synthetic scan and indexed-workflow gates u
 `benchmarks/`, a self-retrieval smoke set, and a fixed multi-repository release gate under
 `evaluation/`. Fixture source, revision, license, tree digest, qrel digest, and review status are
 recorded for all 102 qrels. v0.2 adds optional Tree-sitter adapters, an indexed
-resolved dependency graph, projection-only map/diagram reads, and structured RRF retrieval. The
-next milestones include a public-repository-only Web Demo and an opt-in GitHub Action. The
-project will not claim a complete dynamic call graph from static source. See
+resolved dependency graph, projection-only map/diagram reads, and structured RRF retrieval.
+v0.2.1 adds immutable architecture snapshots, evidence-backed diffs, an opt-in artifact-first
+GitHub Action, and a provenance-checked public regression report. The six benchmark fixtures are
+project-authored synthetic repositories, so their results are reproducible smoke/regression data,
+not independent cross-project quality claims. The next milestones include the read-only MCP and
+IDE surfaces and a public-repository-only Web Demo. The project will not claim a complete dynamic
+call graph from static source. See
 [ROADMAP.md](https://github.com/Henry-Yolky/RepoLocus/blob/main/ROADMAP.md) for scope.
 
 On the recorded Jetson Orin NX synthetic fixture, 10,000 small Python files scanned in 7.54 s

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@ RepoLocus 是一个只读、本地优先的代码库理解工具。它不会执�
 安全扫描源码、建立 SQLite/FTS 索引、生成结构稳定的 `PROJECT_MAP.md`、输出经过校验的
 Mermaid 图，并为代码问题检索可核验的源码证据。
 
-当前仓库实现的是 CLI 优先的 v0.2 开发基线。静态依赖与调用关系是近似结果；路线图中的
+当前仓库实现的是 CLI 优先的 v0.2.1 开发基线。静态依赖与调用关系是近似结果；路线图中的
 公共仓库 Web Demo 尚未包含在本版本中。
 
 ## 快速开始
@@ -61,6 +61,24 @@ facts，`rebuild` 会重新解析所有源码，`never` 只读取最近一次兼
 后续问题关闭 refresh 并要求同一 generation。检索可见 facts 变化时 fail closed，仅诊断性的
 scan revision 不会让证据 snapshot 失效。输入空行即结束，问答历史不会落盘。
 
+`repolocus diff OLD NEW` 可以比较两个仓库目录或两个不可变架构 snapshot。结果覆盖文件、
+symbol、入口点、依赖边、配置、安全边界和测试区域变化；每项均带 old/new 路径与行号证据，
+并按透明、确定性的规则给出建议审阅顺序。比较过程不会调用 Git 或目标仓库命令；分析器指纹
+不一致时会明确标为 degraded，而不会把分析策略变化伪装成源码变化。
+
+可以先把两个 generation 固定为不含源码正文的规范 JSON snapshot，再输出 Markdown 或机器
+可读 JSON 差异：
+
+```bash
+repolocus snapshot /path/to/old-checkout old.snapshot.json
+repolocus snapshot /path/to/new-checkout new.snapshot.json
+repolocus diff old.snapshot.json new.snapshot.json
+repolocus diff old.snapshot.json new.snapshot.json --json > architecture-diff.json
+```
+
+`snapshot` 默认拒绝覆盖已有目标，只有显式传入 `--force` 才会替换。`diff` 也可直接接收仓库
+目录；只有在明确要求复用已经存在的外部索引状态、且不扫描目录时才使用 `--refresh never`。
+
 ## 常用命令
 
 | 命令 | 用途 |
@@ -70,6 +88,8 @@ scan revision 不会让证据 snapshot 失效。输入空行即结束，问答�
 | `repolocus map [PATH]` | 生成 `PROJECT_MAP.md`，或通过 `--stdout` 输出 |
 | `repolocus ask QUESTION [PATH]` | 检索带源码位置的证据，并可选调用模型 |
 | `repolocus diagram [PATH]` | 在 `ARCHITECTURE.md` 中生成经过校验的 Mermaid 图 |
+| `repolocus snapshot PATH OUTPUT` | 保存固定 generation 且不含源码正文的架构 snapshot |
+| `repolocus diff OLD NEW` | 对仓库目录或不可变 snapshot 生成带证据的差异 |
 | `repolocus privacy status` | 查看当前仓库记忆的供应商、端点和路由授权 |
 | `repolocus doctor --security` | 检查运行时、FTS5、cache 权限与本地模型连接 |
 | `repolocus clean` | 经确认后删除当前仓库的外部索引 |
@@ -94,13 +114,74 @@ scan revision 不会让证据 snapshot 失效。输入空行即结束，问答�
 - 模型校验：每个实质 claim 后必须紧跟相同 citation 和源码原文子串的 `Evidence quote`；
   校验只确认地址和原文子串，不判断语义支持关系，通过后 confidence 仍为 `needs_review`；
 - 架构图：确定性生成 Mermaid，并为每个节点附代表源码、为每条边附一条具体 import 证据；
+- 架构差异：从 generation-pinned、无源码正文的不可变 snapshot 比较文件、symbol、入口点、
+  依赖、配置、安全边界和测试区域变化，并为每个结论保留 old/new 证据；
+- PR Context Action：显式启用后分别扫描 base/head checkout，默认只生成 Markdown/JSON
+  artifact；调用 workflow 必须显式限制为 `contents: read`，PR comment 需要可信同仓 job 的
+  单独写权限和 token；
 - 模型适配：无模型提取式回答、Ollama、OpenAI-compatible、Anthropic；
 - 隐私控制：默认关闭遥测，云端逐次授权或按仓库和端点记忆授权，可预览与撤回；
 - 自托管 API：安装 `api` 可选依赖后运行 `repolocus serve`。
-- 评测：自仓库 smoke set 之外，固定六个独立合成仓库和 102 条逐项复核 qrels 作为
+- 评测：自仓库 smoke set 之外，固定六个由 RepoLocus 编写、彼此隔离的 synthetic
+  external-repository fixtures 和 102 条逐项复核 qrels 作为
   CI/release gate；覆盖定义、exact/expanded/partial symbol、入口点、正反依赖、配置和
   hard-negative，报告 recall@k、MRR、nDCG@k、citation、no-answer、`must_not_return`
-  及按仓库等维度的汇总；release gate 要求 citation recall 达到 1.0。
+  及按仓库等维度的汇总；release gate 要求 citation recall 达到 1.0。公开 regression
+  报告同时记录质量、no-answer、query latency、peak RSS 和 index cost；这些 fixture 由本项目
+  编写，只代表可复跑 smoke/regression，不作为独立跨项目质量结论。
+
+## PR Context Action
+
+PR Context Action 需要显式启用。wrapper 通过 `actions/checkout` 把精确的 base/head revision
+检出到两个独立目录，并把 `pr-context.md` 与 `pr-context.json` 上传到
+`repolocus-pr-context` artifact。完成 checkout 后，RepoLocus 分析 core 把两个目录都视为
+不可信数据：core 不调用 Git，也不执行目标仓库代码、hook、build 或 test。默认只生成
+artifact，只需要 `contents: read`：
+
+```yaml
+name: RepoLocus PR context
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Henry-Yolky/RepoLocus/.github/actions/pr-context@<FULL_40_CHARACTER_COMMIT_SHA>
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.sha }}
+```
+
+必须把占位符替换为 Action 的完整 40 位小写 commit SHA。Action 会拒绝 branch、tag、短 SHA
+以及本地 `./.github/actions/pr-context` 引用，避免从正在分析的 checkout 执行 Action 代码。
+
+只有同时传入 `comment: "true"` 和 `github-token` 才会发布 PR comment。把该授权放到独立的
+可信同仓 job 中，用条件排除 fork，并且只给这个 job `pull-requests: write`：
+
+```yaml
+  trusted-comment:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Henry-Yolky/RepoLocus/.github/actions/pr-context@<FULL_40_CHARACTER_COMMIT_SHA>
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.pull_request.head.sha }}
+          comment: "true"
+          github-token: ${{ github.token }}
+```
+
+Action 只接受 `pull_request`，不接受 `pull_request_target`。按上述 job 边界配置后，Fork PR
+不会进入可获得 comment token 的 job；即使其他位置误开了 comment 模式，Action 也会再次
+跳过评论并继续生成 artifact。
 
 ## Agent Skill
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,13 +17,14 @@
 - Indexed SQLite symbol and dependency-neighbor queries
 - Projection-only, generation-pinned map and diagram generation
 - Structured query intent, RRF, deduplication, diversity, and explicit no-answer results
-- 102 reviewed external qrels and versioned scan/map/diagram/query/RSS release gates
+- 102 reviewed qrels across six RepoLocus-authored external-repository fixtures, plus versioned
+  scan/map/diagram/query/RSS release gates
 
-## v0.2.x: maintainer workflows
+## v0.2.1: maintainer workflows
 
-- Repository/snapshot architecture diff
-- Opt-in GitHub Action that proposes project-map diffs
-- PR context summaries and reproducible public benchmarks
+- Repository/snapshot architecture diff with old/new evidence and deterministic review ordering
+- Opt-in, artifact-first GitHub Action for PR context summaries
+- Provenance-pinned, reproducible public benchmark reports
 
 ## v0.3: reusable understanding layer
 

--- a/benchmarks/PUBLIC_BENCHMARK.md
+++ b/benchmarks/PUBLIC_BENCHMARK.md
@@ -1,0 +1,145 @@
+# Reproducible public smoke/regression benchmark
+
+This protocol is a public, reproducible **smoke/regression suite** for RepoLocus. The
+six repositories are RepoLocus-authored synthetic fixtures distributed in this
+repository. They are not third-party, independent, or production repositories. The
+quality results test deterministic regressions on those fixtures and **must not be
+extrapolated** to other repositories.
+
+“Public” means that any third party can inspect and rerun the same pinned protocol. It
+does not mean that the fixtures were created by third parties.
+
+## Pinned protocol
+
+[`public-benchmark-manifest.json`](public-benchmark-manifest.json) pins every input by
+repository-relative path and LF-normalized SHA-256 (`sha256-lf-v1`):
+
+- the fixture/qrel manifest, evaluation runner, and retrieval-metrics runner;
+- the v0.2 performance gate manifest and performance runner;
+- the unified report runner and JSON Schema; and
+- the canonical clean-checkout argument vectors for generating and validating reports.
+
+The report builder imports and executes the hash-pinned Python runners. Run it only from
+a trusted RepoLocus source tree (for example, a verified release tag or trusted checkout).
+The manifest pins the listed protocol files and detects their drift; it does not establish
+trust in an otherwise untrusted checkout or claim to pin every file in the Git revision.
+
+The fixture and qrel provenance is public and fixed as follows. `Tree SHA-256` covers
+the fixture's regular files and paths using the evaluator's deterministic tree-hash
+algorithm. `Qrels SHA-256` covers the reviewed JSONL qrels file bytes.
+
+| Fixture | Revision | License | Source | Tree SHA-256 | Qrels SHA-256 | Qrels |
+|---|---|---|---|---|---|---:|
+| `python-small` | `fixture-v4` | Apache-2.0 | RepoLocus-authored synthetic external repository fixture | `52b4bf4cac3311a5eedd16b6bcc17132b5edbbe8586536ee789e78aa6273e624` | `a5daa32634795bc691c16b8fa709ff5604018cd14c3789f901887f82f33128a0` | 17 |
+| `cpp-cmake` | `fixture-v4` | Apache-2.0 | RepoLocus-authored synthetic external repository fixture | `7185d1283b111d3c69cfed39394a32cdf4badbeb994755bf49a49f4fef2ba7fe` | `90e1985e4343c0cad698e6b3664505264afe90f5f00cff7136766f20dc70858e` | 17 |
+| `rust-cli` | `fixture-v4` | Apache-2.0 | RepoLocus-authored synthetic external repository fixture | `12ea2330dafc6bf2496e7899f2695fc3d098f330ca98a78d238696025148aa88` | `2d48d82dae91b8cc4a2cc076b830c4413ad5e36b89cc8052d02c3df45cb1b714` | 17 |
+| `go-service` | `fixture-v4` | Apache-2.0 | RepoLocus-authored synthetic external repository fixture | `b0ca058d6e92b28e6012049428829b4377ac54d15e6f752bbf6ade11e4e134a5` | `25265969549c69dd8b49f4293572c6d2949b5369dfacf34f23e4dbd2f3a51d0d` | 17 |
+| `typescript-web` | `fixture-v4` | Apache-2.0 | RepoLocus-authored synthetic external repository fixture | `f13f5ab375511c565f889465a901c4c86950559789c9c517e1fa27da00648ce4` | `518a69fa12f7af51227626e19e8c3a1c9aaaf7393b65a00f066756104dab7bd7` | 17 |
+| `java-gradle` | `fixture-v4` | Apache-2.0 | RepoLocus-authored synthetic external repository fixture | `ce898b7c3a0ad37d72df2ffac903bc52267d16175d770c31d1120a93dfb37a9f` | `1270bf60a61f4e36f1610e26a3d1064de50b8ab82c68312b7f7ba053cbd03771` | 17 |
+
+The evaluator additionally verifies the reviewed qrel provenance ledger pinned by
+`evaluation/external-manifest.json`. A provenance, license, revision, file, qrel, or
+runner hash mismatch fails closed before the unified report is written. Every serialized
+outcome must match exactly one pinned `fixture`/`case_id`, and all per-case metrics are
+independently recomputed from the pinned qrel truth and serialized retrieval evidence.
+
+## Reproduce from a clean checkout
+
+Use Python 3.10 or newer and install the locked development environment:
+
+```console
+uv sync --all-extras --locked
+```
+
+The tracked `benchmarks/results/.gitignore` ensures that the output directory exists
+in a clean checkout while generated reports stay out of Git. The commands below are
+the protocol's **canonical clean-checkout reproduction vectors**: start from a trusted
+RepoLocus checkout containing this manifest (normally its verified release tag), leave
+every tracked protocol input unchanged, install the locked environment, and run the
+vectors from the repository root in order. The manifest stores these vectors as data
+and the report runner rejects drift in them or in any hash-pinned protocol file.
+
+CI transports the evaluation and performance reports between jobs as downloaded
+artifacts, so its final report step may pass equivalent downloaded input paths instead
+of `benchmarks/results/public-evaluation.json` and
+`benchmarks/results/public-performance.json`. That path substitution is transport
+only: the reports must still come from the pinned upstream vectors and pass the same
+fixture, revision, license, manifest, gate, and provenance validation. The canonical
+vectors embedded in the public report remain the clean-checkout commands below. The CI
+artifact includes both transported input reports, the manifest, the schema, and the
+generated JSON/Markdown report so the substitution is auditable.
+
+This verifier has a deliberate trust boundary. Run it only from a trusted RepoLocus
+checkout whose listed protocol files match the manifest, normally the verified release
+tag associated with a published report. To recompute metrics and gates it loads and
+executes the hash-pinned evaluation, retrieval, and performance Python modules from that
+source tree. The hash checks detect drift from the manifest; they are not a sandbox for
+arbitrary Python, and the manifest does not pin the Git commit or every file in the
+checkout. Treat downloaded evaluation/performance reports as data, and never execute a
+verifier or protocol modules supplied only by an untrusted result bundle.
+
+Generate the quality input report directly from the pinned fixtures and reviewed
+qrels:
+
+```console
+uv run python scripts/evaluate_external_repositories.py evaluation --output benchmarks/results/public-evaluation.json
+```
+
+Generate the resource, latency, and index-cost input report from the pinned 1,000-file
+v0.2 synthetic fixture manifest:
+
+```console
+uv run python benchmarks/benchmark_v020.py --manifest benchmarks/v0.2-gates.json --output benchmarks/results/public-performance.json
+```
+
+Validate both inputs and generate canonical JSON plus a human-readable Markdown
+report:
+
+```console
+uv run python scripts/public_benchmark_report.py --manifest benchmarks/public-benchmark-manifest.json --evaluation-report benchmarks/results/public-evaluation.json --performance-report benchmarks/results/public-performance.json --json-output benchmarks/results/public-report.json --markdown-output benchmarks/results/public-report.md
+```
+
+Finally, prove that the generated reports are byte-for-byte current:
+
+```console
+uv run python scripts/public_benchmark_report.py --manifest benchmarks/public-benchmark-manifest.json --evaluation-report benchmarks/results/public-evaluation.json --performance-report benchmarks/results/public-performance.json --json-output benchmarks/results/public-report.json --markdown-output benchmarks/results/public-report.md --check
+```
+
+Do not copy commands from this document into automation without also validating them
+against the manifest. The runner rejects altered command vectors and protocol files.
+
+## Unified report
+
+The canonical JSON conforms to
+[`public-benchmark-report.schema.json`](public-benchmark-report.schema.json). The
+report contains these measurement families together so no single favorable number is
+presented without the other costs and safeguards:
+
+- **Accuracy:** hit rate, macro recall at `k`, mean reciprocal rank, and citation
+  recall over the reviewed synthetic qrels.
+- **No-answer behavior:** accuracy, precision, recall, and F1 for queries whose
+  reviewed answer is no evidence.
+- **Safety:** duplicate-evidence and must-not-return violation rates.
+- **Query latency:** isolated-worker wall time in seconds for symbol, dependency, and
+  retrieval queries.
+- **Peak memory:** peak resident-set bytes for every indexed operation. Linux reports
+  `ru_maxrss` converted to bytes, macOS reports its byte value, and Windows reports
+  peak working-set bytes.
+- **Index cost:** scan wall/CPU seconds, peak RSS, issued SQLite statement count,
+  database bytes, and WAL bytes.
+
+Quality results are deterministic for the recorded implementation digest and pinned
+fixture/qrel protocol. Timing, CPU, and peak RSS
+depend on the host, operating system, filesystem, load, and Python build; the report
+therefore records the environment and should only be compared on equivalent hardware
+and protocol revisions. Passing both embedded gates means **reproducible
+smoke/regression verdict**, not production-repository quality.
+
+## Competitor policy
+
+RepoWiki, DeepWiki, and Sourcebot are explicitly reported as `N/A`. This protocol has
+not pinned an equivalent public input, revision, runner, environment, and metric
+definition for any of them. No marketing number or differently measured result is
+substituted. A future comparison may be populated only after an equivalent public
+protocol is reproducible by third parties; until then, protocol and metric fields
+remain `null`.

--- a/benchmarks/public-benchmark-manifest.json
+++ b/benchmarks/public-benchmark-manifest.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "benchmark_id": "repolocus-public-benchmark-v1",
+  "hash_algorithm": "sha256-lf-v1",
+  "subject": {
+    "name": "RepoLocus"
+  },
+  "scope": {
+    "classification": "smoke",
+    "cross_repository_quality_claim": false,
+    "note": "Public, reproducible RepoLocus-authored synthetic smoke/regression suite only; quality results must not be extrapolated to independent or production repositories."
+  },
+  "artifacts": {
+    "evaluation_manifest": {
+      "path": "evaluation/external-manifest.json",
+      "sha256": "9e5b87c7d6c7a39b7b4c1a64807cb3c8f1e679209595aa60fa423cc7501aa8bd"
+    },
+    "evaluation_runner": {
+      "path": "scripts/evaluate_external_repositories.py",
+      "sha256": "163faf4f1ed8db56541e6261b475218a0f2277c0a4a3fd1ee615b504564eb244"
+    },
+    "evaluation_metrics_runner": {
+      "path": "scripts/evaluate_retrieval.py",
+      "sha256": "1f32aae5c7a7889b03d2919d0d85708de9ec92ad4b495803e01d2ee600190595"
+    },
+    "performance_manifest": {
+      "path": "benchmarks/v0.2-gates.json",
+      "sha256": "169d2a692f2bea50b01173791726eef8b9f88e18d44f1d9541142b1e99ffa091"
+    },
+    "performance_runner": {
+      "path": "benchmarks/benchmark_v020.py",
+      "sha256": "eb1dc57766c1380cfc5e88312d56d48a688e910ef8c87d7f98c50f550f98c801"
+    },
+    "report_runner": {
+      "path": "scripts/public_benchmark_report.py",
+      "sha256": "40159308338cbc0f19b7b05a88754a809d0369be8453496275904569e7ec13e2"
+    },
+    "report_schema": {
+      "path": "benchmarks/public-benchmark-report.schema.json",
+      "sha256": "5c863db840ba65bfc9de72d0fa67193d3c50123864cc7b27802204d4b66bc2cb"
+    }
+  },
+  "commands": [
+    {
+      "id": "evaluation",
+      "argv": [
+        "uv",
+        "run",
+        "python",
+        "scripts/evaluate_external_repositories.py",
+        "evaluation",
+        "--output",
+        "benchmarks/results/public-evaluation.json"
+      ]
+    },
+    {
+      "id": "performance",
+      "argv": [
+        "uv",
+        "run",
+        "python",
+        "benchmarks/benchmark_v020.py",
+        "--manifest",
+        "benchmarks/v0.2-gates.json",
+        "--output",
+        "benchmarks/results/public-performance.json"
+      ]
+    },
+    {
+      "id": "report",
+      "argv": [
+        "uv",
+        "run",
+        "python",
+        "scripts/public_benchmark_report.py",
+        "--manifest",
+        "benchmarks/public-benchmark-manifest.json",
+        "--evaluation-report",
+        "benchmarks/results/public-evaluation.json",
+        "--performance-report",
+        "benchmarks/results/public-performance.json",
+        "--json-output",
+        "benchmarks/results/public-report.json",
+        "--markdown-output",
+        "benchmarks/results/public-report.md"
+      ]
+    },
+    {
+      "id": "check",
+      "argv": [
+        "uv",
+        "run",
+        "python",
+        "scripts/public_benchmark_report.py",
+        "--manifest",
+        "benchmarks/public-benchmark-manifest.json",
+        "--evaluation-report",
+        "benchmarks/results/public-evaluation.json",
+        "--performance-report",
+        "benchmarks/results/public-performance.json",
+        "--json-output",
+        "benchmarks/results/public-report.json",
+        "--markdown-output",
+        "benchmarks/results/public-report.md",
+        "--check"
+      ]
+    }
+  ],
+  "comparisons": [
+    {
+      "system": "RepoWiki",
+      "status": "N/A",
+      "protocol": null,
+      "metrics": null,
+      "reason": "N/A: no equivalent public protocol is pinned by this manifest; no comparison is made."
+    },
+    {
+      "system": "DeepWiki",
+      "status": "N/A",
+      "protocol": null,
+      "metrics": null,
+      "reason": "N/A: no equivalent public protocol is pinned by this manifest; no comparison is made."
+    },
+    {
+      "system": "Sourcebot",
+      "status": "N/A",
+      "protocol": null,
+      "metrics": null,
+      "reason": "N/A: no equivalent public protocol is pinned by this manifest; no comparison is made."
+    }
+  ]
+}

--- a/benchmarks/public-benchmark-report.schema.json
+++ b/benchmarks/public-benchmark-report.schema.json
@@ -1,0 +1,931 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:repolocus:public-benchmark-report:v1",
+  "title": "RepoLocus reproducible public smoke benchmark report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "benchmark_id",
+    "subject",
+    "protocol",
+    "fixtures",
+    "quality",
+    "performance",
+    "comparisons",
+    "validation"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "benchmark_id": {
+      "const": "repolocus-public-benchmark-v1"
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "implementation_sha256",
+        "result_classification",
+        "cross_repository_quality_claim",
+        "note"
+      ],
+      "properties": {
+        "name": {
+          "const": "RepoLocus"
+        },
+        "version": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "implementation_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "result_classification": {
+          "const": "smoke"
+        },
+        "cross_repository_quality_claim": {
+          "const": false
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[Ss][Mm][Oo][Kk][Ee]"
+        }
+      }
+    },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifest",
+        "manifest_sha256",
+        "hash_algorithm",
+        "evaluation_manifest",
+        "evaluation_manifest_sha256",
+        "evaluation_runner",
+        "evaluation_runner_sha256",
+        "evaluation_metrics_runner",
+        "evaluation_metrics_runner_sha256",
+        "performance_manifest",
+        "performance_manifest_sha256",
+        "reproduction_commands"
+      ],
+      "properties": {
+        "manifest": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "hash_algorithm": {
+          "const": "sha256-lf-v1"
+        },
+        "evaluation_manifest": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "evaluation_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_runner": {
+          "const": "scripts/evaluate_external_repositories.py"
+        },
+        "evaluation_runner_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_metrics_runner": {
+          "const": "scripts/evaluate_retrieval.py"
+        },
+        "evaluation_metrics_runner_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "performance_manifest": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "performance_manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "reproduction_commands": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "prefixItems": [
+            {
+              "$ref": "#/$defs/evaluation_command"
+            },
+            {
+              "$ref": "#/$defs/performance_command"
+            },
+            {
+              "$ref": "#/$defs/report_command"
+            },
+            {
+              "$ref": "#/$defs/check_command"
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "fixtures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/fixture"
+      }
+    },
+    "quality": {
+      "$ref": "#/$defs/quality"
+    },
+    "performance": {
+      "$ref": "#/$defs/performance"
+    },
+    "comparisons": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/repowiki_comparison"
+        },
+        {
+          "$ref": "#/$defs/deepwiki_comparison"
+        },
+        {
+          "$ref": "#/$defs/sourcebot_comparison"
+        }
+      ],
+      "items": false
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evaluation_report_sha256",
+        "performance_report_sha256",
+        "evaluation_gate_passed",
+        "performance_gate_passed"
+      ],
+      "properties": {
+        "evaluation_report_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "performance_report_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evaluation_gate_passed": {
+          "type": "boolean"
+        },
+        "performance_gate_passed": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\r\\n\\u0000]+$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "positive_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "evaluation_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "argv"
+      ],
+      "properties": {
+        "id": {
+          "const": "evaluation"
+        },
+        "argv": {
+          "type": "array",
+          "minItems": 7,
+          "maxItems": 7,
+          "prefixItems": [
+            {
+              "const": "uv"
+            },
+            {
+              "const": "run"
+            },
+            {
+              "const": "python"
+            },
+            {
+              "const": "scripts/evaluate_external_repositories.py"
+            },
+            {
+              "const": "evaluation"
+            },
+            {
+              "const": "--output"
+            },
+            {
+              "const": "benchmarks/results/public-evaluation.json"
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "performance_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "argv"
+      ],
+      "properties": {
+        "id": {
+          "const": "performance"
+        },
+        "argv": {
+          "type": "array",
+          "minItems": 8,
+          "maxItems": 8,
+          "prefixItems": [
+            {
+              "const": "uv"
+            },
+            {
+              "const": "run"
+            },
+            {
+              "const": "python"
+            },
+            {
+              "const": "benchmarks/benchmark_v020.py"
+            },
+            {
+              "const": "--manifest"
+            },
+            {
+              "const": "benchmarks/v0.2-gates.json"
+            },
+            {
+              "const": "--output"
+            },
+            {
+              "const": "benchmarks/results/public-performance.json"
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "report_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "argv"
+      ],
+      "properties": {
+        "id": {
+          "const": "report"
+        },
+        "argv": {
+          "type": "array",
+          "minItems": 14,
+          "maxItems": 14,
+          "prefixItems": [
+            {
+              "const": "uv"
+            },
+            {
+              "const": "run"
+            },
+            {
+              "const": "python"
+            },
+            {
+              "const": "scripts/public_benchmark_report.py"
+            },
+            {
+              "const": "--manifest"
+            },
+            {
+              "const": "benchmarks/public-benchmark-manifest.json"
+            },
+            {
+              "const": "--evaluation-report"
+            },
+            {
+              "const": "benchmarks/results/public-evaluation.json"
+            },
+            {
+              "const": "--performance-report"
+            },
+            {
+              "const": "benchmarks/results/public-performance.json"
+            },
+            {
+              "const": "--json-output"
+            },
+            {
+              "const": "benchmarks/results/public-report.json"
+            },
+            {
+              "const": "--markdown-output"
+            },
+            {
+              "const": "benchmarks/results/public-report.md"
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "check_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "argv"
+      ],
+      "properties": {
+        "id": {
+          "const": "check"
+        },
+        "argv": {
+          "type": "array",
+          "minItems": 15,
+          "maxItems": 15,
+          "prefixItems": [
+            {
+              "const": "uv"
+            },
+            {
+              "const": "run"
+            },
+            {
+              "const": "python"
+            },
+            {
+              "const": "scripts/public_benchmark_report.py"
+            },
+            {
+              "const": "--manifest"
+            },
+            {
+              "const": "benchmarks/public-benchmark-manifest.json"
+            },
+            {
+              "const": "--evaluation-report"
+            },
+            {
+              "const": "benchmarks/results/public-evaluation.json"
+            },
+            {
+              "const": "--performance-report"
+            },
+            {
+              "const": "benchmarks/results/public-performance.json"
+            },
+            {
+              "const": "--json-output"
+            },
+            {
+              "const": "benchmarks/results/public-report.json"
+            },
+            {
+              "const": "--markdown-output"
+            },
+            {
+              "const": "benchmarks/results/public-report.md"
+            },
+            {
+              "const": "--check"
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "fixture_path",
+        "qrels_path",
+        "source",
+        "license",
+        "revision",
+        "tree_sha256",
+        "qrels_sha256",
+        "qrels",
+        "case_families",
+        "must_not_return_qrels"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "fixture_path": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "qrels_path": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "source": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "license": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "revision": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "tree_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "qrels_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "qrels": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "case_families": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "must_not_return_qrels": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "accuracy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hit_rate",
+        "macro_recall_at_k",
+        "mrr",
+        "citation_recall"
+      ],
+      "properties": {
+        "hit_rate": {
+          "$ref": "#/$defs/rate"
+        },
+        "macro_recall_at_k": {
+          "$ref": "#/$defs/rate"
+        },
+        "mrr": {
+          "$ref": "#/$defs/rate"
+        },
+        "citation_recall": {
+          "$ref": "#/$defs/rate"
+        }
+      }
+    },
+    "no_answer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "accuracy",
+        "precision",
+        "recall",
+        "f1"
+      ],
+      "properties": {
+        "accuracy": {
+          "$ref": "#/$defs/rate"
+        },
+        "precision": {
+          "$ref": "#/$defs/rate"
+        },
+        "recall": {
+          "$ref": "#/$defs/rate"
+        },
+        "f1": {
+          "$ref": "#/$defs/rate"
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "duplicate_evidence_rate",
+        "must_not_return_violation_rate"
+      ],
+      "properties": {
+        "duplicate_evidence_rate": {
+          "$ref": "#/$defs/rate"
+        },
+        "must_not_return_violation_rate": {
+          "$ref": "#/$defs/rate"
+        }
+      }
+    },
+    "interval": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/rate"
+        },
+        {
+          "$ref": "#/$defs/rate"
+        }
+      ],
+      "items": false
+    },
+    "bootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "confidence",
+        "samples",
+        "cluster_unit",
+        "intervals"
+      ],
+      "properties": {
+        "confidence": {
+          "$ref": "#/$defs/rate"
+        },
+        "samples": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "cluster_unit": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "intervals": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "any_expected_path_rate",
+            "macro_recall_at_k",
+            "mrr",
+            "citation_recall",
+            "no_answer_f1"
+          ],
+          "properties": {
+            "any_expected_path_rate": {
+              "$ref": "#/$defs/interval"
+            },
+            "macro_recall_at_k": {
+              "$ref": "#/$defs/interval"
+            },
+            "mrr": {
+              "$ref": "#/$defs/interval"
+            },
+            "citation_recall": {
+              "$ref": "#/$defs/interval"
+            },
+            "no_answer_f1": {
+              "$ref": "#/$defs/interval"
+            }
+          }
+        }
+      }
+    },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fixture_count",
+        "qrels",
+        "case_families",
+        "answerable_qrels",
+        "no_answer_qrels",
+        "citation_qrels",
+        "must_not_return_qrels",
+        "accuracy",
+        "no_answer",
+        "safety",
+        "bootstrap",
+        "gate_passed"
+      ],
+      "properties": {
+        "fixture_count": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "qrels": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "case_families": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "answerable_qrels": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "no_answer_qrels": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "citation_qrels": {
+          "$ref": "#/$defs/positive_count"
+        },
+        "must_not_return_qrels": {
+          "$ref": "#/$defs/count"
+        },
+        "accuracy": {
+          "$ref": "#/$defs/accuracy"
+        },
+        "no_answer": {
+          "$ref": "#/$defs/no_answer"
+        },
+        "safety": {
+          "$ref": "#/$defs/safety"
+        },
+        "bootstrap": {
+          "$ref": "#/$defs/bootstrap"
+        },
+        "gate_passed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "measurement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_seconds",
+        "cpu_seconds",
+        "peak_rss_bytes",
+        "sqlite_query_count",
+        "database_bytes",
+        "wal_bytes"
+      ],
+      "properties": {
+        "wall_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "cpu_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "peak_rss_bytes": {
+          "$ref": "#/$defs/count"
+        },
+        "sqlite_query_count": {
+          "$ref": "#/$defs/count"
+        },
+        "database_bytes": {
+          "$ref": "#/$defs/count"
+        },
+        "wal_bytes": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "operation_measurements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scan",
+        "map",
+        "diagram",
+        "symbol_query",
+        "dependency_query",
+        "retrieval"
+      ],
+      "properties": {
+        "scan": {
+          "$ref": "#/$defs/measurement"
+        },
+        "map": {
+          "$ref": "#/$defs/measurement"
+        },
+        "diagram": {
+          "$ref": "#/$defs/measurement"
+        },
+        "symbol_query": {
+          "$ref": "#/$defs/measurement"
+        },
+        "dependency_query": {
+          "$ref": "#/$defs/measurement"
+        },
+        "retrieval": {
+          "$ref": "#/$defs/measurement"
+        }
+      }
+    },
+    "performance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "environment",
+        "fixture",
+        "query_latency_seconds",
+        "peak_rss_bytes",
+        "index_cost",
+        "operations",
+        "gate_passed"
+      ],
+      "properties": {
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "python",
+            "platform",
+            "machine",
+            "cpu_count"
+          ],
+          "properties": {
+            "python": {
+              "$ref": "#/$defs/non_empty_string"
+            },
+            "platform": {
+              "$ref": "#/$defs/non_empty_string"
+            },
+            "machine": {
+              "$ref": "#/$defs/non_empty_string"
+            },
+            "cpu_count": {
+              "$ref": "#/$defs/positive_count"
+            }
+          }
+        },
+        "fixture": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "manifest",
+            "files",
+            "source_bytes",
+            "symbols",
+            "dependencies"
+          ],
+          "properties": {
+            "manifest": {
+              "$ref": "#/$defs/non_empty_string"
+            },
+            "files": {
+              "$ref": "#/$defs/positive_count"
+            },
+            "source_bytes": {
+              "$ref": "#/$defs/positive_count"
+            },
+            "symbols": {
+              "$ref": "#/$defs/positive_count"
+            },
+            "dependencies": {
+              "$ref": "#/$defs/positive_count"
+            }
+          }
+        },
+        "query_latency_seconds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "symbol_query",
+            "dependency_query",
+            "retrieval"
+          ],
+          "properties": {
+            "symbol_query": {
+              "type": "number",
+              "minimum": 0
+            },
+            "dependency_query": {
+              "type": "number",
+              "minimum": 0
+            },
+            "retrieval": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "peak_rss_bytes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scan",
+            "map",
+            "diagram",
+            "symbol_query",
+            "dependency_query",
+            "retrieval"
+          ],
+          "properties": {
+            "scan": {
+              "$ref": "#/$defs/count"
+            },
+            "map": {
+              "$ref": "#/$defs/count"
+            },
+            "diagram": {
+              "$ref": "#/$defs/count"
+            },
+            "symbol_query": {
+              "$ref": "#/$defs/count"
+            },
+            "dependency_query": {
+              "$ref": "#/$defs/count"
+            },
+            "retrieval": {
+              "$ref": "#/$defs/count"
+            }
+          }
+        },
+        "index_cost": {
+          "$ref": "#/$defs/measurement"
+        },
+        "operations": {
+          "$ref": "#/$defs/operation_measurements"
+        },
+        "gate_passed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "system",
+        "status",
+        "protocol",
+        "metrics",
+        "reason"
+      ],
+      "properties": {
+        "system": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "status": {
+          "const": "N/A"
+        },
+        "protocol": {
+          "type": "null"
+        },
+        "metrics": {
+          "type": "null"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[Ee][Qq][Uu][Ii][Vv][Aa][Ll][Ee][Nn][Tt] [Pp][Uu][Bb][Ll][Ii][Cc] [Pp][Rr][Oo][Tt][Oo][Cc][Oo][Ll]"
+        }
+      }
+    },
+    "repowiki_comparison": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/comparison"
+        },
+        {
+          "properties": {
+            "system": {
+              "const": "RepoWiki"
+            }
+          }
+        }
+      ]
+    },
+    "deepwiki_comparison": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/comparison"
+        },
+        {
+          "properties": {
+            "system": {
+              "const": "DeepWiki"
+            }
+          }
+        }
+      ]
+    },
+    "sourcebot_comparison": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/comparison"
+        },
+        {
+          "properties": {
+            "system": {
+              "const": "Sourcebot"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/results/.gitignore
+++ b/benchmarks/results/.gitignore
@@ -1,0 +1,3 @@
+# Reproducible public benchmark outputs are generated locally.
+*
+!.gitignore

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,8 @@ flowchart LR
     C --> D["Files, symbols, imports, chunks"]
     D --> E["SQLite, FTS5, and term index"]
     E --> F["Symbol, text, and graph retrieval"]
+    E --> L["Bounded architecture snapshot"]
+    L --> M["Pure old/new architecture diff"]
     F --> G["Source evidence bundle"]
     G --> H["Deterministic map and Mermaid"]
     G --> I["Extractive answer"]
@@ -31,6 +33,11 @@ flowchart LR
   candidates. `RepositoryView` pins one generation while exposing only bounded projections.
 - `graph/` owns the language-neutral dependency resolver used by index commits, retrieval, maps,
   and diagrams. Ambiguous aliases retain every candidate and never become a guessed edge.
+- `diff/` projects a generation-pinned index into a portable architecture snapshot and compares
+  two snapshots without reading source bodies or invoking repository tools. The result records
+  old/new evidence, explicit move confidence, fingerprint compatibility, and a deterministic
+  security-first review order. The CLI, PR-context wrapper, and future MCP surface share this
+  pure core.
 - `retrieval/` combines indexed symbol matches, FTS5/BM25 ranks, deterministic lexical terms, and
   resolved dependency neighbors with reciprocal-rank fusion. Query intent selects reverse graph
   retrieval for callers/references; content hashes, line-range overlap, and path diversity suppress
@@ -47,6 +54,9 @@ flowchart LR
 - `core/` is the workflow boundary shared by the CLI and optional API.
 - `api/` authenticates requests, bounds exposure, and holds short-lived single-use preview
   snapshots for two-stage cloud approval.
+- `.github/actions/pr-context/` is an opt-in GitHub wrapper, not part of the analysis core. It checks out
+  caller-selected revisions with GitHub's checkout Action, invokes RepoLocus on those directory
+  trees, and uploads the same JSON/Markdown diff artifacts available locally.
 
 ## Data invariants
 
@@ -86,6 +96,14 @@ Map and diagram generation open one `RepositoryView` read transaction. They cons
 entry points, area summaries, resolved edges, and bounded README prefixes; they do not materialize
 all source bodies, chunks, or symbols. Retrieval uses the same generation-pinned database snapshot,
 and every returned evidence item records that content generation.
+
+Architecture snapshot generation similarly opens a generation-pinned read transaction and selects
+only the file digests and sizes, symbol identities and ranges, resolved dependency witnesses,
+entry-point flags, schema version, repository identity, and analysis fingerprints required for a
+comparison. Snapshot serialization is canonical and integrity checked. It intentionally excludes
+source bodies and retrieval chunks. A snapshot whose schema or analysis fingerprints differ can
+still produce an explicitly degraded inventory comparison, but policy drift is never reported as
+a repository code change.
 
 Each scan starts from one transactionally consistent SQLite snapshot and commits with both content
 generation and scan revision compare-and-swap values. An old scan cannot overwrite a newer commit.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -6,7 +6,7 @@ RepoLocus protects source text outside the selected root, excluded secrets withi
 cloud credentials, locally indexed content, and the user's expectation that analysis is
 read-only.
 
-## Threats addressed in v0.1
+## Threats addressed
 
 | Threat | Control |
 |---|---|
@@ -26,6 +26,9 @@ read-only.
 | Generated-output symlink or replacement race | Descriptor-relative or handle-validated same-directory atomic writes attest parent and target identities and fail closed on races; ambiguous post-commit objects are preserved under reported recovery names rather than deleted |
 | Mermaid links or directives | Deterministic restricted grammar; model output is never diagram source |
 | Index committed to Git | Cache defaults outside the repository; `.repolocus/` is ignored |
+| Diff invokes untrusted repository code | Snapshot projection and comparison are pure reads; Git, hooks, builds, tests, and target executables remain outside the core interface |
+| Fork pull request receives write token or secrets | The opt-in PR-context Action is artifact-only by default, documents a caller job with only `contents: read`, persists no checkout credentials, and refuses comment mode for fork events |
+| Analysis-policy drift looks like a code change | Snapshot schema and component fingerprints are compared first and incompatible comparisons are labeled degraded |
 
 ## Non-goals and residual risk
 
@@ -69,3 +72,17 @@ A non-loopback listener is refused unless the operator supplies `--allow-remote`
 allowed Host, and a TLS certificate/key pair. Preview state is intentionally bounded and
 process-local; the built-in `repolocus serve` path runs one worker. This remains a self-hosted
 single-operator API, not the public Web Demo architecture.
+
+Architecture snapshots are metadata artifacts, not source archives: they contain paths, digests,
+bounded symbol/range data, dependency witnesses, repository identity, generation, schema, and
+analysis fingerprints, but no source bodies or retrieval chunks. Paths and symbol names may still
+be sensitive metadata, so callers should apply the same access controls used for repository build
+artifacts. Snapshot integrity detects accidental or malicious edits; it is not a signature or an
+authorization mechanism.
+
+The PR-context GitHub Action is deliberately artifact-first. A composite Action cannot set its
+caller's job permissions, so the documented workflow explicitly grants only `contents: read`;
+checkout credentials are not persisted, target repository code is never run, and no cloud provider
+is used. Commenting is an explicit trusted-context mode requiring a separate same-repository job,
+`pull-requests: write`, and a token. Fork pull requests never receive that capability, and the
+Action does not use `pull_request_target` to analyze untrusted head code with repository secrets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repolocus"
-version = "0.2.0"
+version = "0.2.1"
 description = "A read-only, local-first codebase map with source-backed answers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/evaluate_external_repositories.py
+++ b/scripts/evaluate_external_repositories.py
@@ -17,8 +17,13 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from tempfile import TemporaryDirectory
 from typing import Any
 
-from evaluate_retrieval import evaluate_cases
+from evaluate_retrieval import (
+    evaluate_cases,
+    summarize_outcomes,
+    validate_outcomes_against_qrels,
+)
 
+from repolocus import __version__
 from repolocus.config import Settings
 from repolocus.core import RepoLocusService
 from repolocus.index import RepositoryIndex
@@ -67,6 +72,7 @@ _QUERY_TYPE_INTENTS = {
 }
 _BOOTSTRAP_SEED = 2_020_020
 _BOOTSTRAP_SAMPLES = 2_000
+_DEFAULT_LIMIT = 5
 _SHA256 = re.compile(r"[0-9a-f]{64}")
 _CANONICAL_INTENT = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
 _QREL_REQUIRED_FIELDS = frozenset(
@@ -112,6 +118,36 @@ _COUNT_THRESHOLDS = frozenset(
         "minimum_citation_qrels",
     }
 )
+
+
+def _canonical_bytes(payload: bytes) -> bytes:
+    """Normalize checkout line endings before computing protocol hashes."""
+
+    return payload.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def _script_sha256() -> str:
+    return hashlib.sha256(_canonical_bytes(Path(__file__).read_bytes())).hexdigest()
+
+
+def _metrics_script_sha256() -> str:
+    metrics_runner = Path(__file__).with_name("evaluate_retrieval.py")
+    return hashlib.sha256(_canonical_bytes(metrics_runner.read_bytes())).hexdigest()
+
+
+def _implementation_sha256() -> str:
+    repository = Path(__file__).resolve().parents[1]
+    paths = [repository / "pyproject.toml", repository / "uv.lock"]
+    paths.extend(sorted((repository / "src" / "repolocus").rglob("*.py")))
+    digest = hashlib.sha256()
+    for path in paths:
+        relative = path.relative_to(repository).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(4, "big"))
+        digest.update(relative)
+        payload = _canonical_bytes(path.read_bytes())
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+    return digest.hexdigest()
 
 
 def _reject_json_constant(value: str) -> None:
@@ -884,6 +920,7 @@ def evaluate_suite(
 
     all_cases: list[dict[str, Any]] = []
     routes: dict[str, RetrievalEngine] = {}
+    fixture_roots: dict[str, Path] = {}
     fixture_reports: list[dict[str, object]] = []
     seen_fixture_ids: set[str] = set()
     seen_roots: set[Path] = set()
@@ -927,6 +964,7 @@ def evaluate_suite(
                 raise ValueError(f"fixture roots and qrel paths must be unique: {fixture}")
             seen_roots.add(root)
             seen_qrel_paths.add(qrels)
+            fixture_roots[fixture] = root
 
             actual_tree = fixture_tree_sha256(root)
             actual_qrels = _sha256_file(qrels)
@@ -1069,12 +1107,23 @@ def evaluate_suite(
                 raise ValueError(f"fixture has too few must_not_return qrels: {fixture}")
 
         query_types = set(families_by_type)
-        outcomes, metrics = evaluate_cases(_RoutedRetrieval(routes), all_cases, limit=limit)
+        outcomes, _ = evaluate_cases(_RoutedRetrieval(routes), all_cases, limit=limit)
+        outcomes = validate_outcomes_against_qrels(
+            all_cases,
+            outcomes,
+            limit=limit,
+            fixture_roots=fixture_roots,
+        )
+        metrics = summarize_outcomes(outcomes)
 
     for fixture_report in fixture_reports:
         fixture_report["case_families"] = family_counts[str(fixture_report["id"])]
     return {
         "manifest": manifest_path.relative_to(evaluation_root).as_posix(),
+        "evaluation_script_sha256": _script_sha256(),
+        "evaluation_metrics_script_sha256": _metrics_script_sha256(),
+        "implementation_sha256": _implementation_sha256(),
+        "repolocus_version": __version__,
         "review_provenance": review_report,
         "fixtures": fixture_reports,
         "fixture_count": len(fixture_reports),
@@ -1217,6 +1266,37 @@ def _gate_report(
     }
 
 
+def default_thresholds() -> dict[str, int | float]:
+    """Return the release-gate thresholds used by the public protocol."""
+
+    return {
+        "minimum_hit_rate": 0.90,
+        "minimum_macro_recall": 0.80,
+        "minimum_mrr": 0.75,
+        "minimum_citation_recall": 1.0,
+        "minimum_no_answer_f1": 0.80,
+        "maximum_must_not_return_rate": 0.0,
+        "maximum_duplicate_evidence_rate": 0.0,
+        "maximum_line_iou": 0.79,
+        "minimum_intent_accuracy": 1.0,
+        "minimum_graph_grounded_rate": 1.0,
+        "minimum_mean_path_diversity": 0.50,
+        "minimum_slice_hit_rate": 0.50,
+        "minimum_slice_mrr": 0.50,
+        "minimum_slice_no_answer_f1": 0.75,
+        "minimum_qrels": 100,
+        "minimum_answerable_qrels": 60,
+        "minimum_no_answer_qrels": 20,
+        "minimum_citation_qrels": 60,
+    }
+
+
+def default_limit() -> int:
+    """Return the top-k limit used by the canonical public evaluation command."""
+
+    return _DEFAULT_LIMIT
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -1225,7 +1305,7 @@ def main() -> int:
         nargs="?",
         default=Path("evaluation"),
     )
-    parser.add_argument("--limit", type=_positive_cli_integer, default=5)
+    parser.add_argument("--limit", type=_positive_cli_integer, default=default_limit())
     parser.add_argument("--minimum-hit-rate", type=_unit_interval, default=0.90)
     parser.add_argument("--minimum-macro-recall", type=_unit_interval, default=0.80)
     parser.add_argument("--minimum-mrr", type=_unit_interval, default=0.75)
@@ -1247,7 +1327,7 @@ def main() -> int:
     parser.add_argument("--output", type=Path)
     arguments = parser.parse_args()
     report = evaluate_suite(arguments.evaluation_root.resolve(strict=True), limit=arguments.limit)
-    thresholds = {
+    thresholds = default_thresholds() | {
         "minimum_hit_rate": arguments.minimum_hit_rate,
         "minimum_macro_recall": arguments.minimum_macro_recall,
         "minimum_mrr": arguments.minimum_mrr,

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import re
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Protocol
 
 from repolocus.config import Settings
@@ -18,6 +19,59 @@ from repolocus.index import RepositoryIndex
 from repolocus.retrieval import RetrievalEngine
 
 _CITATION = re.compile(r"^(.+):([1-9]\d*)(?:-([1-9]\d*))?$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_OUTCOME_FIELDS = frozenset(
+    {
+        "question",
+        "case_id",
+        "case_family",
+        "language",
+        "query_type",
+        "answerable",
+        "predicted_no_answer",
+        "any_expected_path",
+        "all_expected_paths",
+        "recall_at_k",
+        "reciprocal_rank",
+        "ndcg_at_k",
+        "citation_recall",
+        "duplicate_evidence_count",
+        "duplicate_evidence_rate",
+        "path_diversity",
+        "maximum_line_iou",
+        "expected_intent",
+        "intent",
+        "intent_match",
+        "graph_grounded",
+        "confidence",
+        "rejected_reason",
+        "retrieval_hits",
+        "suppressed",
+        "expected_paths",
+        "returned_paths",
+        "returned_citations",
+        "returned_evidence",
+        "must_not_return",
+        "must_not_return_violations",
+        "fixture",
+        "fixture_revision",
+        "qrel_line",
+    }
+)
+_SERIALIZED_EVIDENCE_FIELDS = frozenset(
+    {
+        "path",
+        "start_line",
+        "end_line",
+        "citation",
+        "content_sha256",
+        "symbol",
+        "generation",
+        "reason",
+    }
+)
+_SERIALIZED_HIT_FIELDS = frozenset({"chunk_id", "retriever", "rank", "raw_score", "features"})
+_SERIALIZED_SUPPRESSED_FIELDS = frozenset({"chunk_id", "reason"})
 
 
 class EvidenceLike(Protocol):
@@ -212,6 +266,140 @@ def _citation_recall(evidence: Sequence[EvidenceLike], expected: Sequence[str]) 
     return matches / len(expected)
 
 
+def summarize_outcomes(outcomes: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    """Recompute every aggregate metric from serialized per-case outcomes."""
+
+    def average(items: Sequence[Mapping[str, object]], field: str) -> float | None:
+        values = [float(item[field]) for item in items if item.get(field) is not None]
+        return round(sum(values) / len(values), 6) if values else None
+
+    def summarize(items: Sequence[Mapping[str, object]]) -> dict[str, object]:
+        answerable = [item for item in items if bool(item["answerable"])]
+        no_answer = [item for item in items if not bool(item["answerable"])]
+        true_positive = sum(bool(item["predicted_no_answer"]) for item in no_answer)
+        false_positive = sum(bool(item["predicted_no_answer"]) for item in answerable)
+        true_negative = len(answerable) - false_positive
+        precision_denominator = true_positive + false_positive
+        no_answer_precision = (
+            true_positive / precision_denominator
+            if precision_denominator
+            else 0.0
+            if no_answer
+            else None
+        )
+        no_answer_recall = true_positive / len(no_answer) if no_answer else None
+        no_answer_f1 = (
+            2 * no_answer_precision * no_answer_recall / (no_answer_precision + no_answer_recall)
+            if no_answer_precision is not None
+            and no_answer_recall is not None
+            and no_answer_precision + no_answer_recall > 0
+            else 0.0
+            if no_answer_precision is not None and no_answer_recall is not None
+            else None
+        )
+        citations = [
+            float(item["citation_recall"])
+            for item in items
+            if item.get("citation_recall") is not None
+        ]
+        constrained = [item for item in items if item.get("must_not_return")]
+        violations = sum(bool(item["must_not_return_violations"]) for item in constrained)
+        evidence_count = sum(len(item["returned_evidence"]) for item in items)  # type: ignore[arg-type]
+        duplicate_count = sum(int(item["duplicate_evidence_count"]) for item in items)
+        intent_cases = [item for item in items if item.get("intent_match") is not None]
+        graph_cases = [item for item in items if item.get("graph_grounded") is not None]
+        return {
+            "cases": len(items),
+            "answerable_cases": len(answerable),
+            "no_answer_cases": len(no_answer),
+            "macro_recall_at_k": average(answerable, "recall_at_k"),
+            "mrr": average(answerable, "reciprocal_rank"),
+            "mean_ndcg_at_k": average(answerable, "ndcg_at_k"),
+            "any_expected_path_rate": average(answerable, "any_expected_path"),
+            "all_expected_paths_rate": average(answerable, "all_expected_paths"),
+            "citation_recall": round(sum(citations) / len(citations), 6) if citations else None,
+            "citation_cases": len(citations),
+            "must_not_return_cases": len(constrained),
+            "must_not_return_violations": violations,
+            "must_not_return_violation_rate": round(violations / len(constrained), 6)
+            if constrained
+            else 0.0,
+            "no_answer_precision": round(no_answer_precision, 6)
+            if no_answer_precision is not None
+            else None,
+            "no_answer_recall": round(no_answer_recall, 6)
+            if no_answer_recall is not None
+            else None,
+            "no_answer_f1": round(no_answer_f1, 6) if no_answer_f1 is not None else None,
+            "no_answer_accuracy": round((true_positive + true_negative) / len(items), 6)
+            if items
+            else None,
+            "returned_evidence": evidence_count,
+            "duplicate_evidence": duplicate_count,
+            "duplicate_evidence_rate": round(duplicate_count / evidence_count, 6)
+            if evidence_count
+            else 0.0,
+            "mean_path_diversity": average(items, "path_diversity"),
+            "maximum_line_iou": max(
+                (float(item["maximum_line_iou"]) for item in items), default=0.0
+            ),
+            "intent_cases": len(intent_cases),
+            "intent_matches": sum(bool(item["intent_match"]) for item in intent_cases),
+            "intent_accuracy": average(intent_cases, "intent_match"),
+            "graph_cases": len(graph_cases),
+            "graph_grounded": sum(bool(item["graph_grounded"]) for item in graph_cases),
+            "graph_grounded_rate": average(graph_cases, "graph_grounded"),
+        }
+
+    def bucket_summary(field: str) -> dict[str, dict[str, object]]:
+        def label(item: Mapping[str, object]) -> str:
+            value = item.get(field)
+            return str(value) if value is not None else "unspecified"
+
+        labels = sorted({label(item) for item in outcomes})
+        return {
+            bucket: summarize([item for item in outcomes if label(item) == bucket])
+            for bucket in labels
+        }
+
+    metrics = summarize(outcomes)
+    # Compatibility alias retained for reports produced by v0.1.3.
+    metrics["answerable_all_paths_rate"] = metrics["all_expected_paths_rate"]
+    metrics["by_language"] = bucket_summary("language")
+    metrics["by_repository"] = bucket_summary("fixture")
+    metrics["by_query_type"] = bucket_summary("query_type")
+    metrics["by_intent"] = bucket_summary("expected_intent")
+    metrics["intent_counts"] = dict(
+        sorted(Counter(str(item["intent"]) for item in outcomes if item.get("intent")).items())
+    )
+    metrics["rejected_reason_counts"] = dict(
+        sorted(
+            Counter(
+                str(item["rejected_reason"]) for item in outcomes if item.get("rejected_reason")
+            ).items()
+        )
+    )
+    metrics["retriever_hit_counts"] = dict(
+        sorted(
+            Counter(
+                str(hit["retriever"])
+                for item in outcomes
+                for hit in item["retrieval_hits"]  # type: ignore[union-attr]
+            ).items()
+        )
+    )
+    metrics["suppressed_reason_counts"] = dict(
+        sorted(
+            Counter(
+                str(suppressed["reason"])
+                for item in outcomes
+                for suppressed in item["suppressed"]  # type: ignore[union-attr]
+            ).items()
+        )
+    )
+    return metrics
+
+
 def evaluate_cases(
     retrieval: RetrievalLike,
     cases: Sequence[Mapping[str, Any]],
@@ -355,6 +543,9 @@ def evaluate_cases(
                         "start_line": int(item.start_line),
                         "end_line": int(item.end_line),
                         "citation": str(item.citation),
+                        "content_sha256": hashlib.sha256(
+                            str(item.content).encode("utf-8")
+                        ).hexdigest(),
                         "symbol": str(getattr(item, "symbol", "")),
                         "generation": int(getattr(item, "generation", 0)),
                         "reason": str(getattr(item, "reason", "")),
@@ -369,135 +560,434 @@ def evaluate_cases(
             }
         )
 
-    def average(items: Sequence[Mapping[str, object]], field: str) -> float | None:
-        values = [float(item[field]) for item in items if item.get(field) is not None]
-        return round(sum(values) / len(values), 6) if values else None
+    return outcomes, summarize_outcomes(outcomes)
 
-    def summarize(items: Sequence[Mapping[str, object]]) -> dict[str, object]:
-        answerable = [item for item in items if bool(item["answerable"])]
-        no_answer = [item for item in items if not bool(item["answerable"])]
-        true_positive = sum(bool(item["predicted_no_answer"]) for item in no_answer)
-        false_positive = sum(bool(item["predicted_no_answer"]) for item in answerable)
-        true_negative = len(answerable) - false_positive
-        precision_denominator = true_positive + false_positive
-        no_answer_precision = (
-            true_positive / precision_denominator
-            if precision_denominator
-            else 0.0
-            if no_answer
-            else None
-        )
-        no_answer_recall = true_positive / len(no_answer) if no_answer else None
-        no_answer_f1 = (
-            2 * no_answer_precision * no_answer_recall / (no_answer_precision + no_answer_recall)
-            if no_answer_precision is not None
-            and no_answer_recall is not None
-            and no_answer_precision + no_answer_recall > 0
-            else 0.0
-            if no_answer_precision is not None and no_answer_recall is not None
-            else None
-        )
-        citations = [
-            float(item["citation_recall"])
-            for item in items
-            if item.get("citation_recall") is not None
-        ]
-        constrained = [item for item in items if item.get("must_not_return")]
-        violations = sum(bool(item["must_not_return_violations"]) for item in constrained)
-        evidence_count = sum(len(item["returned_evidence"]) for item in items)  # type: ignore[arg-type]
-        duplicate_count = sum(int(item["duplicate_evidence_count"]) for item in items)
-        intent_cases = [item for item in items if item.get("intent_match") is not None]
-        graph_cases = [item for item in items if item.get("graph_grounded") is not None]
-        return {
-            "cases": len(items),
-            "answerable_cases": len(answerable),
-            "no_answer_cases": len(no_answer),
-            "macro_recall_at_k": average(answerable, "recall_at_k"),
-            "mrr": average(answerable, "reciprocal_rank"),
-            "mean_ndcg_at_k": average(answerable, "ndcg_at_k"),
-            "any_expected_path_rate": average(answerable, "any_expected_path"),
-            "all_expected_paths_rate": average(answerable, "all_expected_paths"),
-            "citation_recall": round(sum(citations) / len(citations), 6) if citations else None,
-            "citation_cases": len(citations),
-            "must_not_return_cases": len(constrained),
-            "must_not_return_violations": violations,
-            "must_not_return_violation_rate": round(violations / len(constrained), 6)
-            if constrained
-            else 0.0,
-            "no_answer_precision": round(no_answer_precision, 6)
-            if no_answer_precision is not None
-            else None,
-            "no_answer_recall": round(no_answer_recall, 6)
-            if no_answer_recall is not None
-            else None,
-            "no_answer_f1": round(no_answer_f1, 6) if no_answer_f1 is not None else None,
-            "no_answer_accuracy": round((true_positive + true_negative) / len(items), 6)
-            if items
-            else None,
-            "returned_evidence": evidence_count,
-            "duplicate_evidence": duplicate_count,
-            "duplicate_evidence_rate": round(duplicate_count / evidence_count, 6)
-            if evidence_count
-            else 0.0,
-            "mean_path_diversity": average(items, "path_diversity"),
-            "maximum_line_iou": max(
-                (float(item["maximum_line_iou"]) for item in items), default=0.0
-            ),
-            "intent_cases": len(intent_cases),
-            "intent_matches": sum(bool(item["intent_match"]) for item in intent_cases),
-            "intent_accuracy": average(intent_cases, "intent_match"),
-            "graph_cases": len(graph_cases),
-            "graph_grounded": sum(bool(item["graph_grounded"]) for item in graph_cases),
-            "graph_grounded_rate": average(graph_cases, "graph_grounded"),
-        }
 
-    def bucket_summary(field: str) -> dict[str, dict[str, object]]:
-        def label(item: Mapping[str, object]) -> str:
-            value = item.get(field)
-            return str(value) if value is not None else "unspecified"
+def _strict_integer(value: object, field: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{field} must be an integer >= {minimum}")
+    return value
 
-        labels = sorted({label(item) for item in outcomes})
-        return {
-            bucket: summarize([item for item in outcomes if label(item) == bucket])
-            for bucket in labels
-        }
 
-    metrics = summarize(outcomes)
-    # Compatibility alias retained for reports produced by v0.1.3.
-    metrics["answerable_all_paths_rate"] = metrics["all_expected_paths_rate"]
-    metrics["by_language"] = bucket_summary("language")
-    metrics["by_repository"] = bucket_summary("fixture")
-    metrics["by_query_type"] = bucket_summary("query_type")
-    metrics["by_intent"] = bucket_summary("expected_intent")
-    metrics["intent_counts"] = dict(
-        sorted(Counter(str(item["intent"]) for item in outcomes if item.get("intent")).items())
+def _finite_number(value: object, field: str) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a finite number")
+    if not math.isfinite(float(value)):
+        raise ValueError(f"{field} must be a finite number")
+    return value
+
+
+def _required_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _same_json_value(left: object, right: object) -> bool:
+    return json.dumps(
+        left,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ) == json.dumps(
+        right,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
     )
-    metrics["rejected_reason_counts"] = dict(
-        sorted(
-            Counter(
-                str(item["rejected_reason"]) for item in outcomes if item.get("rejected_reason")
-            ).items()
+
+
+def _serialized_evidence(
+    value: object,
+    *,
+    identity: str,
+    limit: int,
+    fixture_root: Path,
+) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise ValueError(f"outcome {identity} returned_evidence must be a list")
+    if len(value) > limit:
+        raise ValueError(f"outcome {identity} contains more evidence than its top-k limit")
+    evidence: list[dict[str, object]] = []
+    for index, raw in enumerate(value):
+        field = f"outcome {identity} returned_evidence[{index}]"
+        if not isinstance(raw, Mapping) or set(raw) != _SERIALIZED_EVIDENCE_FIELDS:
+            raise ValueError(f"{field} fields do not match the pinned evidence schema")
+        path = _required_string(raw.get("path"), f"{field}.path")
+        start = _strict_integer(raw.get("start_line"), f"{field}.start_line", minimum=1)
+        end = _strict_integer(raw.get("end_line"), f"{field}.end_line", minimum=start)
+        citation = _required_string(raw.get("citation"), f"{field}.citation")
+        expected_citation = f"{path}:{start}" + (f"-{end}" if end != start else "")
+        if citation != expected_citation:
+            raise ValueError(f"{field}.citation does not match its serialized source range")
+        content_sha256 = raw.get("content_sha256")
+        if not isinstance(content_sha256, str) or _SHA256.fullmatch(content_sha256) is None:
+            raise ValueError(f"{field}.content_sha256 must be a lowercase SHA-256")
+        relative = PurePosixPath(path)
+        windows_path = PureWindowsPath(path)
+        if (
+            "\\" in path
+            or relative.is_absolute()
+            or bool(windows_path.drive)
+            or bool(windows_path.root)
+            or ".." in relative.parts
+            or "." in relative.parts
+            or relative.as_posix() != path
+        ):
+            raise ValueError(f"{field}.path must be a canonical fixture-relative path")
+        source = fixture_root.joinpath(*relative.parts)
+        if source.is_symlink() or not source.is_file():
+            raise ValueError(f"{field}.path is not a regular pinned fixture file")
+        source.resolve(strict=True).relative_to(fixture_root.resolve(strict=True))
+        source_lines = source.read_text(encoding="utf-8").splitlines(keepends=True)
+        if end > len(source_lines):
+            raise ValueError(f"{field} source range exceeds the pinned fixture file")
+        actual_content_sha256 = hashlib.sha256(
+            "".join(source_lines[start - 1 : end]).encode("utf-8")
+        ).hexdigest()
+        if content_sha256 != actual_content_sha256:
+            raise ValueError(f"{field}.content_sha256 does not match the pinned fixture content")
+        symbol = raw.get("symbol")
+        reason = raw.get("reason")
+        if not isinstance(symbol, str) or not isinstance(reason, str):
+            raise ValueError(f"{field} symbol and reason must be strings")
+        generation = _strict_integer(raw.get("generation"), f"{field}.generation")
+        evidence.append(
+            {
+                "path": path,
+                "start_line": start,
+                "end_line": end,
+                "citation": citation,
+                "content_sha256": content_sha256,
+                "symbol": symbol,
+                "generation": generation,
+                "reason": reason,
+            }
         )
-    )
-    metrics["retriever_hit_counts"] = dict(
-        sorted(
-            Counter(
-                str(hit["retriever"])
-                for item in outcomes
-                for hit in item["retrieval_hits"]  # type: ignore[union-attr]
-            ).items()
+    return evidence
+
+
+def _serialized_hits(value: object, *, identity: str) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise ValueError(f"outcome {identity} retrieval_hits must be a list")
+    hits: list[dict[str, object]] = []
+    for index, raw in enumerate(value):
+        field = f"outcome {identity} retrieval_hits[{index}]"
+        if not isinstance(raw, Mapping) or set(raw) != _SERIALIZED_HIT_FIELDS:
+            raise ValueError(f"{field} fields do not match the pinned hit schema")
+        chunk_id = _strict_integer(raw.get("chunk_id"), f"{field}.chunk_id", minimum=1)
+        retriever = _required_string(raw.get("retriever"), f"{field}.retriever")
+        rank = _strict_integer(raw.get("rank"), f"{field}.rank", minimum=1)
+        raw_score = raw.get("raw_score")
+        if raw_score is not None:
+            raw_score = _finite_number(raw_score, f"{field}.raw_score")
+        features = raw.get("features")
+        if not isinstance(features, Mapping):
+            raise ValueError(f"{field}.features must be an object")
+        hits.append(
+            {
+                "chunk_id": chunk_id,
+                "retriever": retriever,
+                "rank": rank,
+                "raw_score": raw_score,
+                "features": dict(features),
+            }
         )
-    )
-    metrics["suppressed_reason_counts"] = dict(
-        sorted(
-            Counter(
-                str(suppressed["reason"])
-                for item in outcomes
-                for suppressed in item["suppressed"]  # type: ignore[union-attr]
-            ).items()
+    return hits
+
+
+def _serialized_suppressed(value: object, *, identity: str) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise ValueError(f"outcome {identity} suppressed must be a list")
+    suppressed: list[dict[str, object]] = []
+    for index, raw in enumerate(value):
+        field = f"outcome {identity} suppressed[{index}]"
+        if not isinstance(raw, Mapping) or set(raw) != _SERIALIZED_SUPPRESSED_FIELDS:
+            raise ValueError(f"{field} fields do not match the pinned suppression schema")
+        suppressed.append(
+            {
+                "chunk_id": _strict_integer(raw.get("chunk_id"), f"{field}.chunk_id", minimum=1),
+                "reason": _required_string(raw.get("reason"), f"{field}.reason"),
+            }
         )
+    return suppressed
+
+
+def _serialized_evidence_diagnostics(
+    evidence: Sequence[Mapping[str, object]],
+) -> tuple[int, float | None, float]:
+    seen_ranges: set[tuple[str, int, int]] = set()
+    seen_content: set[str] = set()
+    duplicates = 0
+    for item in evidence:
+        identity = (str(item["path"]), int(item["start_line"]), int(item["end_line"]))
+        content_sha256 = item.get("content_sha256")
+        if identity in seen_ranges or (
+            isinstance(content_sha256, str) and content_sha256 in seen_content
+        ):
+            duplicates += 1
+        seen_ranges.add(identity)
+        if isinstance(content_sha256, str):
+            seen_content.add(content_sha256)
+    path_diversity = (
+        len({str(item["path"]) for item in evidence}) / len(evidence) if evidence else None
     )
-    return outcomes, metrics
+    maximum_iou = max(
+        (
+            _serialized_line_iou(first, second)
+            for index, first in enumerate(evidence)
+            for second in evidence[index + 1 :]
+        ),
+        default=0.0,
+    )
+    return duplicates, path_diversity, maximum_iou
+
+
+def _serialized_line_iou(first: Mapping[str, object], second: Mapping[str, object]) -> float:
+    if first["path"] != second["path"]:
+        return 0.0
+    first_start, first_end = int(first["start_line"]), int(first["end_line"])
+    second_start, second_end = int(second["start_line"]), int(second["end_line"])
+    intersection = max(0, min(first_end, second_end) - max(first_start, second_start) + 1)
+    union = max(first_end, second_end) - min(first_start, second_start) + 1
+    return intersection / union if union else 0.0
+
+
+def _serialized_citation_recall(
+    evidence: Sequence[Mapping[str, object]], expected: Sequence[str]
+) -> float | None:
+    if not expected:
+        return None
+    matches = 0
+    for citation in expected:
+        path, start, end = _citation_range(citation)
+        if any(
+            item["path"] == path
+            and int(item["start_line"]) <= start
+            and end <= int(item["end_line"])
+            for item in evidence
+        ):
+            matches += 1
+    return matches / len(expected)
+
+
+def _canonical_outcome_from_serialized_evidence(
+    case: Mapping[str, object],
+    outcome: Mapping[str, object],
+    *,
+    limit: int,
+    fixture_root: Path,
+) -> dict[str, object]:
+    fixture = _required_string(case.get("fixture"), "qrel fixture")
+    case_id = _required_string(case.get("case_id"), f"qrel {fixture} case_id")
+    identity = f"{fixture}/{case_id}"
+    if set(outcome) != _OUTCOME_FIELDS:
+        missing = sorted(_OUTCOME_FIELDS - set(outcome))
+        extra = sorted(set(outcome) - _OUTCOME_FIELDS)
+        raise ValueError(
+            f"outcome {identity} fields do not match the pinned schema; "
+            f"missing={missing}, extra={extra}"
+        )
+
+    question = _required_string(case.get("question"), f"qrel {identity} question")
+    case_family = _required_string(case.get("case_family"), f"qrel {identity} case_family")
+    language = _required_string(case.get("language"), f"qrel {identity} language")
+    query_type = _required_string(case.get("query_type"), f"qrel {identity} query_type")
+    fixture_revision = _required_string(
+        case.get("fixture_revision"), f"qrel {identity} fixture_revision"
+    )
+    qrel_line = _strict_integer(case.get("qrel_line"), f"qrel {identity} line", minimum=1)
+    expected_intent = _required_string(
+        case.get("expected_intent"), f"qrel {identity} expected_intent"
+    )
+    answerable = case.get("answerable")
+    if not isinstance(answerable, bool):
+        raise ValueError(f"qrel {identity} answerable must be a boolean")
+
+    relevant = case.get("relevant")
+    if not isinstance(relevant, list):
+        raise ValueError(f"qrel {identity} relevant must be a list")
+    grades: dict[str, int] = {}
+    expected_citations: list[str] = []
+    for index, raw in enumerate(relevant):
+        field = f"qrel {identity} relevant[{index}]"
+        if not isinstance(raw, Mapping) or set(raw) != {"path", "start", "end", "grade"}:
+            raise ValueError(f"{field} fields do not match the pinned qrel schema")
+        path = _required_string(raw.get("path"), f"{field}.path")
+        start = _strict_integer(raw.get("start"), f"{field}.start", minimum=1)
+        end = _strict_integer(raw.get("end"), f"{field}.end", minimum=start)
+        grade = _strict_integer(raw.get("grade"), f"{field}.grade", minimum=1)
+        if grade > 3:
+            raise ValueError(f"{field}.grade must be <= 3")
+        grades[path] = max(grades.get(path, 0), grade)
+        expected_citations.append(f"{path}:{start}" + (f"-{end}" if end != start else ""))
+    expected = set(grades)
+    if answerable != bool(expected):
+        raise ValueError(f"qrel {identity} answerable does not match its relevant paths")
+
+    raw_forbidden = case.get("must_not_return")
+    if not isinstance(raw_forbidden, list) or any(
+        not isinstance(path, str) or not path for path in raw_forbidden
+    ):
+        raise ValueError(f"qrel {identity} must_not_return must contain non-empty paths")
+    forbidden = {str(path) for path in raw_forbidden}
+    if len(forbidden) != len(raw_forbidden):
+        raise ValueError(f"qrel {identity} must_not_return contains duplicate paths")
+
+    evidence = _serialized_evidence(
+        outcome.get("returned_evidence"),
+        identity=identity,
+        limit=limit,
+        fixture_root=fixture_root,
+    )
+    hits = _serialized_hits(outcome.get("retrieval_hits"), identity=identity)
+    suppressed = _serialized_suppressed(outcome.get("suppressed"), identity=identity)
+    returned: list[str] = []
+    for item in evidence:
+        path = str(item["path"])
+        if path not in returned:
+            returned.append(path)
+    duplicate_count, path_diversity, maximum_line_iou = _serialized_evidence_diagnostics(evidence)
+
+    confidence = outcome.get("confidence")
+    if confidence is not None:
+        confidence = _finite_number(confidence, f"outcome {identity} confidence")
+        if not 0.0 <= float(confidence) <= 1.0:
+            raise ValueError(f"outcome {identity} confidence must be from 0 to 1")
+    rejected_reason = outcome.get("rejected_reason")
+    if rejected_reason is not None:
+        rejected_reason = _required_string(rejected_reason, f"outcome {identity} rejected_reason")
+    if evidence and rejected_reason is not None:
+        raise ValueError(f"outcome {identity} cannot reject returned evidence")
+    if not evidence and rejected_reason is None:
+        raise ValueError(f"outcome {identity} no-answer result needs a rejected reason")
+    intent = outcome.get("intent")
+    if intent is not None:
+        intent = _required_string(intent, f"outcome {identity} intent")
+
+    relevant_ranks = [rank for rank, path in enumerate(returned, 1) if path in expected]
+    recall = len(expected.intersection(returned)) / len(expected) if answerable else None
+    reciprocal_rank = (1.0 / relevant_ranks[0] if relevant_ranks else 0.0) if answerable else None
+    citation_recall = _serialized_citation_recall(evidence, expected_citations)
+    forbidden_returned = sorted(forbidden.intersection(returned))
+    required_graph_retriever = {
+        "direct_dependency": "outbound_dependency",
+        "reverse_dependency": "reverse_dependency",
+    }.get(query_type)
+    graph_grounded: bool | None = None
+    if required_graph_retriever is not None:
+        retriever_present = any(hit["retriever"] == required_graph_retriever for hit in hits)
+        graph_reason = "dependency of" if query_type == "direct_dependency" else "dependent of"
+        relevant_graph_evidence = any(
+            item["path"] in expected and graph_reason in str(item["reason"]) for item in evidence
+        )
+        graph_grounded = retriever_present and relevant_graph_evidence
+
+    return {
+        "question": question,
+        "case_id": case_id,
+        "case_family": case_family,
+        "language": language,
+        "query_type": query_type,
+        "answerable": answerable,
+        "predicted_no_answer": not returned,
+        "any_expected_path": bool(expected.intersection(returned)) if answerable else None,
+        "all_expected_paths": expected.issubset(returned) if answerable else None,
+        "recall_at_k": round(recall, 6) if recall is not None else None,
+        "reciprocal_rank": round(reciprocal_rank, 6) if reciprocal_rank is not None else None,
+        "ndcg_at_k": round(_ndcg(returned, grades, limit), 6) if answerable else None,
+        "citation_recall": (round(citation_recall, 6) if citation_recall is not None else None),
+        "duplicate_evidence_count": duplicate_count,
+        "duplicate_evidence_rate": (round(duplicate_count / len(evidence), 6) if evidence else 0.0),
+        "path_diversity": round(path_diversity, 6) if path_diversity is not None else None,
+        "maximum_line_iou": round(maximum_line_iou, 6),
+        "expected_intent": expected_intent,
+        "intent": intent,
+        "intent_match": intent == expected_intent,
+        "graph_grounded": graph_grounded,
+        "confidence": confidence,
+        "rejected_reason": rejected_reason,
+        "retrieval_hits": hits,
+        "suppressed": suppressed,
+        "expected_paths": sorted(expected),
+        "returned_paths": returned,
+        "returned_citations": [str(item["citation"]) for item in evidence],
+        "returned_evidence": evidence,
+        "must_not_return": sorted(forbidden),
+        "must_not_return_violations": forbidden_returned,
+        "fixture": fixture,
+        "fixture_revision": fixture_revision,
+        "qrel_line": qrel_line,
+    }
+
+
+def validate_outcomes_against_qrels(
+    cases: Sequence[Mapping[str, object]],
+    outcomes: Sequence[Mapping[str, object]],
+    *,
+    limit: int,
+    fixture_roots: Mapping[str, Path],
+) -> list[dict[str, object]]:
+    """Bind serialized outcomes to an exact qrel inventory and recompute every case metric."""
+
+    if limit <= 0:
+        raise ValueError("outcome validation limit must be positive")
+    expected: dict[tuple[str, str], Mapping[str, object]] = {}
+    expected_order: list[tuple[str, str]] = []
+    global_case_ids: set[str] = set()
+    for case in cases:
+        fixture = _required_string(case.get("fixture"), "qrel fixture")
+        case_id = _required_string(case.get("case_id"), f"qrel {fixture} case_id")
+        key = (fixture, case_id)
+        if key in expected or case_id in global_case_ids:
+            raise ValueError(f"pinned qrel inventory contains duplicate case: {fixture}/{case_id}")
+        expected[key] = case
+        expected_order.append(key)
+        global_case_ids.add(case_id)
+
+    reported: dict[tuple[str, str], Mapping[str, object]] = {}
+    for index, outcome in enumerate(outcomes):
+        if not isinstance(outcome, Mapping):
+            raise ValueError(f"evaluation outcome {index} must be an object")
+        fixture = _required_string(outcome.get("fixture"), f"evaluation outcome {index}.fixture")
+        case_id = _required_string(outcome.get("case_id"), f"evaluation outcome {index}.case_id")
+        key = (fixture, case_id)
+        if key not in expected:
+            raise ValueError(
+                f"evaluation outcome is not in the pinned qrel inventory: {fixture}/{case_id}"
+            )
+        if key in reported:
+            raise ValueError(f"evaluation outcome is duplicated: {fixture}/{case_id}")
+        reported[key] = outcome
+
+    missing = [
+        f"{fixture}/{case_id}"
+        for fixture, case_id in expected_order
+        if (fixture, case_id) not in reported
+    ]
+    if missing:
+        raise ValueError(f"evaluation outcomes are missing pinned qrels: {', '.join(missing)}")
+
+    canonical: list[dict[str, object]] = []
+    for key in expected_order:
+        outcome = reported[key]
+        fixture, case_id = key
+        fixture_root = fixture_roots.get(fixture)
+        if not isinstance(fixture_root, Path):
+            raise ValueError(f"pinned fixture root is missing for {fixture}/{case_id}")
+        recomputed = _canonical_outcome_from_serialized_evidence(
+            expected[key], outcome, limit=limit, fixture_root=fixture_root
+        )
+        for field in sorted(_OUTCOME_FIELDS):
+            if not _same_json_value(outcome.get(field), recomputed[field]):
+                raise ValueError(
+                    f"evaluation outcome {fixture}/{case_id} field {field} does not match "
+                    "the pinned qrel and serialized retrieval evidence"
+                )
+        canonical.append(recomputed)
+    return canonical
 
 
 def main() -> int:

--- a/scripts/public_benchmark_report.py
+++ b/scripts/public_benchmark_report.py
@@ -1,0 +1,1589 @@
+#!/usr/bin/env python3
+"""Build and validate the reproducible public benchmark summary.
+
+The runner combines the existing external-evaluation and indexed-workflow
+reports.  It does not execute either benchmark and it never treats the bundled
+synthetic fixtures as evidence of production-repository quality.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import shlex
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+_SCHEMA_VERSION = 1
+_BENCHMARK_ID = "repolocus-public-benchmark-v1"
+_HASH_ALGORITHM = "sha256-lf-v1"
+_OPERATIONS = (
+    "scan",
+    "map",
+    "diagram",
+    "symbol_query",
+    "dependency_query",
+    "retrieval",
+)
+_QUERY_OPERATIONS = ("symbol_query", "dependency_query", "retrieval")
+_MEASUREMENT_FIELDS = (
+    "wall_seconds",
+    "cpu_seconds",
+    "peak_rss_bytes",
+    "sqlite_query_count",
+    "database_bytes",
+    "wal_bytes",
+)
+_INTEGER_MEASUREMENTS = frozenset(
+    {"peak_rss_bytes", "sqlite_query_count", "database_bytes", "wal_bytes"}
+)
+_QUALITY_RATES = (
+    "any_expected_path_rate",
+    "macro_recall_at_k",
+    "mrr",
+    "citation_recall",
+    "no_answer_accuracy",
+    "no_answer_precision",
+    "no_answer_recall",
+    "no_answer_f1",
+    "duplicate_evidence_rate",
+    "must_not_return_violation_rate",
+)
+_BOOTSTRAP_RATES = (
+    "any_expected_path_rate",
+    "macro_recall_at_k",
+    "mrr",
+    "citation_recall",
+    "no_answer_f1",
+)
+_ARTIFACT_IDS = frozenset(
+    {
+        "evaluation_manifest",
+        "evaluation_metrics_runner",
+        "evaluation_runner",
+        "performance_manifest",
+        "performance_runner",
+        "report_runner",
+        "report_schema",
+    }
+)
+_COMPARISON_SYSTEMS = ("RepoWiki", "DeepWiki", "Sourcebot")
+_COMMAND_IDS = ("evaluation", "performance", "report", "check")
+
+
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _canonical_bytes(payload: bytes) -> bytes:
+    """Normalize checkout line endings for cross-platform protocol hashes."""
+
+    return payload.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(_canonical_bytes(path.read_bytes())).hexdigest()
+
+
+def _raw_sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"benchmark JSON contains non-finite number: {value}")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    output: dict[str, object] = {}
+    for key, value in pairs:
+        if key in output:
+            raise ValueError(f"benchmark JSON contains duplicate key: {key}")
+        output[key] = value
+    return output
+
+
+def _load_json(path: Path) -> object:
+    return json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=_reject_json_constant,
+        object_pairs_hook=_reject_duplicate_keys,
+    )
+
+
+def _load_protocol_module(
+    path: Path,
+    name: str,
+    *,
+    injected_modules: Mapping[str, object] | None = None,
+):  # type: ignore[no-untyped-def]
+    specification = importlib.util.spec_from_file_location(name, path)
+    if specification is None or specification.loader is None:
+        raise ValueError(f"could not load pinned protocol module: {path}")
+    module = importlib.util.module_from_spec(specification)
+    script_directory = str(path.parent)
+    inserted = script_directory not in sys.path
+    if inserted:
+        sys.path.insert(0, script_directory)
+    missing = object()
+    previous_modules: dict[str, object] = {}
+    for module_name, injected_module in (injected_modules or {}).items():
+        previous_modules[module_name] = sys.modules.get(module_name, missing)
+        sys.modules[module_name] = injected_module  # type: ignore[assignment]
+    try:
+        specification.loader.exec_module(module)
+    finally:
+        for module_name, previous in previous_modules.items():
+            if previous is missing:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = previous  # type: ignore[assignment]
+        if inserted:
+            sys.path.remove(script_directory)
+    return module
+
+
+def _same_json_value(left: object, right: object) -> bool:
+    return json.dumps(left, sort_keys=True, allow_nan=False) == json.dumps(
+        right, sort_keys=True, allow_nan=False
+    )
+
+
+def _mapping(value: object, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    return value
+
+
+def _sequence(value: object, field: str) -> Sequence[object]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{field} must be an array")
+    return value
+
+
+def _string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or "\n" in value:
+        raise ValueError(f"{field} must be a non-empty single-line string")
+    return value
+
+
+def _boolean(value: object, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be boolean")
+    return value
+
+
+def _integer(value: object, field: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{field} must be an integer >= {minimum}")
+    return value
+
+
+def _number(value: object, field: str, *, rate: bool = False) -> int | float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or value < 0
+        or (rate and value > 1)
+    ):
+        qualifier = "a rate from 0 through 1" if rate else "a finite non-negative number"
+        raise ValueError(f"{field} must be {qualifier}")
+    return value
+
+
+def _sha256(value: object, field: str) -> str:
+    digest = _string(value, field)
+    if len(digest) != 64:
+        raise ValueError(f"{field} must be a SHA-256 digest")
+    try:
+        bytes.fromhex(digest)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be a SHA-256 digest") from exc
+    return digest.lower()
+
+
+def _exact_keys(value: Mapping[str, object], expected: set[str], field: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise ValueError(f"{field} fields must be exactly {sorted(expected)}; got {sorted(actual)}")
+
+
+def _relative_file(root: Path, value: object, field: str) -> tuple[str, Path]:
+    raw = _string(value, field)
+    pure = PurePosixPath(raw)
+    windows_path = PureWindowsPath(raw)
+    if (
+        "\\" in raw
+        or pure.is_absolute()
+        or bool(windows_path.drive)
+        or bool(windows_path.root)
+        or ".." in pure.parts
+        or pure.as_posix() != raw
+    ):
+        raise ValueError(f"{field} must be a normalized repository-relative path")
+    candidate = root.joinpath(*pure.parts)
+    if candidate.is_symlink() or not candidate.is_file():
+        raise ValueError(f"{field} must identify a regular repository file")
+    candidate.resolve(strict=True).relative_to(root.resolve(strict=True))
+    return raw, candidate
+
+
+def _relative_directory(root: Path, value: object, field: str) -> tuple[str, Path]:
+    raw = _string(value, field)
+    pure = PurePosixPath(raw)
+    windows_path = PureWindowsPath(raw)
+    if (
+        "\\" in raw
+        or pure.is_absolute()
+        or bool(windows_path.drive)
+        or bool(windows_path.root)
+        or ".." in pure.parts
+        or pure.as_posix() != raw
+    ):
+        raise ValueError(f"{field} must be a normalized repository-relative path")
+    candidate = root.joinpath(*pure.parts)
+    if candidate.is_symlink() or not candidate.is_dir():
+        raise ValueError(f"{field} must identify a regular repository directory")
+    candidate.resolve(strict=True).relative_to(root.resolve(strict=True))
+    return raw, candidate
+
+
+def _validate_artifacts(
+    root: Path,
+    value: object,
+) -> dict[str, dict[str, str]]:
+    artifacts = _mapping(value, "manifest.artifacts")
+    if set(artifacts) != _ARTIFACT_IDS:
+        raise ValueError(f"manifest.artifacts must contain exactly {sorted(_ARTIFACT_IDS)}")
+    validated: dict[str, dict[str, str]] = {}
+    for artifact_id in sorted(_ARTIFACT_IDS):
+        artifact = _mapping(artifacts[artifact_id], f"manifest.artifacts.{artifact_id}")
+        _exact_keys(artifact, {"path", "sha256"}, f"manifest.artifacts.{artifact_id}")
+        relative, path = _relative_file(
+            root,
+            artifact.get("path"),
+            f"manifest.artifacts.{artifact_id}.path",
+        )
+        expected = _sha256(
+            artifact.get("sha256"),
+            f"manifest.artifacts.{artifact_id}.sha256",
+        )
+        actual = _sha256_file(path)
+        if actual != expected:
+            raise ValueError(
+                f"public benchmark protocol drifted: {relative} has {actual}, expected {expected}"
+            )
+        validated[artifact_id] = {"path": relative, "sha256": expected}
+    return validated
+
+
+def _expected_commands(artifacts: Mapping[str, Mapping[str, str]]) -> dict[str, list[str]]:
+    evaluation_output = "benchmarks/results/public-evaluation.json"
+    performance_output = "benchmarks/results/public-performance.json"
+    json_output = "benchmarks/results/public-report.json"
+    markdown_output = "benchmarks/results/public-report.md"
+    report_base = [
+        "uv",
+        "run",
+        "python",
+        artifacts["report_runner"]["path"],
+        "--manifest",
+        "benchmarks/public-benchmark-manifest.json",
+        "--evaluation-report",
+        evaluation_output,
+        "--performance-report",
+        performance_output,
+        "--json-output",
+        json_output,
+        "--markdown-output",
+        markdown_output,
+    ]
+    return {
+        "evaluation": [
+            "uv",
+            "run",
+            "python",
+            artifacts["evaluation_runner"]["path"],
+            "evaluation",
+            "--output",
+            evaluation_output,
+        ],
+        "performance": [
+            "uv",
+            "run",
+            "python",
+            artifacts["performance_runner"]["path"],
+            "--manifest",
+            artifacts["performance_manifest"]["path"],
+            "--output",
+            performance_output,
+        ],
+        "report": report_base,
+        "check": [*report_base, "--check"],
+    }
+
+
+def _validate_commands(
+    value: object,
+    artifacts: Mapping[str, Mapping[str, str]],
+) -> tuple[dict[str, object], ...]:
+    commands = _sequence(value, "manifest.commands")
+    expected = _expected_commands(artifacts)
+    if len(commands) != len(_COMMAND_IDS):
+        raise ValueError(
+            "manifest.commands must contain evaluation, performance, report, and check"
+        )
+    validated: list[dict[str, object]] = []
+    for index, command_id in enumerate(_COMMAND_IDS):
+        command = _mapping(commands[index], f"manifest.commands[{index}]")
+        _exact_keys(command, {"id", "argv"}, f"manifest.commands[{index}]")
+        if command.get("id") != command_id:
+            raise ValueError(f"manifest.commands[{index}].id must be {command_id!r}")
+        argv = [
+            _string(item, f"manifest.commands[{index}].argv")
+            for item in _sequence(command.get("argv"), f"manifest.commands[{index}].argv")
+        ]
+        if argv != expected[command_id]:
+            raise ValueError(f"manifest command {command_id} does not match the public protocol")
+        validated.append({"id": command_id, "argv": argv})
+    return tuple(validated)
+
+
+def _validate_comparisons(value: object) -> tuple[dict[str, object], ...]:
+    comparisons = _sequence(value, "manifest.comparisons")
+    if len(comparisons) != len(_COMPARISON_SYSTEMS):
+        raise ValueError("manifest.comparisons must list RepoWiki, DeepWiki, and Sourcebot")
+    validated: list[dict[str, object]] = []
+    for index, system in enumerate(_COMPARISON_SYSTEMS):
+        comparison = _mapping(comparisons[index], f"manifest.comparisons[{index}]")
+        _exact_keys(
+            comparison,
+            {"system", "status", "protocol", "metrics", "reason"},
+            f"manifest.comparisons[{index}]",
+        )
+        if comparison.get("system") != system or comparison.get("status") != "N/A":
+            raise ValueError(f"{system} must be explicitly marked N/A")
+        if comparison.get("protocol") is not None or comparison.get("metrics") is not None:
+            raise ValueError(f"{system} cannot report metrics without a pinned equivalent protocol")
+        reason = _string(comparison.get("reason"), f"manifest.comparisons[{index}].reason")
+        if "equivalent public protocol" not in reason.casefold():
+            raise ValueError(
+                f"{system} N/A reason must name the missing equivalent public protocol"
+            )
+        validated.append(
+            {
+                "system": system,
+                "status": "N/A",
+                "protocol": None,
+                "metrics": None,
+                "reason": reason,
+            }
+        )
+    return tuple(validated)
+
+
+def load_public_manifest(
+    manifest_path: Path,
+    *,
+    repository_root: Path | None = None,
+) -> dict[str, object]:
+    """Load the strict, hash-pinned public benchmark protocol."""
+
+    root = (repository_root or _repository_root()).resolve(strict=True)
+    manifest_path = manifest_path.resolve(strict=True)
+    manifest_path.relative_to(root)
+    raw = _mapping(_load_json(manifest_path), "manifest")
+    _exact_keys(
+        raw,
+        {
+            "schema_version",
+            "benchmark_id",
+            "hash_algorithm",
+            "subject",
+            "scope",
+            "artifacts",
+            "commands",
+            "comparisons",
+        },
+        "manifest",
+    )
+    if raw.get("schema_version") != _SCHEMA_VERSION:
+        raise ValueError("public benchmark manifest schema_version is unsupported")
+    if raw.get("benchmark_id") != _BENCHMARK_ID:
+        raise ValueError("public benchmark manifest benchmark_id is unsupported")
+    if raw.get("hash_algorithm") != _HASH_ALGORITHM:
+        raise ValueError("public benchmark manifest hash_algorithm is unsupported")
+    subject = _mapping(raw.get("subject"), "manifest.subject")
+    _exact_keys(subject, {"name"}, "manifest.subject")
+    if subject.get("name") != "RepoLocus":
+        raise ValueError("public benchmark subject must be RepoLocus")
+    scope = _mapping(raw.get("scope"), "manifest.scope")
+    _exact_keys(
+        scope,
+        {"classification", "cross_repository_quality_claim", "note"},
+        "manifest.scope",
+    )
+    if scope.get("classification") != "smoke":
+        raise ValueError("RepoLocus public benchmark result must be classified as smoke")
+    if _boolean(
+        scope.get("cross_repository_quality_claim"),
+        "manifest.scope.cross_repository_quality_claim",
+    ):
+        raise ValueError("synthetic fixtures cannot support a cross-repository quality claim")
+    note = _string(scope.get("note"), "manifest.scope.note")
+    if "smoke" not in note.casefold():
+        raise ValueError("manifest.scope.note must clearly identify the result as smoke")
+    artifacts = _validate_artifacts(root, raw.get("artifacts"))
+    commands = _validate_commands(raw.get("commands"), artifacts)
+    comparisons = _validate_comparisons(raw.get("comparisons"))
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "benchmark_id": _BENCHMARK_ID,
+        "hash_algorithm": _HASH_ALGORITHM,
+        "subject": {"name": "RepoLocus"},
+        "scope": {
+            "classification": "smoke",
+            "cross_repository_quality_claim": False,
+            "note": note,
+        },
+        "artifacts": artifacts,
+        "commands": commands,
+        "comparisons": comparisons,
+    }
+
+
+def _pinned_evaluation_cases(
+    evaluation_manifest_path: Path,
+    evaluation_manifest: Mapping[str, object],
+    evaluation_module,  # type: ignore[no-untyped-def]
+) -> tuple[
+    list[Mapping[str, object]],
+    dict[str, Path],
+    dict[str, dict[str, int]],
+    dict[str, object],
+]:
+    """Load the exact qrel inventory without running retrieval against the fixtures."""
+
+    evaluation_root = evaluation_manifest_path.parent.resolve(strict=True)
+    raw_fixtures = _sequence(evaluation_manifest.get("fixtures"), "evaluation manifest fixtures")
+    review_artifacts, review_report, reviewed_no_answer_intents = (
+        evaluation_module._load_review_provenance(evaluation_root, evaluation_manifest)
+    )
+    cases: list[Mapping[str, object]] = []
+    fixture_truth: dict[str, dict[str, int]] = {}
+    fixture_roots: dict[str, Path] = {}
+    seen_fixture_ids: set[str] = set()
+    seen_roots: set[Path] = set()
+    seen_qrel_paths: set[Path] = set()
+    seen_tree_hashes: set[str] = set()
+    seen_qrel_hashes: set[str] = set()
+    for index, item in enumerate(raw_fixtures):
+        fixture = _mapping(item, f"evaluation manifest fixtures[{index}]")
+        fixture_id = _string(fixture.get("id"), f"evaluation fixture {index}.id")
+        if fixture_id in seen_fixture_ids:
+            raise ValueError(f"duplicate evaluation fixture id: {fixture_id}")
+        seen_fixture_ids.add(fixture_id)
+        revision = _string(fixture.get("revision"), f"{fixture_id}.revision")
+        _, fixture_root = _relative_directory(
+            evaluation_root, fixture.get("path"), f"{fixture_id}.path"
+        )
+        _, qrel_path = _relative_file(evaluation_root, fixture.get("qrels"), f"{fixture_id}.qrels")
+        resolved_root = fixture_root.resolve(strict=True)
+        resolved_qrels = qrel_path.resolve(strict=True)
+        if resolved_root in seen_roots or resolved_qrels in seen_qrel_paths:
+            raise ValueError("evaluation fixture roots and qrel paths must be unique")
+        seen_roots.add(resolved_root)
+        seen_qrel_paths.add(resolved_qrels)
+        fixture_roots[fixture_id] = resolved_root
+
+        expected_tree = _sha256(fixture.get("tree_sha256"), f"{fixture_id}.tree_sha256")
+        expected_qrels = _sha256(fixture.get("qrels_sha256"), f"{fixture_id}.qrels_sha256")
+        actual_tree = evaluation_module.fixture_tree_sha256(resolved_root)
+        actual_qrels = _raw_sha256_file(resolved_qrels)
+        if actual_tree != expected_tree:
+            raise ValueError(f"pinned evaluation fixture checksum mismatch: {fixture_id}")
+        if actual_qrels != expected_qrels:
+            raise ValueError(f"pinned evaluation qrel checksum mismatch: {fixture_id}")
+        if actual_tree in seen_tree_hashes or actual_qrels in seen_qrel_hashes:
+            raise ValueError("evaluation fixture tree and qrel hashes must be unique")
+        seen_tree_hashes.add(actual_tree)
+        seen_qrel_hashes.add(actual_qrels)
+
+        review = review_artifacts.pop(fixture_id, None)
+        if (
+            review is None
+            or review.get("fixture_revision") != revision
+            or review.get("tree_sha256") != actual_tree
+            or review.get("qrels_sha256") != actual_qrels
+        ):
+            raise ValueError(f"review provenance does not cover pinned qrels: {fixture_id}")
+        fixture_cases = evaluation_module._load_qrels(
+            resolved_qrels,
+            fixture=fixture_id,
+            revision=revision,
+        )
+        expected_count = _integer(
+            fixture.get("qrels_count"), f"{fixture_id}.qrels_count", minimum=1
+        )
+        if len(fixture_cases) != expected_count:
+            raise ValueError(f"pinned evaluation qrel count mismatch: {fixture_id}")
+        evaluation_module._validate_case_sources(resolved_root, fixture_cases)
+        fixture_truth[fixture_id] = {
+            "qrels": len(fixture_cases),
+            "must_not_return_qrels": sum(bool(case["must_not_return"]) for case in fixture_cases),
+        }
+        cases.extend(fixture_cases)
+    if review_artifacts:
+        raise ValueError("review provenance contains undeclared evaluation fixtures")
+    family_counts, families_by_type, fixtures_by_type = evaluation_module._case_family_report(
+        cases,
+        reviewed_no_answer_intents=reviewed_no_answer_intents,
+    )
+    for fixture_id, truth in fixture_truth.items():
+        truth["case_families"] = family_counts[fixture_id]
+    truth_summary = {
+        "qrels": len(cases),
+        "reviewed_qrels": len(cases),
+        "case_families": sum(family_counts.values()),
+        "case_families_by_query_type": dict(sorted(families_by_type.items())),
+        "query_type_fixture_counts": dict(sorted(fixtures_by_type.items())),
+        "query_types": sorted(families_by_type),
+        "runtime_intents": sorted(evaluation_module._RUNTIME_INTENTS),
+        "corpus_coverage": evaluation_module._corpus_coverage(cases),
+        "answerable_qrels": sum(bool(case["answerable"]) for case in cases),
+        "no_answer_qrels": sum(not bool(case["answerable"]) for case in cases),
+        "citation_qrels": sum(bool(case["relevant"]) for case in cases),
+        "must_not_return_qrels": sum(bool(case["must_not_return"]) for case in cases),
+    }
+    return (
+        cases,
+        fixture_roots,
+        fixture_truth,
+        {
+            "review": review_report,
+            "summary": truth_summary,
+        },
+    )
+
+
+def _evaluation_fixtures(
+    evaluation_report: Mapping[str, object],
+    evaluation_manifest: Mapping[str, object],
+    fixture_truth: Mapping[str, Mapping[str, int]],
+) -> list[dict[str, object]]:
+    manifest_fixtures = _sequence(
+        evaluation_manifest.get("fixtures"), "evaluation manifest fixtures"
+    )
+    expected: dict[str, Mapping[str, object]] = {}
+    for index, item in enumerate(manifest_fixtures):
+        fixture = _mapping(item, f"evaluation manifest fixtures[{index}]")
+        fixture_id = _string(fixture.get("id"), f"evaluation manifest fixtures[{index}].id")
+        if fixture_id in expected:
+            raise ValueError(f"duplicate evaluation fixture id: {fixture_id}")
+        expected[fixture_id] = fixture
+    report_fixtures = _sequence(evaluation_report.get("fixtures"), "evaluation report fixtures")
+    if len(report_fixtures) != len(expected):
+        raise ValueError("evaluation report fixture count does not match its manifest")
+    output: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(report_fixtures):
+        fixture = _mapping(item, f"evaluation report fixtures[{index}]")
+        fixture_id = _string(fixture.get("id"), f"evaluation report fixtures[{index}].id")
+        if fixture_id in seen or fixture_id not in expected:
+            raise ValueError(f"unexpected or duplicate evaluation fixture: {fixture_id}")
+        seen.add(fixture_id)
+        pinned = expected[fixture_id]
+        provenance_fields = (
+            "source",
+            "license",
+            "revision",
+            "tree_sha256",
+            "qrels_sha256",
+        )
+        for field in provenance_fields:
+            if fixture.get(field) != pinned.get(field):
+                raise ValueError(f"evaluation fixture provenance drifted: {fixture_id}.{field}")
+        if fixture.get("qrels") != pinned.get("qrels_count"):
+            raise ValueError(f"evaluation fixture qrel count drifted: {fixture_id}")
+        truth = fixture_truth[fixture_id]
+        for field in ("qrels", "case_families", "must_not_return_qrels"):
+            if fixture.get(field) != truth[field]:
+                raise ValueError(f"evaluation fixture truth drifted: {fixture_id}.{field}")
+        output.append(
+            {
+                "id": fixture_id,
+                "fixture_path": _string(pinned.get("path"), f"{fixture_id}.path"),
+                "qrels_path": _string(pinned.get("qrels"), f"{fixture_id}.qrels"),
+                "source": _string(fixture.get("source"), f"{fixture_id}.source"),
+                "license": _string(fixture.get("license"), f"{fixture_id}.license"),
+                "revision": _string(fixture.get("revision"), f"{fixture_id}.revision"),
+                "tree_sha256": _sha256(fixture.get("tree_sha256"), f"{fixture_id}.tree_sha256"),
+                "qrels_sha256": _sha256(fixture.get("qrels_sha256"), f"{fixture_id}.qrels_sha256"),
+                "qrels": truth["qrels"],
+                "case_families": truth["case_families"],
+                "must_not_return_qrels": truth["must_not_return_qrels"],
+            }
+        )
+    return sorted(output, key=lambda fixture: str(fixture["id"]))
+
+
+def _quality_summary(evaluation_report: Mapping[str, object]) -> dict[str, object]:
+    metrics = _mapping(evaluation_report.get("metrics"), "evaluation report metrics")
+    rates = {
+        name: _number(metrics.get(name), f"evaluation metrics.{name}", rate=True)
+        for name in _QUALITY_RATES
+    }
+    bootstrap = _mapping(evaluation_report.get("bootstrap"), "evaluation report bootstrap")
+    intervals = _mapping(bootstrap.get("intervals"), "evaluation report bootstrap.intervals")
+    selected_intervals: dict[str, list[int | float]] = {}
+    for metric in _BOOTSTRAP_RATES:
+        interval = _sequence(intervals.get(metric), f"bootstrap interval {metric}")
+        if len(interval) != 2:
+            raise ValueError(f"bootstrap interval {metric} must have two bounds")
+        lower = _number(interval[0], f"bootstrap interval {metric}[0]", rate=True)
+        upper = _number(interval[1], f"bootstrap interval {metric}[1]", rate=True)
+        if lower > upper:
+            raise ValueError(f"bootstrap interval {metric} is reversed")
+        selected_intervals[metric] = [lower, upper]
+    gate = _mapping(evaluation_report.get("gate"), "evaluation report gate")
+    return {
+        "fixture_count": _integer(
+            evaluation_report.get("fixture_count"), "evaluation fixture_count", minimum=1
+        ),
+        "qrels": _integer(evaluation_report.get("qrels"), "evaluation qrels", minimum=1),
+        "case_families": _integer(
+            evaluation_report.get("case_families"), "evaluation case_families", minimum=1
+        ),
+        "answerable_qrels": _integer(
+            evaluation_report.get("answerable_qrels"), "evaluation answerable_qrels", minimum=1
+        ),
+        "no_answer_qrels": _integer(
+            evaluation_report.get("no_answer_qrels"), "evaluation no_answer_qrels", minimum=1
+        ),
+        "citation_qrels": _integer(
+            evaluation_report.get("citation_qrels"), "evaluation citation_qrels", minimum=1
+        ),
+        "must_not_return_qrels": _integer(
+            evaluation_report.get("must_not_return_qrels"),
+            "evaluation must_not_return_qrels",
+        ),
+        "accuracy": {
+            "hit_rate": rates["any_expected_path_rate"],
+            "macro_recall_at_k": rates["macro_recall_at_k"],
+            "mrr": rates["mrr"],
+            "citation_recall": rates["citation_recall"],
+        },
+        "no_answer": {
+            "accuracy": rates["no_answer_accuracy"],
+            "precision": rates["no_answer_precision"],
+            "recall": rates["no_answer_recall"],
+            "f1": rates["no_answer_f1"],
+        },
+        "safety": {
+            "duplicate_evidence_rate": rates["duplicate_evidence_rate"],
+            "must_not_return_violation_rate": rates["must_not_return_violation_rate"],
+        },
+        "bootstrap": {
+            "confidence": _number(
+                bootstrap.get("confidence"), "evaluation bootstrap.confidence", rate=True
+            ),
+            "samples": _integer(
+                bootstrap.get("samples"), "evaluation bootstrap.samples", minimum=1
+            ),
+            "cluster_unit": _string(
+                bootstrap.get("cluster_unit"), "evaluation bootstrap.cluster_unit"
+            ),
+            "intervals": selected_intervals,
+        },
+        "gate_passed": _boolean(gate.get("passed"), "evaluation gate.passed"),
+    }
+
+
+def _measurement(value: object, operation: str) -> dict[str, int | float]:
+    measurement = _mapping(value, f"performance operation {operation}")
+    if measurement.get("name") != operation:
+        raise ValueError(f"performance operation {operation} has a mismatched name")
+    output: dict[str, int | float] = {}
+    for field in _MEASUREMENT_FIELDS:
+        raw = measurement.get(field)
+        if field in _INTEGER_MEASUREMENTS:
+            output[field] = _integer(raw, f"performance {operation}.{field}")
+        else:
+            output[field] = _number(raw, f"performance {operation}.{field}")
+    return output
+
+
+def _performance_summary(performance_report: Mapping[str, object]) -> dict[str, object]:
+    operations = _mapping(performance_report.get("operations"), "performance report operations")
+    if set(operations) != set(_OPERATIONS):
+        raise ValueError(f"performance operations must be exactly {list(_OPERATIONS)}")
+    validated = {
+        operation: _measurement(operations[operation], operation) for operation in _OPERATIONS
+    }
+    scan = validated["scan"]
+    gate = _mapping(performance_report.get("gate"), "performance report gate")
+    return {
+        "environment": {
+            "python": _string(performance_report.get("python"), "performance python"),
+            "platform": _string(performance_report.get("platform"), "performance platform"),
+            "machine": _string(performance_report.get("machine"), "performance machine"),
+            "cpu_count": _integer(
+                performance_report.get("cpu_count"), "performance cpu_count", minimum=1
+            ),
+        },
+        "fixture": {
+            "manifest": _string(performance_report.get("manifest"), "performance manifest"),
+            "files": _integer(performance_report.get("files"), "performance files", minimum=1),
+            "source_bytes": _integer(
+                performance_report.get("source_bytes"),
+                "performance source_bytes",
+                minimum=1,
+            ),
+            "symbols": _integer(
+                performance_report.get("symbols"), "performance symbols", minimum=1
+            ),
+            "dependencies": _integer(
+                performance_report.get("dependencies"),
+                "performance dependencies",
+                minimum=1,
+            ),
+        },
+        "query_latency_seconds": {
+            operation: validated[operation]["wall_seconds"] for operation in _QUERY_OPERATIONS
+        },
+        "peak_rss_bytes": {
+            operation: validated[operation]["peak_rss_bytes"] for operation in _OPERATIONS
+        },
+        "index_cost": {field: scan[field] for field in _MEASUREMENT_FIELDS},
+        "operations": validated,
+        "gate_passed": _boolean(gate.get("passed"), "performance gate.passed"),
+    }
+
+
+def build_public_report(
+    manifest_path: Path,
+    evaluation_report_path: Path,
+    performance_report_path: Path,
+    *,
+    repository_root: Path | None = None,
+) -> dict[str, object]:
+    """Validate pinned inputs and build the deterministic public summary."""
+
+    root = (repository_root or _repository_root()).resolve(strict=True)
+    manifest_path = manifest_path.resolve(strict=True)
+    manifest = load_public_manifest(manifest_path, repository_root=root)
+    artifacts = _mapping(manifest["artifacts"], "manifest artifacts")
+    evaluation_manifest_artifact = _mapping(
+        artifacts["evaluation_manifest"], "evaluation manifest artifact"
+    )
+    performance_manifest_artifact = _mapping(
+        artifacts["performance_manifest"], "performance manifest artifact"
+    )
+    performance_runner_artifact = _mapping(
+        artifacts["performance_runner"], "performance runner artifact"
+    )
+    evaluation_runner_artifact = _mapping(
+        artifacts["evaluation_runner"], "evaluation runner artifact"
+    )
+    evaluation_metrics_runner_artifact = _mapping(
+        artifacts["evaluation_metrics_runner"], "evaluation metrics runner artifact"
+    )
+    evaluation_manifest_path = root / _string(
+        evaluation_manifest_artifact["path"], "evaluation manifest path"
+    )
+    evaluation_manifest = _mapping(_load_json(evaluation_manifest_path), "evaluation manifest")
+    evaluation_report_path = evaluation_report_path.resolve(strict=True)
+    performance_report_path = performance_report_path.resolve(strict=True)
+    evaluation_report = _mapping(_load_json(evaluation_report_path), "evaluation report")
+    performance_report = _mapping(_load_json(performance_report_path), "performance report")
+    if evaluation_report.get("manifest") != Path(evaluation_manifest_path).name:
+        raise ValueError("evaluation report was produced from a different manifest")
+    if (
+        performance_report.get("manifest")
+        != Path(_string(performance_manifest_artifact["path"], "performance manifest path")).name
+    ):
+        raise ValueError("performance report was produced from a different manifest")
+    if performance_report.get("benchmark") != "v0.2-indexed-workflows-v1":
+        raise ValueError("performance report benchmark identity is unsupported")
+    if performance_report.get("benchmark_script_sha256") != performance_runner_artifact["sha256"]:
+        raise ValueError("performance report runner hash does not match the pinned protocol")
+    if evaluation_report.get("evaluation_script_sha256") != evaluation_runner_artifact["sha256"]:
+        raise ValueError("evaluation report runner hash does not match the pinned protocol")
+    if (
+        evaluation_report.get("evaluation_metrics_script_sha256")
+        != evaluation_metrics_runner_artifact["sha256"]
+    ):
+        raise ValueError("evaluation report metrics runner hash does not match the pinned protocol")
+    for field in ("repolocus_version", "implementation_sha256"):
+        if evaluation_report.get(field) != performance_report.get(field):
+            raise ValueError(f"evaluation and performance reports use different {field}")
+
+    retrieval_module = _load_protocol_module(
+        root
+        / _string(evaluation_metrics_runner_artifact["path"], "evaluation metrics runner path"),
+        "repolocus_public_retrieval_protocol",
+    )
+    evaluation_runner_path = root / _string(
+        evaluation_runner_artifact["path"], "evaluation runner path"
+    )
+    evaluation_module = _load_protocol_module(
+        evaluation_runner_path,
+        "repolocus_public_evaluation_protocol",
+        injected_modules={"evaluate_retrieval": retrieval_module},
+    )
+    cases, fixture_roots, fixture_truth, pinned_truth = _pinned_evaluation_cases(
+        evaluation_manifest_path,
+        evaluation_manifest,
+        evaluation_module,
+    )
+    top_k = _integer(evaluation_report.get("top_k"), "evaluation report top_k", minimum=1)
+    if top_k != evaluation_module.default_limit():
+        raise ValueError("evaluation report top_k does not match the pinned public protocol")
+    raw_outcomes = _sequence(evaluation_report.get("outcomes"), "evaluation report outcomes")
+    outcomes = retrieval_module.validate_outcomes_against_qrels(
+        cases,
+        raw_outcomes,
+        limit=top_k,
+        fixture_roots=fixture_roots,
+    )
+    truth_summary = _mapping(pinned_truth["summary"], "pinned evaluation truth summary")
+    for field, expected in truth_summary.items():
+        if not _same_json_value(evaluation_report.get(field), expected):
+            raise ValueError(f"evaluation report {field} does not match the pinned qrels")
+    recomputed_metrics = retrieval_module.summarize_outcomes(outcomes)
+    if not _same_json_value(evaluation_report.get("metrics"), recomputed_metrics):
+        raise ValueError("evaluation metrics do not match the serialized outcomes")
+    recomputed_bootstrap = evaluation_module._bootstrap_report(outcomes)
+    if not _same_json_value(evaluation_report.get("bootstrap"), recomputed_bootstrap):
+        raise ValueError("evaluation bootstrap does not match the serialized outcomes")
+    recomputed_evaluation_gate = evaluation_module._gate_report(
+        evaluation_report,
+        evaluation_module.default_thresholds(),
+    )
+    if not _same_json_value(evaluation_report.get("gate"), recomputed_evaluation_gate):
+        raise ValueError("evaluation gate does not match recomputed pinned thresholds")
+
+    performance_manifest_path = root / _string(
+        performance_manifest_artifact["path"], "performance manifest path"
+    )
+    performance_manifest = _mapping(_load_json(performance_manifest_path), "performance manifest")
+    performance_module = _load_protocol_module(
+        root / _string(performance_runner_artifact["path"], "performance runner path"),
+        "repolocus_public_performance_protocol",
+    )
+    if (
+        performance_report.get("implementation_sha256")
+        != performance_module._implementation_sha256()
+    ):
+        raise ValueError("benchmark reports do not match the current pinned implementation")
+    if performance_report.get("repolocus_version") != performance_module.__version__:
+        raise ValueError("benchmark reports do not match the current RepoLocus version")
+    raw_operations = _mapping(performance_report.get("operations"), "performance operations")
+    raw_thresholds = _mapping(performance_manifest.get("thresholds"), "performance thresholds")
+    recomputed_passed, recomputed_violations = performance_module._gate(
+        raw_operations, raw_thresholds
+    )
+    recomputed_performance_gate = {
+        "passed": recomputed_passed,
+        "violations": recomputed_violations,
+    }
+    if not _same_json_value(performance_report.get("gate"), recomputed_performance_gate):
+        raise ValueError("performance gate does not match recomputed pinned thresholds")
+    fixtures = _evaluation_fixtures(evaluation_report, evaluation_manifest, fixture_truth)
+    if evaluation_report.get("fixture_count") != len(fixtures):
+        raise ValueError("evaluation fixture_count does not match fixture provenance")
+    if evaluation_report.get("qrels") != sum(int(fixture["qrels"]) for fixture in fixtures):
+        raise ValueError("evaluation qrel total does not match fixture provenance")
+    reported_review = _mapping(
+        evaluation_report.get("review_provenance"), "evaluation report review_provenance"
+    )
+    if not _same_json_value(reported_review, pinned_truth["review"]):
+        raise ValueError("evaluation review provenance does not match its pinned manifest")
+    quality = _quality_summary(evaluation_report)
+    performance = _performance_summary(performance_report)
+    if not quality["gate_passed"] or not performance["gate_passed"]:
+        raise ValueError("public benchmark inputs must pass both pinned gates")
+    scope = _mapping(manifest["scope"], "manifest scope")
+    relative_manifest = manifest_path.relative_to(root).as_posix()
+    report = {
+        "schema_version": _SCHEMA_VERSION,
+        "benchmark_id": _BENCHMARK_ID,
+        "subject": {
+            "name": "RepoLocus",
+            "version": _string(
+                performance_report.get("repolocus_version"), "performance repolocus_version"
+            ),
+            "implementation_sha256": _sha256(
+                performance_report.get("implementation_sha256"),
+                "performance implementation_sha256",
+            ),
+            "result_classification": "smoke",
+            "cross_repository_quality_claim": False,
+            "note": scope["note"],
+        },
+        "protocol": {
+            "manifest": relative_manifest,
+            "manifest_sha256": _sha256_file(manifest_path),
+            "hash_algorithm": _HASH_ALGORITHM,
+            "evaluation_manifest": evaluation_manifest_artifact["path"],
+            "evaluation_manifest_sha256": evaluation_manifest_artifact["sha256"],
+            "evaluation_runner": evaluation_runner_artifact["path"],
+            "evaluation_runner_sha256": evaluation_runner_artifact["sha256"],
+            "evaluation_metrics_runner": evaluation_metrics_runner_artifact["path"],
+            "evaluation_metrics_runner_sha256": evaluation_metrics_runner_artifact["sha256"],
+            "performance_manifest": performance_manifest_artifact["path"],
+            "performance_manifest_sha256": performance_manifest_artifact["sha256"],
+            "reproduction_commands": list(manifest["commands"]),
+        },
+        "fixtures": fixtures,
+        "quality": quality,
+        "performance": performance,
+        "comparisons": list(manifest["comparisons"]),
+        "validation": {
+            "evaluation_report_sha256": _sha256_file(evaluation_report_path),
+            "performance_report_sha256": _sha256_file(performance_report_path),
+            "evaluation_gate_passed": quality["gate_passed"],
+            "performance_gate_passed": performance["gate_passed"],
+        },
+    }
+    validate_public_report(report)
+    return report
+
+
+def validate_public_report(value: object) -> None:
+    """Validate the stable public-report schema without an optional dependency."""
+
+    report = _mapping(value, "public report")
+    _exact_keys(
+        report,
+        {
+            "schema_version",
+            "benchmark_id",
+            "subject",
+            "protocol",
+            "fixtures",
+            "quality",
+            "performance",
+            "comparisons",
+            "validation",
+        },
+        "public report",
+    )
+    if (
+        report.get("schema_version") != _SCHEMA_VERSION
+        or report.get("benchmark_id") != _BENCHMARK_ID
+    ):
+        raise ValueError("public report schema identity is unsupported")
+    subject = _mapping(report.get("subject"), "public report subject")
+    _exact_keys(
+        subject,
+        {
+            "name",
+            "version",
+            "implementation_sha256",
+            "result_classification",
+            "cross_repository_quality_claim",
+            "note",
+        },
+        "public report subject",
+    )
+    if (
+        subject.get("name") != "RepoLocus"
+        or subject.get("result_classification") != "smoke"
+        or subject.get("cross_repository_quality_claim") is not False
+    ):
+        raise ValueError("public report must describe RepoLocus smoke results only")
+    _string(subject.get("version"), "public report subject.version")
+    _sha256(subject.get("implementation_sha256"), "public report subject.implementation_sha256")
+    note = _string(subject.get("note"), "public report subject.note")
+    if "smoke" not in note.casefold():
+        raise ValueError("public report subject.note must identify the result as smoke")
+
+    protocol = _mapping(report.get("protocol"), "public report protocol")
+    _exact_keys(
+        protocol,
+        {
+            "manifest",
+            "manifest_sha256",
+            "hash_algorithm",
+            "evaluation_manifest",
+            "evaluation_manifest_sha256",
+            "evaluation_runner",
+            "evaluation_runner_sha256",
+            "evaluation_metrics_runner",
+            "evaluation_metrics_runner_sha256",
+            "performance_manifest",
+            "performance_manifest_sha256",
+            "reproduction_commands",
+        },
+        "public report protocol",
+    )
+    for field in (
+        "manifest",
+        "evaluation_manifest",
+        "evaluation_runner",
+        "evaluation_metrics_runner",
+        "performance_manifest",
+    ):
+        _string(protocol.get(field), f"public report protocol.{field}")
+    if protocol.get("evaluation_runner") != "scripts/evaluate_external_repositories.py":
+        raise ValueError("public report evaluation runner is unsupported")
+    if protocol.get("evaluation_metrics_runner") != "scripts/evaluate_retrieval.py":
+        raise ValueError("public report evaluation metrics runner is unsupported")
+    for field in (
+        "manifest_sha256",
+        "evaluation_manifest_sha256",
+        "evaluation_runner_sha256",
+        "evaluation_metrics_runner_sha256",
+        "performance_manifest_sha256",
+    ):
+        _sha256(protocol.get(field), f"public report protocol.{field}")
+    if protocol.get("hash_algorithm") != _HASH_ALGORITHM:
+        raise ValueError("public report hash_algorithm is unsupported")
+    commands = _sequence(
+        protocol.get("reproduction_commands"),
+        "public report protocol.reproduction_commands",
+    )
+    if len(commands) != len(_COMMAND_IDS):
+        raise ValueError("public report must include all four reproduction commands")
+    expected_commands = _expected_commands(
+        {
+            "evaluation_runner": {"path": "scripts/evaluate_external_repositories.py"},
+            "performance_runner": {"path": "benchmarks/benchmark_v020.py"},
+            "performance_manifest": {"path": "benchmarks/v0.2-gates.json"},
+            "report_runner": {"path": "scripts/public_benchmark_report.py"},
+        }
+    )
+    for index, command_id in enumerate(_COMMAND_IDS):
+        command = _mapping(commands[index], f"public report command {index}")
+        _exact_keys(command, {"id", "argv"}, f"public report command {index}")
+        if command.get("id") != command_id:
+            raise ValueError(f"public report command {index} must be {command_id}")
+        argv = _sequence(command.get("argv"), f"public report command {command_id}.argv")
+        validated_argv = [
+            _string(argument, f"public report command {command_id}.argv[{position}]")
+            for position, argument in enumerate(argv)
+        ]
+        if validated_argv != expected_commands[command_id]:
+            raise ValueError(f"public report reproduction command {command_id} drifted")
+
+    fixtures = _sequence(report.get("fixtures"), "public report fixtures")
+    if not fixtures:
+        raise ValueError("public report fixtures cannot be empty")
+    fixture_ids: set[str] = set()
+    qrel_total = 0
+    for index, item in enumerate(fixtures):
+        fixture = _mapping(item, f"public report fixtures[{index}]")
+        _exact_keys(
+            fixture,
+            {
+                "id",
+                "fixture_path",
+                "qrels_path",
+                "source",
+                "license",
+                "revision",
+                "tree_sha256",
+                "qrels_sha256",
+                "qrels",
+                "case_families",
+                "must_not_return_qrels",
+            },
+            f"public report fixtures[{index}]",
+        )
+        fixture_id = _string(fixture.get("id"), f"public report fixtures[{index}].id")
+        if fixture_id in fixture_ids:
+            raise ValueError(f"duplicate public report fixture id: {fixture_id}")
+        fixture_ids.add(fixture_id)
+        for field in (
+            "fixture_path",
+            "qrels_path",
+            "source",
+            "license",
+            "revision",
+        ):
+            _string(fixture.get(field), f"public report fixture {fixture_id}.{field}")
+        _sha256(fixture.get("tree_sha256"), f"public report fixture {fixture_id}.tree_sha256")
+        _sha256(
+            fixture.get("qrels_sha256"),
+            f"public report fixture {fixture_id}.qrels_sha256",
+        )
+        qrel_total += _integer(
+            fixture.get("qrels"), f"public report fixture {fixture_id}.qrels", minimum=1
+        )
+        _integer(
+            fixture.get("case_families"),
+            f"public report fixture {fixture_id}.case_families",
+            minimum=1,
+        )
+        _integer(
+            fixture.get("must_not_return_qrels"),
+            f"public report fixture {fixture_id}.must_not_return_qrels",
+        )
+
+    quality = _mapping(report.get("quality"), "public report quality")
+    _exact_keys(
+        quality,
+        {
+            "fixture_count",
+            "qrels",
+            "case_families",
+            "answerable_qrels",
+            "no_answer_qrels",
+            "citation_qrels",
+            "must_not_return_qrels",
+            "accuracy",
+            "no_answer",
+            "safety",
+            "bootstrap",
+            "gate_passed",
+        },
+        "public report quality",
+    )
+    fixture_count = _integer(
+        quality.get("fixture_count"), "public report quality.fixture_count", minimum=1
+    )
+    if fixture_count != len(fixtures):
+        raise ValueError("public report fixture_count does not match fixtures")
+    quality_qrels = _integer(quality.get("qrels"), "public report quality.qrels", minimum=1)
+    if quality_qrels != qrel_total:
+        raise ValueError("public report qrel total does not match fixtures")
+    for field in (
+        "case_families",
+        "answerable_qrels",
+        "no_answer_qrels",
+        "citation_qrels",
+    ):
+        _integer(quality.get(field), f"public report quality.{field}", minimum=1)
+    _integer(
+        quality.get("must_not_return_qrels"),
+        "public report quality.must_not_return_qrels",
+    )
+    if quality.get("answerable_qrels") + quality.get("no_answer_qrels") != quality_qrels:
+        raise ValueError("public report answerable and no-answer qrels do not sum to qrels")
+    rate_groups = {
+        "accuracy": ("hit_rate", "macro_recall_at_k", "mrr", "citation_recall"),
+        "no_answer": ("accuracy", "precision", "recall", "f1"),
+        "safety": ("duplicate_evidence_rate", "must_not_return_violation_rate"),
+    }
+    for group_name, fields in rate_groups.items():
+        group = _mapping(quality.get(group_name), f"public report quality.{group_name}")
+        _exact_keys(group, set(fields), f"public report quality.{group_name}")
+        for field in fields:
+            _number(
+                group.get(field),
+                f"public report quality.{group_name}.{field}",
+                rate=True,
+            )
+    bootstrap = _mapping(quality.get("bootstrap"), "public report quality.bootstrap")
+    _exact_keys(
+        bootstrap,
+        {"confidence", "samples", "cluster_unit", "intervals"},
+        "public report quality.bootstrap",
+    )
+    _number(
+        bootstrap.get("confidence"),
+        "public report quality.bootstrap.confidence",
+        rate=True,
+    )
+    _integer(
+        bootstrap.get("samples"),
+        "public report quality.bootstrap.samples",
+        minimum=1,
+    )
+    _string(
+        bootstrap.get("cluster_unit"),
+        "public report quality.bootstrap.cluster_unit",
+    )
+    intervals = _mapping(bootstrap.get("intervals"), "public report quality.bootstrap.intervals")
+    _exact_keys(intervals, set(_BOOTSTRAP_RATES), "public report quality.bootstrap.intervals")
+    for metric in _BOOTSTRAP_RATES:
+        interval = _sequence(
+            intervals.get(metric),
+            f"public report quality.bootstrap.intervals.{metric}",
+        )
+        if len(interval) != 2:
+            raise ValueError(f"public report bootstrap interval {metric} needs two bounds")
+        lower = _number(interval[0], f"public report bootstrap {metric}[0]", rate=True)
+        upper = _number(interval[1], f"public report bootstrap {metric}[1]", rate=True)
+        if lower > upper:
+            raise ValueError(f"public report bootstrap interval {metric} is reversed")
+    quality_gate = _boolean(quality.get("gate_passed"), "public report quality.gate_passed")
+
+    performance = _mapping(report.get("performance"), "public report performance")
+    _exact_keys(
+        performance,
+        {
+            "environment",
+            "fixture",
+            "query_latency_seconds",
+            "peak_rss_bytes",
+            "index_cost",
+            "operations",
+            "gate_passed",
+        },
+        "public report performance",
+    )
+    environment = _mapping(performance.get("environment"), "public report performance.environment")
+    _exact_keys(
+        environment,
+        {"python", "platform", "machine", "cpu_count"},
+        "public report performance.environment",
+    )
+    for field in ("python", "platform", "machine"):
+        _string(environment.get(field), f"public report performance.environment.{field}")
+    _integer(
+        environment.get("cpu_count"),
+        "public report performance.environment.cpu_count",
+        minimum=1,
+    )
+    performance_fixture = _mapping(performance.get("fixture"), "public report performance.fixture")
+    _exact_keys(
+        performance_fixture,
+        {"manifest", "files", "source_bytes", "symbols", "dependencies"},
+        "public report performance.fixture",
+    )
+    _string(
+        performance_fixture.get("manifest"),
+        "public report performance.fixture.manifest",
+    )
+    for field in ("files", "source_bytes", "symbols", "dependencies"):
+        _integer(
+            performance_fixture.get(field),
+            f"public report performance.fixture.{field}",
+            minimum=1,
+        )
+    query_latency = _mapping(
+        performance.get("query_latency_seconds"),
+        "public report performance.query_latency_seconds",
+    )
+    _exact_keys(
+        query_latency,
+        set(_QUERY_OPERATIONS),
+        "public report performance.query_latency_seconds",
+    )
+    for operation in _QUERY_OPERATIONS:
+        _number(
+            query_latency.get(operation),
+            f"public report performance.query_latency_seconds.{operation}",
+        )
+    peak_rss = _mapping(
+        performance.get("peak_rss_bytes"), "public report performance.peak_rss_bytes"
+    )
+    _exact_keys(peak_rss, set(_OPERATIONS), "public report performance.peak_rss_bytes")
+    for operation in _OPERATIONS:
+        _integer(
+            peak_rss.get(operation),
+            f"public report performance.peak_rss_bytes.{operation}",
+        )
+    operations = _mapping(performance.get("operations"), "public report performance.operations")
+    _exact_keys(operations, set(_OPERATIONS), "public report performance.operations")
+    validated_operations: dict[str, dict[str, int | float]] = {}
+    for operation in _OPERATIONS:
+        measurement = _mapping(
+            operations.get(operation),
+            f"public report performance.operations.{operation}",
+        )
+        _exact_keys(
+            measurement,
+            set(_MEASUREMENT_FIELDS),
+            f"public report performance.operations.{operation}",
+        )
+        validated_measurement: dict[str, int | float] = {}
+        for field in _MEASUREMENT_FIELDS:
+            if field in _INTEGER_MEASUREMENTS:
+                validated_measurement[field] = _integer(
+                    measurement.get(field),
+                    f"public report performance.operations.{operation}.{field}",
+                )
+            else:
+                validated_measurement[field] = _number(
+                    measurement.get(field),
+                    f"public report performance.operations.{operation}.{field}",
+                )
+        validated_operations[operation] = validated_measurement
+    index_cost = _mapping(performance.get("index_cost"), "public report performance.index_cost")
+    _exact_keys(index_cost, set(_MEASUREMENT_FIELDS), "public report performance.index_cost")
+    if dict(index_cost) != validated_operations["scan"]:
+        raise ValueError("public report index_cost must equal the scan operation")
+    for operation in _QUERY_OPERATIONS:
+        if query_latency.get(operation) != validated_operations[operation]["wall_seconds"]:
+            raise ValueError(f"public report query latency drifted for {operation}")
+    for operation in _OPERATIONS:
+        if peak_rss.get(operation) != validated_operations[operation]["peak_rss_bytes"]:
+            raise ValueError(f"public report peak RSS drifted for {operation}")
+    performance_gate = _boolean(
+        performance.get("gate_passed"), "public report performance.gate_passed"
+    )
+
+    _validate_comparisons(report.get("comparisons"))
+    validation = _mapping(report.get("validation"), "public report validation")
+    _exact_keys(
+        validation,
+        {
+            "evaluation_report_sha256",
+            "performance_report_sha256",
+            "evaluation_gate_passed",
+            "performance_gate_passed",
+        },
+        "public report validation",
+    )
+    _sha256(validation.get("evaluation_report_sha256"), "evaluation report digest")
+    _sha256(validation.get("performance_report_sha256"), "performance report digest")
+    if (
+        _boolean(validation.get("evaluation_gate_passed"), "evaluation gate verdict")
+        != quality_gate
+    ):
+        raise ValueError("public report evaluation gate verdict is inconsistent")
+    if (
+        _boolean(validation.get("performance_gate_passed"), "performance gate verdict")
+        != performance_gate
+    ):
+        raise ValueError("public report performance gate verdict is inconsistent")
+
+
+def canonical_json(report: Mapping[str, object]) -> str:
+    validate_public_report(report)
+    return json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True, allow_nan=False) + "\n"
+
+
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("|", "\\|").replace("\r", " ").replace("\n", " ")
+
+
+def _format_rate(value: object) -> str:
+    return f"{float(value):.6f}"
+
+
+def _format_seconds(value: object) -> str:
+    return f"{float(value):.6f}"
+
+
+def render_markdown(report: Mapping[str, object]) -> str:
+    """Render the public report with stable headings, ordering, and precision."""
+
+    validate_public_report(report)
+    subject = _mapping(report["subject"], "subject")
+    protocol = _mapping(report["protocol"], "protocol")
+    quality = _mapping(report["quality"], "quality")
+    accuracy = _mapping(quality["accuracy"], "quality.accuracy")
+    no_answer = _mapping(quality["no_answer"], "quality.no_answer")
+    safety = _mapping(quality["safety"], "quality.safety")
+    performance = _mapping(report["performance"], "performance")
+    environment = _mapping(performance["environment"], "performance.environment")
+    fixture = _mapping(performance["fixture"], "performance.fixture")
+    query_latency = _mapping(
+        performance["query_latency_seconds"], "performance.query_latency_seconds"
+    )
+    peak_rss = _mapping(performance["peak_rss_bytes"], "performance.peak_rss_bytes")
+    index_cost = _mapping(performance["index_cost"], "performance.index_cost")
+    lines = [
+        "# RepoLocus public benchmark report",
+        "",
+        "> **SMOKE ONLY.** " + _markdown_cell(subject["note"]),
+        "> This report makes no cross-repository quality claim.",
+        "",
+        "## Subject and protocol",
+        "",
+        f"- RepoLocus version: `{_markdown_cell(subject['version'])}`",
+        f"- Implementation SHA-256: `{_markdown_cell(subject['implementation_sha256'])}`",
+        f"- Protocol manifest: `{_markdown_cell(protocol['manifest'])}`",
+        f"- Protocol manifest SHA-256: `{_markdown_cell(protocol['manifest_sha256'])}`",
+        f"- Hash algorithm: `{_markdown_cell(protocol['hash_algorithm'])}`",
+        "",
+        "## Fixture and qrel provenance",
+        "",
+        "| Fixture | Revision | License | Source | Fixture SHA-256 | Qrels SHA-256 | Qrels |",
+        "|---|---|---|---|---|---|---:|",
+    ]
+    for item in _sequence(report["fixtures"], "fixtures"):
+        provenance = _mapping(item, "fixture")
+        lines.append(
+            "| "
+            + " | ".join(
+                _markdown_cell(provenance[field])
+                for field in (
+                    "id",
+                    "revision",
+                    "license",
+                    "source",
+                    "tree_sha256",
+                    "qrels_sha256",
+                    "qrels",
+                )
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Quality smoke metrics",
+            "",
+            "| Metric | Value |",
+            "|---|---:|",
+            f"| Reviewed qrels | {quality['qrels']} |",
+            f"| Answerable qrels | {quality['answerable_qrels']} |",
+            f"| No-answer qrels | {quality['no_answer_qrels']} |",
+            f"| Hit rate | {_format_rate(accuracy['hit_rate'])} |",
+            f"| Macro recall@k | {_format_rate(accuracy['macro_recall_at_k'])} |",
+            f"| MRR | {_format_rate(accuracy['mrr'])} |",
+            f"| Citation recall | {_format_rate(accuracy['citation_recall'])} |",
+            f"| No-answer accuracy | {_format_rate(no_answer['accuracy'])} |",
+            f"| No-answer precision | {_format_rate(no_answer['precision'])} |",
+            f"| No-answer recall | {_format_rate(no_answer['recall'])} |",
+            f"| No-answer F1 | {_format_rate(no_answer['f1'])} |",
+            f"| Duplicate evidence rate | {_format_rate(safety['duplicate_evidence_rate'])} |",
+            "| Must-not-return violation rate | "
+            f"{_format_rate(safety['must_not_return_violation_rate'])} |",
+            f"| Evaluation gate passed | `{str(quality['gate_passed']).lower()}` |",
+            "",
+            "## Resource and latency smoke metrics",
+            "",
+            f"Performance fixture: `{_markdown_cell(fixture['manifest'])}` with "
+            f"{fixture['files']} files, {fixture['symbols']} symbols, "
+            f"{fixture['dependencies']} dependencies, and {fixture['source_bytes']} source bytes.",
+            "",
+            "Environment: "
+            f"Python `{_markdown_cell(environment['python'])}`, "
+            f"platform `{_markdown_cell(environment['platform'])}`, "
+            f"machine `{_markdown_cell(environment['machine'])}`, "
+            f"{environment['cpu_count']} visible CPUs.",
+            "",
+            "| Query | Wall seconds |",
+            "|---|---:|",
+        ]
+    )
+    for operation in _QUERY_OPERATIONS:
+        lines.append(f"| {operation} | {_format_seconds(query_latency[operation])} |")
+    lines.extend(
+        [
+            "",
+            "Peak resident memory by isolated operation:",
+            "",
+            "| Operation | Peak RSS bytes |",
+            "|---|---:|",
+        ]
+    )
+    for operation in _OPERATIONS:
+        lines.append(f"| {operation} | {peak_rss[operation]} |")
+    lines.extend(
+        [
+            "",
+            "Index cost:",
+            "",
+            f"- Wall seconds: {_format_seconds(index_cost['wall_seconds'])}",
+            f"- CPU seconds: {_format_seconds(index_cost['cpu_seconds'])}",
+            f"- Peak RSS bytes: {index_cost['peak_rss_bytes']}",
+            f"- SQLite statements: {index_cost['sqlite_query_count']}",
+            f"- Database bytes: {index_cost['database_bytes']}",
+            f"- WAL bytes: {index_cost['wal_bytes']}",
+            f"- Performance gate passed: `{str(performance['gate_passed']).lower()}`",
+            "",
+            "## Competitor comparison",
+            "",
+            "| System | Status | Public equivalent protocol | Metrics | Reason |",
+            "|---|---|---|---|---|",
+        ]
+    )
+    for item in _sequence(report["comparisons"], "comparisons"):
+        comparison = _mapping(item, "comparison")
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    _markdown_cell(comparison["system"]),
+                    "N/A",
+                    "N/A",
+                    "N/A",
+                    _markdown_cell(comparison["reason"]),
+                )
+            )
+            + " |"
+        )
+    lines.extend(["", "## Reproduction", ""])
+    for command in _sequence(protocol["reproduction_commands"], "reproduction commands"):
+        command_data = _mapping(command, "reproduction command")
+        argv = [
+            _string(item, "reproduction argv")
+            for item in _sequence(command_data["argv"], "reproduction argv")
+        ]
+        lines.extend(
+            [
+                f"### {_markdown_cell(command_data['id'])}",
+                "",
+                "```console",
+                shlex.join(argv),
+                "```",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_or_check_outputs(
+    report: Mapping[str, object],
+    json_output: Path,
+    markdown_output: Path,
+    *,
+    check: bool,
+) -> None:
+    json_text = canonical_json(report)
+    markdown_text = render_markdown(report)
+    if json_output.resolve() == markdown_output.resolve():
+        raise ValueError("JSON and Markdown outputs must be different paths")
+    if check:
+        for path, expected in ((json_output, json_text), (markdown_output, markdown_text)):
+            if not path.is_file() or path.read_text(encoding="utf-8") != expected:
+                raise ValueError(f"public benchmark output is missing or stale: {path}")
+        return
+    json_output.parent.mkdir(parents=True, exist_ok=True)
+    markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    json_output.write_text(json_text, encoding="utf-8", newline="\n")
+    markdown_output.write_text(markdown_text, encoding="utf-8", newline="\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("benchmarks/public-benchmark-manifest.json"),
+    )
+    parser.add_argument("--evaluation-report", type=Path, required=True)
+    parser.add_argument("--performance-report", type=Path, required=True)
+    parser.add_argument("--json-output", type=Path, required=True)
+    parser.add_argument("--markdown-output", type=Path, required=True)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify that existing JSON and Markdown outputs are byte-for-byte current",
+    )
+    arguments = parser.parse_args()
+    try:
+        report = build_public_report(
+            arguments.manifest,
+            arguments.evaluation_report,
+            arguments.performance_report,
+        )
+        write_or_check_outputs(
+            report,
+            arguments.json_output,
+            arguments.markdown_output,
+            check=arguments.check,
+        )
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+    print(
+        "public benchmark outputs are current"
+        if arguments.check
+        else "public benchmark outputs written"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/repolocus/__init__.py
+++ b/src/repolocus/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import random
@@ -214,6 +215,10 @@ def test_evaluation_uses_structured_results_without_hiding_duplicate_ranges() ->
     outcome = outcomes[0]
     assert outcome["returned_paths"] == ["answer.py"]
     assert len(outcome["returned_evidence"]) == 2  # type: ignore[arg-type]
+    assert (
+        outcome["returned_evidence"][0]["content_sha256"]
+        == hashlib.sha256(duplicate.content.encode("utf-8")).hexdigest()
+    )
     assert outcome["duplicate_evidence_rate"] == 0.5
     assert outcome["path_diversity"] == 0.5
     assert outcome["maximum_line_iou"] == 1.0
@@ -887,6 +892,9 @@ def test_external_multi_repository_release_gate_is_reproducible() -> None:
         "must_not_return_violation_rate",
     }
     assert report["manifest"] == "external-manifest.json"
+    assert report["evaluation_metrics_script_sha256"] == (
+        _external_evaluation_script()._metrics_script_sha256()
+    )
     assert report["fixture_count"] == 6
     assert report["qrels"] == 102
     assert report["reviewed_qrels"] == 102

--- a/tests/test_public_benchmark.py
+++ b/tests/test_public_benchmark.py
@@ -1,0 +1,674 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import shutil
+import sys
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_OPERATIONS = (
+    "scan",
+    "map",
+    "diagram",
+    "symbol_query",
+    "dependency_query",
+    "retrieval",
+)
+_COMMAND_IDS = ("evaluation", "performance", "report", "check")
+
+
+def _repository() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _report_module() -> ModuleType:
+    scripts = str(_repository() / "scripts")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    path = _repository() / "scripts" / "public_benchmark_report.py"
+    spec = importlib.util.spec_from_file_location("repolocus_public_benchmark", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _script_module(filename: str, name: str) -> ModuleType:
+    scripts = str(_repository() / "scripts")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    path = _repository() / "scripts" / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@lru_cache(maxsize=1)
+def _benchmark_module() -> ModuleType:
+    path = _repository() / "benchmarks" / "benchmark_v020.py"
+    spec = importlib.util.spec_from_file_location(
+        "repolocus_test_public_performance_protocol", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _external_manifest() -> dict[str, object]:
+    return json.loads(
+        (_repository() / "evaluation" / "external-manifest.json").read_text(encoding="utf-8")
+    )
+
+
+@lru_cache(maxsize=1)
+def _pinned_evaluation_truth() -> dict[str, object]:
+    evaluation_module = _script_module(
+        "evaluate_external_repositories.py", "repolocus_test_public_truth_protocol"
+    )
+    evaluation_root = _repository() / "evaluation"
+    manifest = _external_manifest()
+    review_artifacts, review_report, reviewed_no_answer_intents = (
+        evaluation_module._load_review_provenance(evaluation_root, manifest)
+    )
+    cases: list[dict[str, object]] = []
+    fixture_roots: dict[str, Path] = {}
+    fixtures: list[dict[str, object]] = []
+    for fixture in manifest["fixtures"]:
+        fixture_id = fixture["id"]
+        revision = fixture["revision"]
+        root = (evaluation_root / fixture["path"]).resolve(strict=True)
+        qrels = (evaluation_root / fixture["qrels"]).resolve(strict=True)
+        assert evaluation_module.fixture_tree_sha256(root) == fixture["tree_sha256"]
+        assert evaluation_module._sha256_file(qrels) == fixture["qrels_sha256"]
+        review = review_artifacts.pop(fixture_id)
+        assert review["fixture_revision"] == revision
+        fixture_cases = evaluation_module._load_qrels(
+            qrels,
+            fixture=fixture_id,
+            revision=revision,
+        )
+        evaluation_module._validate_case_sources(root, fixture_cases)
+        assert len(fixture_cases) == fixture["qrels_count"]
+        cases.extend(fixture_cases)
+        fixture_roots[fixture_id] = root
+        fixtures.append(
+            {
+                "id": fixture_id,
+                "revision": revision,
+                "source": fixture["source"],
+                "license": fixture["license"],
+                "tree_sha256": fixture["tree_sha256"],
+                "qrels_sha256": fixture["qrels_sha256"],
+                "qrels": len(fixture_cases),
+                "must_not_return_qrels": sum(
+                    bool(case["must_not_return"]) for case in fixture_cases
+                ),
+                "dependency_expectations": sum(
+                    case.get("expected_dependency") is not None for case in fixture_cases
+                ),
+                "content_generation": 1,
+                "scan_revision": 1,
+            }
+        )
+    assert not review_artifacts
+    family_counts, families_by_type, fixtures_by_type = evaluation_module._case_family_report(
+        cases,
+        reviewed_no_answer_intents=reviewed_no_answer_intents,
+    )
+    for fixture in fixtures:
+        fixture["case_families"] = family_counts[fixture["id"]]
+    return {
+        "cases": cases,
+        "fixture_roots": fixture_roots,
+        "fixtures": fixtures,
+        "review_provenance": review_report,
+        "qrels": len(cases),
+        "reviewed_qrels": len(cases),
+        "case_families": sum(family_counts.values()),
+        "case_families_by_query_type": dict(sorted(families_by_type.items())),
+        "query_type_fixture_counts": dict(sorted(fixtures_by_type.items())),
+        "query_types": sorted(families_by_type),
+        "runtime_intents": sorted(evaluation_module._RUNTIME_INTENTS),
+        "corpus_coverage": evaluation_module._corpus_coverage(cases),
+        "answerable_qrels": sum(bool(case["answerable"]) for case in cases),
+        "no_answer_qrels": sum(not bool(case["answerable"]) for case in cases),
+        "citation_qrels": sum(bool(case["relevant"]) for case in cases),
+        "must_not_return_qrels": sum(bool(case["must_not_return"]) for case in cases),
+    }
+
+
+def _evaluation_outcomes() -> list[dict[str, object]]:
+    retrieval_module = _script_module(
+        "evaluate_retrieval.py", "repolocus_test_public_outcome_protocol"
+    )
+    truth = _pinned_evaluation_truth()
+    fixture_roots = truth["fixture_roots"]
+    outcomes: list[dict[str, object]] = []
+    for case in truth["cases"]:
+        fixture = case["fixture"]
+        evidence = []
+        for relevant in case["relevant"]:
+            path = relevant["path"]
+            start = relevant["start"]
+            end = relevant["end"]
+            source = fixture_roots[fixture] / path
+            content = "".join(
+                source.read_text(encoding="utf-8").splitlines(keepends=True)[start - 1 : end]
+            )
+            graph_reason = {
+                "direct_dependency": "dependency of pinned-source",
+                "reverse_dependency": "dependent of pinned-source",
+            }.get(case["query_type"], "pinned test evidence")
+            evidence.append(
+                {
+                    "path": path,
+                    "start_line": start,
+                    "end_line": end,
+                    "citation": f"{path}:{start}" + (f"-{end}" if end != start else ""),
+                    "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+                    "symbol": "",
+                    "generation": 1,
+                    "reason": graph_reason,
+                }
+            )
+        graph_retriever = {
+            "direct_dependency": "outbound_dependency",
+            "reverse_dependency": "reverse_dependency",
+        }.get(case["query_type"])
+        hits = (
+            [
+                {
+                    "chunk_id": 1,
+                    "retriever": graph_retriever,
+                    "rank": 1,
+                    "raw_score": 1.0,
+                    "features": {},
+                }
+            ]
+            if graph_retriever is not None
+            else []
+        )
+        placeholder = {field: None for field in retrieval_module._OUTCOME_FIELDS}
+        placeholder.update(
+            {
+                "fixture": fixture,
+                "case_id": case["case_id"],
+                "intent": case["expected_intent"],
+                "confidence": 1.0 if evidence else 0.0,
+                "rejected_reason": None if evidence else "no_candidates",
+                "returned_evidence": evidence,
+                "retrieval_hits": hits,
+                "suppressed": [],
+            }
+        )
+        outcomes.append(
+            retrieval_module._canonical_outcome_from_serialized_evidence(
+                case,
+                placeholder,
+                limit=5,
+                fixture_root=fixture_roots[fixture],
+            )
+        )
+    return outcomes
+
+
+@lru_cache(maxsize=1)
+def _base_evaluation_report() -> dict[str, object]:
+    retrieval_module = _script_module(
+        "evaluate_retrieval.py", "repolocus_test_public_retrieval_protocol"
+    )
+    evaluation_module = _script_module(
+        "evaluate_external_repositories.py", "repolocus_test_public_evaluation_protocol"
+    )
+    public_manifest = json.loads(
+        (_repository() / "benchmarks" / "public-benchmark-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    benchmark_module = _benchmark_module()
+    truth = _pinned_evaluation_truth()
+    outcomes = _evaluation_outcomes()
+    metrics = retrieval_module.summarize_outcomes(outcomes)
+    report = {
+        "manifest": "external-manifest.json",
+        "evaluation_script_sha256": public_manifest["artifacts"]["evaluation_runner"]["sha256"],
+        "evaluation_metrics_script_sha256": public_manifest["artifacts"][
+            "evaluation_metrics_runner"
+        ]["sha256"],
+        "implementation_sha256": benchmark_module._implementation_sha256(),
+        "repolocus_version": benchmark_module.__version__,
+        "review_provenance": truth["review_provenance"],
+        "fixtures": truth["fixtures"],
+        "fixture_count": len(truth["fixtures"]),
+        "qrels": truth["qrels"],
+        "reviewed_qrels": truth["reviewed_qrels"],
+        "case_families": truth["case_families"],
+        "case_families_by_query_type": truth["case_families_by_query_type"],
+        "query_type_fixture_counts": truth["query_type_fixture_counts"],
+        "query_types": truth["query_types"],
+        "runtime_intents": truth["runtime_intents"],
+        "corpus_coverage": truth["corpus_coverage"],
+        "answerable_qrels": truth["answerable_qrels"],
+        "no_answer_qrels": truth["no_answer_qrels"],
+        "citation_qrels": truth["citation_qrels"],
+        "must_not_return_qrels": truth["must_not_return_qrels"],
+        "top_k": 5,
+        "metrics": metrics,
+        "bootstrap": evaluation_module._bootstrap_report(outcomes),
+        "outcomes": outcomes,
+    }
+    report["gate"] = evaluation_module._gate_report(report, evaluation_module.default_thresholds())
+    return report
+
+
+def _evaluation_report() -> dict[str, object]:
+    return copy.deepcopy(_base_evaluation_report())
+
+
+def _measurement(operation: str, index: int) -> dict[str, object]:
+    return {
+        "name": operation,
+        "wall_seconds": round(0.1 + index / 100, 6),
+        "cpu_seconds": round(0.08 + index / 100, 6),
+        "peak_rss_bytes": 10_000 + index,
+        "sqlite_query_count": 1,
+        "database_bytes": 20_000,
+        "wal_bytes": 0,
+        "worker_pid": 100 + index,
+    }
+
+
+def _performance_report() -> dict[str, object]:
+    manifest = json.loads(
+        (_repository() / "benchmarks" / "public-benchmark-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    benchmark_module = _benchmark_module()
+    operations = {
+        operation: _measurement(operation, index) for index, operation in enumerate(_OPERATIONS)
+    }
+    performance_manifest = json.loads(
+        (_repository() / "benchmarks" / "v0.2-gates.json").read_text(encoding="utf-8")
+    )
+    passed, violations = benchmark_module._gate(
+        operations,
+        performance_manifest["thresholds"],
+    )
+    return {
+        "benchmark": "v0.2-indexed-workflows-v1",
+        "benchmark_script_sha256": manifest["artifacts"]["performance_runner"]["sha256"],
+        "implementation_sha256": benchmark_module._implementation_sha256(),
+        "repolocus_version": benchmark_module.__version__,
+        "manifest": "v0.2-gates.json",
+        "files": 1_000,
+        "python": "3.12.3",
+        "platform": "Linux-test-x86_64",
+        "machine": "x86_64",
+        "cpu_count": 8,
+        "source_bytes": 5_141_250,
+        "symbols": 5_000,
+        "dependencies": 990,
+        "operations": operations,
+        "gate": {"passed": passed, "violations": violations},
+    }
+
+
+def _build_report(
+    tmp_path: Path,
+    *,
+    evaluation: dict[str, object] | None = None,
+    performance: dict[str, object] | None = None,
+) -> tuple[ModuleType, dict[str, object], Path, Path]:
+    module = _report_module()
+    evaluation_path = tmp_path / "evaluation.json"
+    performance_path = tmp_path / "performance.json"
+    _write_json(evaluation_path, evaluation or _evaluation_report())
+    _write_json(performance_path, performance or _performance_report())
+    report = module.build_public_report(
+        _repository() / "benchmarks" / "public-benchmark-manifest.json",
+        evaluation_path,
+        performance_path,
+        repository_root=_repository(),
+    )
+    return module, report, evaluation_path, performance_path
+
+
+def test_manifest_pins_public_protocol_and_clean_output_directory() -> None:
+    module = _report_module()
+    manifest = module.load_public_manifest(
+        _repository() / "benchmarks" / "public-benchmark-manifest.json",
+        repository_root=_repository(),
+    )
+
+    assert manifest["scope"] == {
+        "classification": "smoke",
+        "cross_repository_quality_claim": False,
+        "note": (
+            "Public, reproducible RepoLocus-authored synthetic smoke/regression suite "
+            "only; quality results must not be extrapolated to independent or "
+            "production repositories."
+        ),
+    }
+    assert set(manifest["artifacts"]) == {
+        "evaluation_manifest",
+        "evaluation_metrics_runner",
+        "evaluation_runner",
+        "performance_manifest",
+        "performance_runner",
+        "report_runner",
+        "report_schema",
+    }
+    assert [command["id"] for command in manifest["commands"]] == [
+        "evaluation",
+        "performance",
+        "report",
+        "check",
+    ]
+    assert all(item["status"] == "N/A" for item in manifest["comparisons"])
+    assert all(item["protocol"] is None for item in manifest["comparisons"])
+    assert all(item["metrics"] is None for item in manifest["comparisons"])
+    assert (_repository() / "benchmarks" / "results" / ".gitignore").is_file()
+
+
+def test_report_unifies_provenance_quality_and_performance(tmp_path: Path) -> None:
+    module, report, evaluation_path, performance_path = _build_report(tmp_path)
+
+    assert report["schema_version"] == 1
+    assert report["benchmark_id"] == "repolocus-public-benchmark-v1"
+    assert report["subject"]["result_classification"] == "smoke"
+    assert report["subject"]["cross_repository_quality_claim"] is False
+    assert [fixture["id"] for fixture in report["fixtures"]] == sorted(
+        fixture["id"] for fixture in report["fixtures"]
+    )
+    assert report["quality"]["qrels"] == 102
+    assert report["quality"]["accuracy"]["hit_rate"] == 1.0
+    assert report["quality"]["no_answer"]["f1"] == 1.0
+    assert report["quality"]["safety"]["must_not_return_violation_rate"] == 0.0
+    performance = report["performance"]
+    assert performance["query_latency_seconds"]["retrieval"] == 0.15
+    assert performance["peak_rss_bytes"]["scan"] == 10_000
+    assert performance["index_cost"] == performance["operations"]["scan"]
+    assert report["validation"] == {
+        "evaluation_report_sha256": module._sha256_file(evaluation_path),
+        "performance_report_sha256": module._sha256_file(performance_path),
+        "evaluation_gate_passed": True,
+        "performance_gate_passed": True,
+    }
+
+
+def test_json_and_markdown_are_deterministic_and_explicitly_smoke_only(
+    tmp_path: Path,
+) -> None:
+    module, report, _, _ = _build_report(tmp_path)
+
+    assert module.canonical_json(report) == module.canonical_json(copy.deepcopy(report))
+    markdown = module.render_markdown(report)
+    assert markdown == module.render_markdown(copy.deepcopy(report))
+    assert "**SMOKE ONLY.**" in markdown
+    assert "no cross-repository quality claim" in markdown
+    assert "## Quality smoke metrics" in markdown
+    assert "## Resource and latency smoke metrics" in markdown
+    assert "RepoWiki | N/A | N/A | N/A" in markdown
+    assert "DeepWiki | N/A | N/A | N/A" in markdown
+    assert "Sourcebot | N/A | N/A | N/A" in markdown
+    assert "scripts/evaluate_external_repositories.py evaluation" in markdown
+    assert "benchmarks/benchmark_v020.py --manifest benchmarks/v0.2-gates.json" in markdown
+
+
+def test_write_and_check_detect_stale_output(tmp_path: Path) -> None:
+    module, report, _, _ = _build_report(tmp_path)
+    json_output = tmp_path / "outputs" / "report.json"
+    markdown_output = tmp_path / "outputs" / "report.md"
+
+    module.write_or_check_outputs(report, json_output, markdown_output, check=False)
+    module.write_or_check_outputs(report, json_output, markdown_output, check=True)
+    markdown_output.write_text("stale\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing or stale"):
+        module.write_or_check_outputs(report, json_output, markdown_output, check=True)
+
+
+def test_report_rejects_fixture_provenance_drift(tmp_path: Path) -> None:
+    evaluation = _evaluation_report()
+    evaluation["fixtures"][0]["license"] = "unknown"
+
+    with pytest.raises(ValueError, match="fixture provenance drifted"):
+        _build_report(tmp_path, evaluation=evaluation)
+
+
+def test_report_rejects_scale_artifact_outside_pinned_public_protocol(
+    tmp_path: Path,
+) -> None:
+    performance = _performance_report()
+    performance["manifest"] = "v0.2-scale-gates.json"
+
+    with pytest.raises(ValueError, match="different manifest"):
+        _build_report(tmp_path, performance=performance)
+
+
+def test_report_rejects_evaluation_metrics_forged_independently_of_outcomes(
+    tmp_path: Path,
+) -> None:
+    evaluation = _evaluation_report()
+    evaluation["metrics"]["any_expected_path_rate"] = 0.0
+
+    with pytest.raises(ValueError, match="metrics do not match the serialized outcomes"):
+        _build_report(tmp_path, evaluation=evaluation)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("missing", "missing pinned qrels"),
+        ("duplicate", "outcome is duplicated"),
+        ("unknown", "not in the pinned qrel inventory"),
+        ("wrong_truth", "field question does not match"),
+        ("forged_metric", "field recall_at_k does not match"),
+    ],
+)
+def test_report_binds_every_outcome_to_pinned_qrel_truth(
+    tmp_path: Path,
+    mutation: str,
+    message: str,
+) -> None:
+    evaluation = _evaluation_report()
+    if mutation == "missing":
+        evaluation["outcomes"].pop()
+    elif mutation == "duplicate":
+        evaluation["outcomes"].append(copy.deepcopy(evaluation["outcomes"][0]))
+    elif mutation == "unknown":
+        evaluation["outcomes"][0]["case_id"] = "unknown-case"
+    elif mutation == "wrong_truth":
+        evaluation["outcomes"][0]["question"] = "forged question"
+    else:
+        evaluation["outcomes"][0]["recall_at_k"] = 0.0
+
+    with pytest.raises(ValueError, match=message):
+        _build_report(tmp_path, evaluation=evaluation)
+
+
+def test_report_rejects_serialized_evidence_content_forgery(tmp_path: Path) -> None:
+    evaluation = _evaluation_report()
+    outcome = next(item for item in evaluation["outcomes"] if item["returned_evidence"])
+    outcome["returned_evidence"][0]["content_sha256"] = "0" * 64
+
+    with pytest.raises(ValueError, match="does not match the pinned fixture content"):
+        _build_report(tmp_path, evaluation=evaluation)
+
+
+def test_qrel_loader_rejects_pinned_qrel_drift(tmp_path: Path) -> None:
+    evaluation_root = tmp_path / "evaluation"
+    shutil.copytree(_repository() / "evaluation", evaluation_root)
+    qrels = evaluation_root / "qrels" / "python-small.jsonl"
+    qrels.write_text(
+        qrels.read_text(encoding="utf-8").replace("local path", "changed path", 1),
+        encoding="utf-8",
+    )
+    manifest_path = evaluation_root / "external-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    report_module = _report_module()
+    evaluation_module = _script_module(
+        "evaluate_external_repositories.py", "repolocus_test_public_drift_protocol"
+    )
+
+    with pytest.raises(ValueError, match="pinned evaluation qrel checksum mismatch"):
+        report_module._pinned_evaluation_cases(
+            manifest_path,
+            manifest,
+            evaluation_module,
+        )
+
+
+def test_report_rejects_evaluation_gate_forged_independently_of_metrics(
+    tmp_path: Path,
+) -> None:
+    evaluation = _evaluation_report()
+    evaluation["gate"]["passed"] = False
+
+    with pytest.raises(ValueError, match="gate does not match recomputed pinned thresholds"):
+        _build_report(tmp_path, evaluation=evaluation)
+
+
+def test_report_rejects_performance_measurement_with_forged_passing_gate(
+    tmp_path: Path,
+) -> None:
+    performance = _performance_report()
+    performance["operations"]["scan"]["wall_seconds"] = 99_999.0
+
+    with pytest.raises(ValueError, match="performance gate does not match recomputed"):
+        _build_report(tmp_path, performance=performance)
+
+
+@pytest.mark.parametrize("field", ["repolocus_version", "implementation_sha256"])
+def test_report_rejects_cross_protocol_subject_mismatch(tmp_path: Path, field: str) -> None:
+    evaluation = _evaluation_report()
+    evaluation[field] = "0.2.0" if field == "repolocus_version" else "2" * 64
+
+    with pytest.raises(ValueError, match=rf"different {field}"):
+        _build_report(tmp_path, evaluation=evaluation)
+
+
+@pytest.mark.parametrize(
+    ("report_name", "field"),
+    [
+        ("evaluation", "evaluation_script_sha256"),
+        ("performance", "benchmark_script_sha256"),
+    ],
+)
+def test_report_rejects_runner_hash_mismatch(
+    tmp_path: Path,
+    report_name: str,
+    field: str,
+) -> None:
+    evaluation = _evaluation_report()
+    performance = _performance_report()
+    report = evaluation if report_name == "evaluation" else performance
+    report[field] = "2" * 64
+
+    with pytest.raises(ValueError, match=rf"{report_name} report runner hash"):
+        _build_report(tmp_path, evaluation=evaluation, performance=performance)
+
+
+def test_report_rejects_metrics_runner_hash_mismatch(tmp_path: Path) -> None:
+    evaluation = _evaluation_report()
+    evaluation["evaluation_metrics_script_sha256"] = "2" * 64
+
+    with pytest.raises(ValueError, match="evaluation report metrics runner hash"):
+        _build_report(tmp_path, evaluation=evaluation)
+
+
+def test_report_injects_pinned_metrics_module_when_loading_evaluator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluation = _evaluation_report()
+    performance = _performance_report()
+    fake = ModuleType("evaluate_retrieval")
+    monkeypatch.setitem(sys.modules, "evaluate_retrieval", fake)
+
+    _, report, _, _ = _build_report(
+        tmp_path,
+        evaluation=evaluation,
+        performance=performance,
+    )
+
+    assert report["quality"]["gate_passed"] is True
+
+
+def test_report_rejects_competitor_metrics_without_equivalent_protocol(
+    tmp_path: Path,
+) -> None:
+    module, report, _, _ = _build_report(tmp_path)
+    report["comparisons"][0]["metrics"] = {"hit_rate": 1.0}
+
+    with pytest.raises(ValueError, match="without a pinned equivalent protocol"):
+        module.validate_public_report(report)
+
+
+def test_report_validator_rejects_cross_field_drift(tmp_path: Path) -> None:
+    module, report, _, _ = _build_report(tmp_path)
+    report["performance"]["query_latency_seconds"]["retrieval"] = 999.0
+
+    with pytest.raises(ValueError, match="query latency drifted"):
+        module.validate_public_report(report)
+
+
+def test_report_validator_rejects_mutated_reproduction_argv(tmp_path: Path) -> None:
+    module, report, _, _ = _build_report(tmp_path)
+    report["protocol"]["reproduction_commands"][0]["argv"] = ["not-the-pinned-command"]
+
+    with pytest.raises(ValueError, match="reproduction command"):
+        module.validate_public_report(report)
+
+
+def test_json_schema_is_strict_and_matches_report_identity(tmp_path: Path) -> None:
+    module, report, _, _ = _build_report(tmp_path)
+    schema = json.loads(
+        (_repository() / "benchmarks" / "public-benchmark-report.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    module.validate_public_report(report)
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["schema_version"]["const"] == 1
+    assert schema["properties"]["benchmark_id"]["const"] == "repolocus-public-benchmark-v1"
+    assert (
+        schema["properties"]["subject"]["properties"]["cross_repository_quality_claim"]["const"]
+        is False
+    )
+    assert schema["properties"]["comparisons"]["minItems"] == 3
+    protocol_properties = schema["properties"]["protocol"]["properties"]
+    assert protocol_properties["evaluation_metrics_runner"] == {
+        "const": "scripts/evaluate_retrieval.py"
+    }
+    assert protocol_properties["evaluation_metrics_runner_sha256"] == {"$ref": "#/$defs/sha256"}
+    manifest = json.loads(
+        (_repository() / "benchmarks" / "public-benchmark-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    for command_id, expected in zip(_COMMAND_IDS, manifest["commands"], strict=True):
+        argv_schema = schema["$defs"][f"{command_id}_command"]["properties"]["argv"]
+        assert argv_schema["minItems"] == len(expected["argv"])
+        assert argv_schema["maxItems"] == len(expected["argv"])
+        assert argv_schema["items"] is False
+        assert [item["const"] for item in argv_schema["prefixItems"]] == expected["argv"]

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -18,8 +18,12 @@ def _workflow(name: str) -> str:
 
 
 def test_third_party_actions_are_pinned_with_readable_versions() -> None:
-    for name in ("ci.yml", "release.yml"):
-        references = _ACTION.findall(_workflow(name))
+    action_documents = [_workflow(name) for name in ("ci.yml", "release.yml")]
+    composite = _repository() / ".github" / "actions" / "pr-context" / "action.yml"
+    if composite.is_file():
+        action_documents.append(composite.read_text(encoding="utf-8"))
+    for document in action_documents:
+        references = _ACTION.findall(document)
         assert references
         for reference, readable_version in references:
             if reference.startswith("./"):
@@ -58,14 +62,32 @@ def test_external_evaluation_blocks_packaging() -> None:
     assert "performance-benchmark:" in workflow
     assert "--manifest benchmarks/v0.2-gates.json" in workflow
     assert "benchmarks/v0.2-scale-gates.json" not in workflow
+    assert "public-benchmark:" in workflow
+    assert "scripts/public_benchmark_report.py" in workflow
+    assert "benchmarks/public-benchmark-manifest.json" in workflow
+    assert "needs: [external-evaluation, performance-benchmark]" in workflow
     assert (
-        "needs: [test, coverage, security, external-evaluation, performance-benchmark]" in workflow
+        "needs: [test, coverage, security, external-evaluation, performance-benchmark, "
+        "public-benchmark]" in workflow
     )
     assert "if: ${{ always() }}" in workflow
     assert "EVALUATION_RESULT: ${{ needs.external-evaluation.result }}" in workflow
     assert "PERFORMANCE_RESULT: ${{ needs.performance-benchmark.result }}" in workflow
+    assert "PUBLIC_BENCHMARK_RESULT: ${{ needs.public-benchmark.result }}" in workflow
     assert 'if [[ "$result" != "success" ]]' in workflow
     assert 'python-version: ["3.10", "3.12", "3.14"]' in workflow
+
+    public_job = workflow.split("  public-benchmark:", 1)[1].split("  package:", 1)[0]
+    assert "Upload the public report and its reproduction inputs" in public_job
+    for artifact_path in (
+        "benchmarks/results/public-report.json",
+        "benchmarks/results/public-report.md",
+        "public-inputs/evaluation/external-evaluation.json",
+        "public-inputs/performance/v0.2-benchmark.json",
+        "benchmarks/public-benchmark-manifest.json",
+        "benchmarks/public-benchmark-report.schema.json",
+    ):
+        assert artifact_path in public_job
 
 
 def test_release_attests_and_verifies_every_asset_before_publish() -> None:
@@ -76,6 +98,13 @@ def test_release_attests_and_verifies_every_asset_before_publish() -> None:
     assert "--minimum-qrels 100" in workflow
     assert "benchmarks/v0.2-scale-gates.json" in workflow
     assert "repolocus-${PROJECT_VERSION}.scale-benchmark.json" in workflow
+    assert "benchmarks/public-benchmark-manifest.json" in workflow
+    assert "repolocus-${PROJECT_VERSION}.public-performance.json" in workflow
+    assert "repolocus-${PROJECT_VERSION}.public-benchmark.json" in workflow
+    assert "repolocus-${PROJECT_VERSION}.public-benchmark.md" in workflow
+    assert "repolocus-${PROJECT_VERSION}.public-benchmark-manifest.json" in workflow
+    assert "repolocus-${PROJECT_VERSION}.public-benchmark-report.schema.json" in workflow
+    assert "--check" in workflow
     assert "timeout-minutes: 45" in workflow
     assert "timeout-minutes: 20" in workflow
     assert "repolocus-${PROJECT_VERSION}.external-evaluation.json" in workflow
@@ -86,6 +115,11 @@ def test_release_attests_and_verifies_every_asset_before_publish() -> None:
     assert 'gh attestation verify "$asset" --repo "$GITHUB_REPOSITORY"' in workflow
     assert "needs: [build, verify-provenance]" in workflow
     assert "repolocus doctor --security --json" in workflow
+
+    protocol_copy = workflow.index("Include the public benchmark protocol")
+    checksums = workflow.index("Generate SHA-256 checksums")
+    attestation = workflow.index("Attest every release asset")
+    assert protocol_copy < checksums < attestation
 
 
 def test_core_and_treesitter_wheels_are_smoke_tested_separately() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -554,7 +554,7 @@ wheels = [
 
 [[package]]
 name = "repolocus"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- publish a provenance-pinned public smoke/regression benchmark with exact fixture, qrel, runner, schema, and report hashes
- independently recompute all 102 serialized evaluation outcomes from pinned truth and returned evidence
- report accuracy, no-answer, safety, latency, memory, and index cost while keeping competitors explicitly N/A without an equivalent protocol
- wire the public report and reproduction inputs into CI, checksums, attestations, and release assets
- update v0.2.1 version metadata, changelog, architecture/security docs, and Action guidance

## Invariant

A public benchmark report is accepted only when every pinned protocol artifact matches, every qrel outcome is present exactly once and recomputes from serialized evidence, both embedded gates pass, and the JSON/Markdown outputs are byte-current. Results are explicitly synthetic smoke/regression evidence, not independent cross-repository quality claims.

## Validation

- Ruff format/check, `git diff --check`, `uv lock --check`
- actionlint v1.7.12
- Draft 2020-12 schema meta-validation and generated report instance validation
- public evaluation + 1k benchmark + report generation/`--check`
- full suite: 729 passed, 11 conditional skips
- all-extras coverage: 737 passed, 3 Windows-only skips, 86.04%
- security doctor required checks passed
- wheel and sdist build metadata verified
- local Jetson aarch64 100k scan exceeded the unchanged 1320s worker timeout; the release workflow retains the x86-hosted 1200s gate and blocks publication unless it passes

The repository-external implementation plan remains untracked and is not part of this PR.
